### PR TITLE
feat: expose and control system prompt from admin UI

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -16,7 +16,7 @@ import secrets
 import urllib.parse
 from base64 import urlsafe_b64encode
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -29,7 +29,13 @@ from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
 
 from core.config_store import ConfigStore
+from core.goal_decomposition import classify_complexity, decompose_goal
 from core.llm import LLMClient
+from core.prompt_builder import (
+    DEFAULT_HISTORY_HANDLING_BLOCK,
+    DEFAULT_TOOL_USAGE_BLOCK,
+    build_prompt_sections,
+)
 from core.wacli import WacliManager
 
 if TYPE_CHECKING:
@@ -432,6 +438,12 @@ class EmailProvidersIn(BaseModel):
     providers: list[dict[str, str]]
 
 
+class PromptPreviewIn(BaseModel):
+    message: str = ""
+    include_memories: bool = True
+    include_reflections: bool = True
+
+
 # ---------------------------------------------------------------------------
 # Auth dependency
 # ---------------------------------------------------------------------------
@@ -532,6 +544,7 @@ def create_admin_app(
     _VOICE_PREFIX = "voice."
     _HISTORY_PREFIX = "history."
     _EMAIL_PREFIX = "email."
+    _PROMPT_PREFIX = "prompt."
 
     def _is_managed_key(key: str) -> bool:
         """Return True if this key is managed by a dedicated tab (not Config)."""
@@ -548,6 +561,7 @@ def create_admin_app(
             _VOICE_PREFIX,
             _HISTORY_PREFIX,
             _EMAIL_PREFIX,
+            _PROMPT_PREFIX,
         ):
             if key.startswith(prefix):
                 return True
@@ -787,6 +801,12 @@ def create_admin_app(
         tr_enabled = tr_enabled if tr_enabled is not None else "true"
         tr_provider = await config_store.get("task_reflection.provider") or "anthropic"
         tr_model = await config_store.get("task_reflection.model") or "claude-haiku-4-5"
+        prompt_tool_usage_override = await config_store.get("prompt.tool_usage_override") or ""
+        prompt_history_override = await config_store.get("prompt.history_handling_override") or ""
+        prompt_capture_enabled = await config_store.get("admin.capture_prompts")
+        prompt_capture_enabled = False
+        if prompt_capture_enabled is not None:
+            prompt_capture_enabled = str(prompt_capture_enabled).lower() == "true"
         return _render_partial(
             "partials/llm.html",
             provider=provider,
@@ -810,6 +830,11 @@ def create_admin_app(
             tr_enabled=tr_enabled,
             tr_provider=tr_provider,
             tr_model=tr_model,
+            prompt_tool_usage_override=prompt_tool_usage_override,
+            prompt_history_override=prompt_history_override,
+            default_tool_usage=DEFAULT_TOOL_USAGE_BLOCK,
+            default_history_handling=DEFAULT_HISTORY_HANDLING_BLOCK,
+            prompt_capture_enabled=prompt_capture_enabled,
         )
 
     @app.get("/partials/search", dependencies=[Depends(auth)])
@@ -1161,6 +1186,116 @@ def create_admin_app(
             except Exception:
                 log.exception("Failed to apply updated config to running agent")
         return {"updated": list(body.values.keys())}
+
+    @app.post("/debug/system-prompt/preview", dependencies=[Depends(auth)])
+    async def system_prompt_preview(body: PromptPreviewIn) -> dict:
+        message = body.message.strip()
+        config = await config_store.export_to_config()
+
+        skills_store = await _skills_store_from_config(config_store)
+        await skills_store.ensure_seeded()
+        skills = await skills_store.list_skills()
+        skill_lines = []
+        for skill in skills:
+            summary = str(skill.get("summary", "")).strip()
+            name = str(skill.get("name", "")).strip()
+            if not name:
+                continue
+            if summary:
+                skill_lines.append(f"- {name}: {summary}")
+            else:
+                skill_lines.append(f"- {name}")
+        skills_index = "\n".join(skill_lines)
+
+        memories = ""
+        if body.include_memories:
+            if agent_state.agent:
+                memories = await agent_state.agent.memory.format_for_prompt()
+            else:
+                from core.memory import MemoryStore
+
+                memories = await MemoryStore(
+                    db_path=config.memory.db_path,
+                    long_term_limit=config.memory.long_term_limit,
+                ).format_for_prompt()
+
+        reflections = ""
+        if body.include_reflections and config.task_reflection.enabled:
+            if agent_state.agent:
+                reflections = await agent_state.agent.reflections.format_for_prompt()
+            else:
+                from core.task_reflection import ReflectionStore
+
+                reflections = await ReflectionStore(
+                    db_path=config.task_reflection.db_path,
+                    max_reflections=config.task_reflection.max_reflections,
+                ).format_for_prompt()
+
+        decomposed_goal = None
+        if message and config.goal_decomposition.enabled:
+            try:
+                if agent_state.agent and hasattr(agent_state.agent, "_background_llm"):
+                    llm = agent_state.agent._background_llm(config.goal_decomposition.provider)
+                else:
+                    provider = config.goal_decomposition.provider
+                    llm = LLMClient(
+                        provider=provider,
+                        api_key=getattr(config.agent, f"{provider}_api_key", ""),
+                        base_url=getattr(
+                            config.agent,
+                            f"{provider}_base_url",
+                            None,
+                        ),
+                    )
+                gd_model = config.goal_decomposition.model
+                is_complex = await classify_complexity(llm, gd_model, message)
+                if is_complex:
+                    decomposed_goal = await decompose_goal(llm, gd_model, message)
+            except Exception:
+                log.exception("Prompt preview decomposition failed")
+
+        history_mode = config.history.mode
+        if agent_state.agent and hasattr(agent_state.agent, "history_mode"):
+            history_mode = cast(str, agent_state.agent.history_mode)
+
+        sections = build_prompt_sections(
+            config=config,
+            history_mode=history_mode,
+            skills_index=skills_index,
+            memories=memories,
+            reflections=reflections,
+            decomposed_goal=decomposed_goal,
+            include_memories=body.include_memories,
+            include_reflections=body.include_reflections,
+        )
+        full_prompt = sections.full_prompt
+        section_map = sections.as_dict()
+        token_estimate = max(1, len(full_prompt) // 4) if full_prompt else 0
+        return {
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "history_mode": history_mode,
+            "token_estimate": token_estimate,
+            "full_prompt": full_prompt,
+            "sections": section_map,
+            "lengths": {k: len(v or "") for k, v in section_map.items()},
+            "flags": {
+                "include_memories": body.include_memories,
+                "include_reflections": body.include_reflections,
+                "decomposition_applied": decomposed_goal is not None,
+            },
+        }
+
+    @app.get("/debug/system-prompt/recent", dependencies=[Depends(auth)])
+    async def system_prompt_recent() -> dict:
+        agent = agent_state.agent
+        if not agent:
+            return {"enabled": False, "items": []}
+        agent_cfg = getattr(agent, "config", None)
+        admin_cfg = getattr(agent_cfg, "admin", None)
+        capture_cfg = bool(getattr(admin_cfg, "capture_prompts", False))
+        enabled = capture_cfg and hasattr(agent, "get_recent_system_prompts")
+        items = agent.get_recent_system_prompts() if enabled else []
+        return {"enabled": enabled, "items": items}
 
     @app.post("/admin/password", dependencies=[Depends(auth)])
     async def change_admin_password(body: PasswordChangeIn) -> dict:

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -42,7 +42,7 @@
     }
     window.showToast = showToast;
 
-    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel) {
+    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled) {
       const currentProvider = provider || 'anthropic';
       return {
         providerOptions: [
@@ -73,6 +73,24 @@
         trEnabled: trEnabled === 'true' || trEnabled === true,
         trProvider: trProvider || 'anthropic',
         trModel: trModel || 'claude-haiku-4-5',
+        promptToolUsageOverride: promptToolUsageOverride || '',
+        promptHistoryOverride: promptHistoryOverride || '',
+        defaultToolUsage: defaultToolUsage || '',
+        defaultHistoryHandling: defaultHistoryHandling || '',
+        promptCaptureEnabled: promptCaptureEnabled === true || promptCaptureEnabled === 'true',
+        promptPreviewMessage: '',
+        includePreviewMemories: true,
+        includePreviewReflections: true,
+        promptPreviewResult: '',
+        promptPreviewOk: false,
+        promptPreviewLoading: false,
+        promptPreviewRaw: '',
+        promptPreviewSections: null,
+        promptPreviewMeta: null,
+        recentPrompts: [],
+        recentPromptsLoading: false,
+        promptSaveResult: '',
+        promptSaveOk: false,
         memoryResult: '',
         memoryResultOk: false,
         gdResult: '',
@@ -251,6 +269,94 @@
             })
             .finally(() => {
               this.testing[service] = false;
+            });
+        },
+        copyText(text) {
+          if (!text) return;
+          navigator.clipboard.writeText(text)
+            .then(() => { if (window.showToast) { window.showToast('Copied'); } })
+            .catch(() => { if (window.showToast) { window.showToast('Copy failed', false); } });
+        },
+        previewSystemPrompt() {
+          this.promptPreviewLoading = true;
+          this.promptPreviewResult = '';
+          fetch('/debug/system-prompt/preview', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+            },
+            body: JSON.stringify({
+              message: this.promptPreviewMessage,
+              include_memories: this.includePreviewMemories,
+              include_reflections: this.includePreviewReflections
+            })
+          })
+            .then(r => { this.promptPreviewOk = r.ok; return r.json(); })
+            .then(d => {
+              this.promptPreviewRaw = d.full_prompt || '';
+              this.promptPreviewSections = d.sections || null;
+              this.promptPreviewMeta = {
+                generated_at: d.generated_at,
+                history_mode: d.history_mode,
+                token_estimate: d.token_estimate,
+                flags: d.flags || {}
+              };
+              this.promptPreviewResult = this.promptPreviewOk ? 'Prompt preview generated' : (d.detail || 'Failed to preview prompt');
+            })
+            .catch(e => {
+              this.promptPreviewOk = false;
+              this.promptPreviewResult = e.message || 'Failed to preview prompt';
+            })
+            .finally(() => {
+              this.promptPreviewLoading = false;
+            });
+        },
+        fetchRecentPrompts() {
+          this.recentPromptsLoading = true;
+          fetch('/debug/system-prompt/recent', {
+            headers: {
+              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+            }
+          })
+            .then(r => r.json())
+            .then(d => {
+              this.recentPrompts = Array.isArray(d.items) ? d.items : [];
+            })
+            .catch(() => {
+              this.recentPrompts = [];
+            })
+            .finally(() => {
+              this.recentPromptsLoading = false;
+            });
+        },
+        resetPromptOverrides() {
+          this.promptToolUsageOverride = '';
+          this.promptHistoryOverride = '';
+          this.promptSaveResult = 'Overrides reset locally';
+          this.promptSaveOk = true;
+        },
+        savePromptConfig() {
+          fetch('/config', {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+            },
+            body: JSON.stringify({values: {
+              'prompt.tool_usage_override': this.promptToolUsageOverride,
+              'prompt.history_handling_override': this.promptHistoryOverride,
+              'admin.capture_prompts': this.promptCaptureEnabled ? 'true' : 'false'
+            }})
+          })
+            .then(r => { this.promptSaveOk = r.ok; return r.json(); })
+            .then(d => {
+              this.promptSaveResult = this.promptSaveOk ? 'Prompt settings saved' : (d.detail || 'Error');
+              if (this.promptSaveOk && window.showToast) { window.showToast('Prompt settings saved'); }
+            })
+            .catch(e => {
+              this.promptSaveOk = false;
+              this.promptSaveResult = e.message || 'Error';
             });
         }
       };

--- a/api/templates/partials/llm.html
+++ b/api/templates/partials/llm.html
@@ -20,8 +20,134 @@
   {{ gd_model|default('claude-haiku-4-5', true)|tojson|forceescape }},
   {{ tr_enabled|default('true', true)|tojson|forceescape }},
   {{ tr_provider|default('anthropic', true)|tojson|forceescape }},
-  {{ tr_model|default('claude-haiku-4-5', true)|tojson|forceescape }}
+  {{ tr_model|default('claude-haiku-4-5', true)|tojson|forceescape }},
+  {{ prompt_tool_usage_override|default('', true)|tojson|forceescape }},
+  {{ prompt_history_override|default('', true)|tojson|forceescape }},
+  {{ default_tool_usage|default('', true)|tojson|forceescape }},
+  {{ default_history_handling|default('', true)|tojson|forceescape }},
+  {{ prompt_capture_enabled|default(false, true)|tojson|forceescape }}
 )">
+  <div class="card">
+    <h2 class="text-base mb-1">System Prompt Controls</h2>
+    <p class="text-muted text-xs mb-4">Preview the full assembled system prompt, edit override blocks, compare against defaults, and optionally capture recent runtime prompts.</p>
+
+    <form class="space-y-4" @submit.prevent>
+      <div class="space-y-2">
+        <label class="label">Tool usage override</label>
+        <textarea class="textarea"
+                  style="min-height:200px; font-size:0.8rem; line-height:1.5; tab-size:2"
+                  x-model="promptToolUsageOverride"
+                  placeholder="Leave empty to use built-in defaults"></textarea>
+        <p class="text-muted text-xs">Effective value: override if non-empty, otherwise default block.</p>
+      </div>
+
+      <div class="space-y-2">
+        <label class="label">History handling override</label>
+        <textarea class="textarea"
+                  style="min-height:140px; font-size:0.8rem; line-height:1.5; tab-size:2"
+                  x-model="promptHistoryOverride"
+                  placeholder="Leave empty to use built-in defaults"></textarea>
+      </div>
+
+      <div class="space-y-2">
+        <label class="label">Default reference: tool usage</label>
+        <textarea class="textarea" style="min-height:160px; font-size:0.75rem" x-model="defaultToolUsage" readonly></textarea>
+      </div>
+
+      <div class="space-y-2">
+        <label class="label">Default reference: history handling</label>
+        <textarea class="textarea" style="min-height:100px; font-size:0.75rem" x-model="defaultHistoryHandling" readonly></textarea>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="label mb-0">Capture recent runtime prompts</label>
+        <input type="checkbox" x-model="promptCaptureEnabled" class="rounded border-border">
+      </div>
+
+      <div class="flex items-center gap-2">
+        <button class="btn-primary btn-sm" type="button" @click="savePromptConfig()">Save prompt settings</button>
+        <button class="btn btn-sm" type="button" @click="resetPromptOverrides()">Reset local overrides</button>
+      </div>
+      <template x-if="promptSaveResult">
+        <div :class="promptSaveOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="promptSaveResult"></div>
+      </template>
+    </form>
+
+    <hr class="border-border my-4">
+
+    <form class="space-y-3" @submit.prevent="previewSystemPrompt()">
+      <div>
+        <label class="label">Preview with test user message (optional)</label>
+        <textarea class="textarea" style="min-height:90px" x-model="promptPreviewMessage" placeholder="Example: Plan my week and draft two emails"></textarea>
+      </div>
+      <div class="flex items-center gap-4">
+        <label class="inline-flex items-center gap-2 text-xs text-muted">
+          <input type="checkbox" x-model="includePreviewMemories" class="rounded border-border">
+          Include memories
+        </label>
+        <label class="inline-flex items-center gap-2 text-xs text-muted">
+          <input type="checkbox" x-model="includePreviewReflections" class="rounded border-border">
+          Include task reflections
+        </label>
+      </div>
+      <div class="flex items-center gap-2">
+        <button class="btn-primary btn-sm" type="submit" :disabled="promptPreviewLoading">
+          <span x-show="!promptPreviewLoading">Generate preview</span>
+          <span x-show="promptPreviewLoading">Generating...</span>
+        </button>
+        <button class="btn btn-sm" type="button" @click="copyText(promptPreviewRaw)" :disabled="!promptPreviewRaw">Copy full prompt</button>
+      </div>
+    </form>
+
+    <template x-if="promptPreviewResult">
+      <div :class="promptPreviewOk ? 'alert-success' : 'alert-error'" class="mt-3" x-text="promptPreviewResult"></div>
+    </template>
+
+    <div class="mt-3" x-show="promptPreviewMeta">
+      <p class="text-muted text-xs" x-text="'Generated: ' + (promptPreviewMeta?.generated_at || '-') + ' · mode=' + (promptPreviewMeta?.history_mode || '-') + ' · ~tokens=' + (promptPreviewMeta?.token_estimate || 0)"></p>
+    </div>
+
+    <div class="mt-3" x-show="promptPreviewSections">
+      <h3 class="text-sm mb-2">Section view</h3>
+      <template x-for="entry in Object.entries(promptPreviewSections || {})" :key="entry[0]">
+        <details class="mb-2 rounded border border-border p-2">
+          <summary class="text-xs" x-text="entry[0]"></summary>
+          <pre class="mt-2 text-xs" style="white-space: pre-wrap" x-text="entry[1]"></pre>
+        </details>
+      </template>
+    </div>
+
+    <div class="mt-3" x-show="promptPreviewRaw">
+      <h3 class="text-sm mb-2">Raw assembled prompt</h3>
+      <pre class="text-xs" style="white-space: pre-wrap" x-text="promptPreviewRaw"></pre>
+    </div>
+
+    <hr class="border-border my-4">
+
+    <div>
+      <h3 class="text-sm mb-2">Recent runtime prompts</h3>
+      <div class="flex items-center gap-2 mb-2">
+        <button class="btn btn-sm" type="button" @click="fetchRecentPrompts()">Refresh captured prompts</button>
+        <span class="text-muted text-xs">Only available when capture is enabled and the agent is running.</span>
+      </div>
+      <template x-if="recentPromptsLoading">
+        <div class="text-muted text-xs">Loading...</div>
+      </template>
+      <template x-if="!recentPromptsLoading && (!recentPrompts || recentPrompts.length === 0)">
+        <div class="text-muted text-xs">No captured prompts yet.</div>
+      </template>
+      <template x-for="(item, idx) in (recentPrompts || [])" :key="idx">
+        <details class="mb-2 rounded border border-border p-2">
+          <summary class="text-xs" x-text="(item.captured_at || '-') + ' · ' + (item.channel || '-') + ' · user=' + (item.user_hash || '-')"></summary>
+          <div class="flex items-center gap-2 mt-2">
+            <button class="btn btn-sm" type="button" @click="copyText(item.prompt || '')">Copy</button>
+          </div>
+          <pre class="mt-2 text-xs" style="white-space: pre-wrap" x-text="item.prompt || ''"></pre>
+        </details>
+      </template>
+    </div>
+  </div>
+
   <div class="card">
     <h2 class="text-base mb-1">Active Inference Provider</h2>
     <p class="text-muted text-xs mb-4">Select the provider used for agent inference after testing its connection.</p>

--- a/core/agent.py
+++ b/core/agent.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import shlex
 import uuid
+from collections import deque
 from datetime import datetime
 from typing import Any, cast
 from zoneinfo import ZoneInfo
@@ -22,6 +24,7 @@ from core.llm import LLMClient, LLMToolCall
 from core.memory import MemoryStore
 from core.models import AgentResponse, Attachment
 from core.permissions import PermissionEngine, PermissionLevel, format_approval_message
+from core.prompt_builder import build_prompt_sections
 from core.scheduler import AgentScheduler
 from core.skills import SkillsEngine
 from core.task_reflection import ReflectionStore
@@ -263,6 +266,7 @@ class AgentCore:
         self.scheduler = AgentScheduler(self, self.job_store)
         config_db = "data/config.db"
         self.permissions = PermissionEngine(db_path=config_db)
+        self.prompt_capture: deque[dict[str, str]] = deque(maxlen=20)
 
         # Web search (Tavily)
         if config.search.enabled and config.search.api_key:
@@ -310,6 +314,13 @@ class AgentCore:
             decomposed_goal = await self._maybe_decompose(message)
 
         system = await self._build_system_prompt(decomposed_goal=decomposed_goal)
+        if self.config.admin.capture_prompts:
+            self._record_system_prompt(
+                channel=channel,
+                user_id=user_id,
+                chat_id=chat_id,
+                prompt=system,
+            )
 
         if self.history_mode == "session":
             return await self._process_session(
@@ -1064,14 +1075,7 @@ class AgentCore:
             log.exception("Background task reflection failed")
 
     async def _build_system_prompt(self, decomposed_goal: DecomposedGoal | None = None) -> str:
-        cfg = self.config.agent
         skills_index = await self.skills.get_index_block()
-        character = cfg.character
-        personalia = cfg.personalia
-        you_personalia = self.config.you.personalia
-        about_user_block = (
-            f"<about_user>\n{you_personalia}\n</about_user>\n\n" if you_personalia.strip() else ""
-        )
         memories = await self.memory.format_for_prompt()
 
         # Task reflections — lessons learned from past tasks
@@ -1082,94 +1086,35 @@ class AgentCore:
             except Exception:
                 log.exception("Failed to load task reflections for prompt")
 
-        tz = ZoneInfo(cfg.timezone)
-        now = datetime.now(tz)
+        sections = build_prompt_sections(
+            config=self.config,
+            history_mode=self.history_mode,
+            skills_index=skills_index,
+            memories=memories,
+            reflections=reflections,
+            decomposed_goal=decomposed_goal,
+        )
+        return sections.full_prompt
 
-        date_str = now.strftime("%A, %B %d, %Y")
-        time_str = now.strftime("%H:%M")
+    def _record_system_prompt(
+        self, *, channel: str, user_id: str, chat_id: str, prompt: str
+    ) -> None:
+        """Record generated prompts in a ring buffer for admin debugging."""
+        user_hash = hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:12]
+        chat_hash = hashlib.sha256(chat_id.encode("utf-8")).hexdigest()[:12] if chat_id else ""
+        self.prompt_capture.appendleft(
+            {
+                "captured_at": datetime.now(ZoneInfo(self.config.agent.timezone)).isoformat(),
+                "channel": channel,
+                "user_hash": user_hash,
+                "chat_hash": chat_hash,
+                "prompt": prompt,
+            }
+        )
 
-        prompt = f"""You are {cfg.name}, a personal AI assistant for {cfg.owner_name}.
-
-Today is {date_str}. Current time: {time_str}. Timezone: {cfg.timezone}.
-
-<personalia>
-{personalia}
-</personalia>
-
-<character>
-{character}
-</character>
-
-{about_user_block}<tool_usage>
-For write actions (sending emails, replying to emails, sending messages, creating calendar events,
-scheduling tasks), ALWAYS use the dedicated structured tools: `send_email`, `reply_email`,
-`send_message`, `create_calendar_event`, `manage_jobs`. NEVER use `run_command` for these — the
-structured tools handle quoting, piping, and permissions correctly.
-
-For scheduling, use the `manage_jobs` tool to create, list, and cancel jobs. For more advanced
-operations (editing jobs, pausing, viewing details), use the `jobs.py` CLI via `run_command`
-after loading the `scheduling` skill.
-
-Use `run_command` only for read/query operations (listing emails, reading messages, searching,
-managing flags/folders, contacts, memory, etc.).
-Always use the skill documentation to construct the correct command.
-If you don't have the skill content in context, call `load_skill` with the skill name to load it.
-Parse JSON output when available (himalaya supports -o json, sqlite3 supports -json).
-If a command fails, read the error and try to fix it.
-Never guess at command syntax — always refer to the skill file.
-
-You may create or update skills using the `skills.py` CLI after loading the `skill-creator` skill.
-</tool_usage>
-
-You can store and recall memories using the sqlite3 CLI (see the memory skill).
-Proactively remember important facts about the user and their contacts.
-Before inserting a new long-term memory, check if it already exists to avoid duplicates."""
-
-        # Only include history_handling instructions in injection mode;
-        # in session mode the conversation is natively threaded.
-        if self.history_mode != "session":
-            prompt += """
-
-<history_handling>
-Previous messages in this conversation have already been handled.
-Always focus exclusively on the latest user message as the current, active request.
-Use earlier messages only to understand context, resolve references (e.g. "that", "it",
-"the one I mentioned"), and maintain conversational continuity.
-</history_handling>"""
-
-        if memories:
-            prompt += f"""
-
-<memories>
-{memories}
-</memories>"""
-
-        if skills_index:
-            prompt += f"""
-
-<available_skills>
-{skills_index}
-</available_skills>"""
-
-        if reflections:
-            prompt += f"""
-
-<task_reflections>
-{reflections}
-</task_reflections>"""
-
-        if decomposed_goal:
-            prompt += f"""
-
-<execution_plan>
-The user's request has been analysed and broken into the following sub-goals.
-Follow this plan step-by-step, completing each sub-goal in order (respecting
-dependencies). Report progress as you go.
-
-{decomposed_goal.format_for_prompt()}
-</execution_plan>"""
-
-        return prompt
+    def get_recent_system_prompts(self) -> list[dict[str, str]]:
+        """Return recent captured system prompts for admin debug endpoints."""
+        return list(self.prompt_capture)
 
     def _extract_text(self, response) -> str:
         """Deprecated: retained for backward compatibility."""

--- a/core/config.py
+++ b/core/config.py
@@ -122,6 +122,7 @@ class SchedulerConfig(BaseModel):
 class AdminConfig(BaseModel):
     port: int = 8000
     api_key: str = ""
+    capture_prompts: bool = False
 
 
 class HistoryConfig(BaseModel):
@@ -165,6 +166,11 @@ class YouConfig(BaseModel):
     personalia: str = ""
 
 
+class PromptConfig(BaseModel):
+    tool_usage_override: str = ""
+    history_handling_override: str = ""
+
+
 class Config(BaseModel):
     agent: AgentConfig = AgentConfig()
     channels: ChannelsConfig = ChannelsConfig()
@@ -178,6 +184,7 @@ class Config(BaseModel):
     task_reflection: TaskReflectionConfig = TaskReflectionConfig()
     search: SearchConfig = SearchConfig()
     you: YouConfig = YouConfig()
+    prompt: PromptConfig = PromptConfig()
 
 
 def load_config(path: str | Path = "config.yml") -> Config:

--- a/core/prompt_builder.py
+++ b/core/prompt_builder.py
@@ -1,0 +1,180 @@
+"""System prompt builder shared by runtime and admin preview."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from core.config import Config
+from core.goal_decomposition import DecomposedGoal
+
+DEFAULT_TOOL_USAGE_BLOCK = """For write actions
+(sending emails, replying to emails, sending messages, creating calendar events,
+scheduling tasks), ALWAYS use the dedicated structured tools: `send_email`, `reply_email`,
+`send_message`, `create_calendar_event`, `manage_jobs`. NEVER use `run_command` for these — the
+structured tools handle quoting, piping, and permissions correctly.
+
+For scheduling, use the `manage_jobs` tool to create, list, and cancel jobs. For more advanced
+operations (editing jobs, pausing, viewing details), use the `jobs.py` CLI via `run_command`
+after loading the `scheduling` skill.
+
+Use `run_command` only for read/query operations (listing emails, reading messages, searching,
+managing flags/folders, contacts, memory, etc.).
+Always use the skill documentation to construct the correct command.
+If you don't have the skill content in context, call `load_skill` with the skill name to load it.
+Parse JSON output when available (himalaya supports -o json, sqlite3 supports -json).
+If a command fails, read the error and try to fix it.
+Never guess at command syntax — always refer to the skill file.
+
+You may create or update skills using the `skills.py` CLI
+after loading the `skill-creator` skill."""
+
+DEFAULT_HISTORY_HANDLING_BLOCK = """Previous messages in this conversation
+have already been handled.
+Always focus exclusively on the latest user message as the current, active request.
+Use earlier messages only to understand context, resolve references (e.g. "that", "it",
+"the one I mentioned"), and maintain conversational continuity."""
+
+
+def resolve_prompt_block(default_text: str, override_text: str | None) -> str:
+    """Resolve a prompt block, using override when non-empty."""
+    if override_text and override_text.strip():
+        return override_text.strip()
+    return default_text
+
+
+@dataclass(slots=True)
+class PromptSections:
+    intro: str
+    personalia: str
+    character: str
+    about_user: str
+    tool_usage: str
+    memory_instruction: str
+    history_handling: str
+    memories: str
+    available_skills: str
+    task_reflections: str
+    execution_plan: str
+
+    @property
+    def full_prompt(self) -> str:
+        parts = [
+            self.intro,
+            self.personalia,
+            self.character,
+            self.about_user,
+            self.tool_usage,
+            self.memory_instruction,
+        ]
+        if self.history_handling:
+            parts.append(self.history_handling)
+        if self.memories:
+            parts.append(self.memories)
+        if self.available_skills:
+            parts.append(self.available_skills)
+        if self.task_reflections:
+            parts.append(self.task_reflections)
+        if self.execution_plan:
+            parts.append(self.execution_plan)
+        return "\n\n".join(p.strip("\n") for p in parts if p)
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "intro": self.intro,
+            "personalia": self.personalia,
+            "character": self.character,
+            "about_user": self.about_user,
+            "tool_usage": self.tool_usage,
+            "memory_instruction": self.memory_instruction,
+            "history_handling": self.history_handling,
+            "memories": self.memories,
+            "available_skills": self.available_skills,
+            "task_reflections": self.task_reflections,
+            "execution_plan": self.execution_plan,
+        }
+
+
+def build_prompt_sections(
+    *,
+    config: Config,
+    history_mode: str,
+    skills_index: str,
+    memories: str,
+    reflections: str,
+    decomposed_goal: DecomposedGoal | None,
+    include_memories: bool = True,
+    include_reflections: bool = True,
+) -> PromptSections:
+    """Build all prompt sections with current config and dynamic context."""
+    cfg = config.agent
+    now = datetime.now(ZoneInfo(cfg.timezone))
+    date_str = now.strftime("%A, %B %d, %Y")
+    time_str = now.strftime("%H:%M")
+
+    about_user_block = config.you.personalia.strip()
+    tool_usage_text = resolve_prompt_block(
+        DEFAULT_TOOL_USAGE_BLOCK,
+        getattr(config.prompt, "tool_usage_override", ""),
+    )
+    history_handling_text = resolve_prompt_block(
+        DEFAULT_HISTORY_HANDLING_BLOCK,
+        getattr(config.prompt, "history_handling_override", ""),
+    )
+
+    intro = (
+        f"You are {cfg.name}, a personal AI assistant for {cfg.owner_name}.\n\n"
+        f"Today is {date_str}. Current time: {time_str}. Timezone: {cfg.timezone}."
+    )
+
+    personalia = f"<personalia>\n{cfg.personalia}\n</personalia>"
+    character = f"<character>\n{cfg.character}\n</character>"
+    about_user = f"<about_user>\n{about_user_block}\n</about_user>" if about_user_block else ""
+    tool_usage = f"<tool_usage>\n{tool_usage_text}\n</tool_usage>"
+    memory_instruction = (
+        "You can store and recall memories using the sqlite3 CLI (see the memory skill).\n"
+        "Proactively remember important facts about the user and their contacts.\n"
+        "Before inserting a new long-term memory, check if it already exists to avoid duplicates."
+    )
+
+    history_handling = ""
+    if history_mode != "session":
+        history_handling = f"<history_handling>\n{history_handling_text}\n</history_handling>"
+
+    memory_section = ""
+    if include_memories and memories:
+        memory_section = f"<memories>\n{memories}\n</memories>"
+
+    skills_section = ""
+    if skills_index:
+        skills_section = f"<available_skills>\n{skills_index}\n</available_skills>"
+
+    reflections_section = ""
+    if include_reflections and reflections:
+        reflections_section = f"<task_reflections>\n{reflections}\n</task_reflections>"
+
+    execution_plan = ""
+    if decomposed_goal:
+        execution_plan = (
+            "<execution_plan>\n"
+            "The user's request has been analysed and broken into the following sub-goals.\n"
+            "Follow this plan step-by-step, completing each sub-goal in order (respecting\n"
+            "dependencies). Report progress as you go.\n\n"
+            f"{decomposed_goal.format_for_prompt()}\n"
+            "</execution_plan>"
+        )
+
+    return PromptSections(
+        intro=intro,
+        personalia=personalia,
+        character=character,
+        about_user=about_user,
+        tool_usage=tool_usage,
+        memory_instruction=memory_instruction,
+        history_handling=history_handling,
+        memories=memory_section,
+        available_skills=skills_section,
+        task_reflections=reflections_section,
+        execution_plan=execution_plan,
+    )

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from fastapi.testclient import TestClient
 
 from api.admin import AgentState, _should_capture_log_record, create_admin_app
+from core.config import Config
 from core.config_store import ConfigStore
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,35 @@ class _ConfigStoreStub:
     async def set_many(self, values: dict) -> None:
         self._last_set = values
         self._data.update(values)
+
+    async def export_to_config(self) -> Config:
+        cfg = Config()
+        for key, value in self._data.items():
+            if key == "agent.name":
+                cfg.agent.name = value
+            elif key == "agent.owner_name":
+                cfg.agent.owner_name = value
+            elif key == "agent.llm_provider":
+                cfg.agent.llm_provider = value
+            elif key == "agent.model":
+                cfg.agent.model = value
+            elif key == "agent.timezone":
+                cfg.agent.timezone = value
+            elif key == "agent.character":
+                cfg.agent.character = value
+            elif key == "agent.personalia":
+                cfg.agent.personalia = value
+            elif key == "you.personalia":
+                cfg.you.personalia = value
+            elif key == "history.mode":
+                cfg.history.mode = value
+            elif key == "prompt.tool_usage_override":
+                cfg.prompt.tool_usage_override = value
+            elif key == "prompt.history_handling_override":
+                cfg.prompt.history_handling_override = value
+            elif key == "admin.capture_prompts":
+                cfg.admin.capture_prompts = str(value).lower() == "true"
+        return cfg
 
     async def verify_admin_password(self, password: str) -> bool:
         return password == "secret"
@@ -266,6 +296,7 @@ class TestPartialRoutes:
             "/partials/status",
             "/partials/identity",
             "/partials/you",
+            "/partials/llm",
             "/partials/calendars",
             "/partials/history",
             "/partials/permissions",
@@ -471,6 +502,44 @@ class TestConfigAPI:
         assert resp.status_code == 200
         assert resp.json()["updated"] == "you.personalia"
         assert store._data.get("you.personalia") == "Loves hiking and coffee"
+
+    def test_preview_system_prompt(self):
+        store = _ConfigStoreStub(setup_complete=True)
+        store._data["agent.name"] = "Clio"
+        store._data["agent.owner_name"] = "Matteo"
+        store._data["agent.character"] = "# Character"
+        store._data["agent.personalia"] = "# Personalia"
+        store._data["you.personalia"] = "Likes espresso"
+        agent_state = AgentState(agent=cast(Any, _AgentStub()))
+        app, _ = create_admin_app(agent_state, cast(ConfigStore, store))
+        client = TestClient(app, follow_redirects=False)
+
+        resp = client.post(
+            "/debug/system-prompt/preview",
+            json={
+                "message": "Plan my week",
+                "include_memories": False,
+                "include_reflections": False,
+            },
+            headers=AUTH,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "full_prompt" in data
+        assert "sections" in data
+        assert "tool_usage" in data["sections"]
+        assert "You are" in data["full_prompt"]
+
+    def test_recent_system_prompts_when_no_agent(self):
+        store = _ConfigStoreStub(setup_complete=True)
+        agent_state = AgentState(agent=None)
+        app, _ = create_admin_app(agent_state, cast(ConfigStore, store))
+        client = TestClient(app, follow_redirects=False)
+        resp = client.get("/debug/system-prompt/recent", headers=AUTH)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["items"] == []
 
     def test_save_calendar_providers(self):
         store = _ConfigStoreStub(setup_complete=True)


### PR DESCRIPTION
## Summary
- Add a new system prompt controls panel in the LLM admin tab with live preview, section breakdown, copy actions, and runtime prompt capture browsing.
- Add backend debug endpoints for assembled prompt preview and recent captured runtime prompts, plus config-driven override support for tool usage/history handling blocks.
- Refactor prompt composition into a shared `core/prompt_builder.py` used by runtime and admin preview, and add tests for the new admin API routes.

## Verification
- `uv run ruff check .`
- `uv run pytest tests/test_admin_ui.py tests/test_goal_decomposition.py tests/test_task_reflection.py tests/test_memory_extraction.py tests/test_memory_consolidation.py`

## Notes
- Prompt capture is opt-in via `admin.capture_prompts` and stores only a small in-memory ring buffer (not persisted).
- Captured prompt metadata hashes user/chat identifiers before exposing them in admin debug output.