### PR TITLE
feat: vision fallback — caption images via a secondary model on non-vision models

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -889,6 +889,10 @@ def create_admin_app(
         compaction_provider = await config_store.get("compaction.provider") or "anthropic"
         compaction_model = await config_store.get("compaction.model") or "claude-haiku-4-5"
         compaction_thinking_level = await config_store.get("compaction.thinking_level") or ""
+        vision_enabled = await config_store.get("vision.enabled")
+        vision_enabled = vision_enabled if vision_enabled is not None else "false"
+        vision_provider = await config_store.get("vision.provider") or "anthropic"
+        vision_model = await config_store.get("vision.model") or "claude-haiku-4-5"
         prompt_tool_usage_override = await config_store.get("prompt.tool_usage_override") or ""
         prompt_history_override = await config_store.get("prompt.history_handling_override") or ""
         prompt_capture_enabled = await config_store.get("admin.capture_prompts")
@@ -926,6 +930,9 @@ def create_admin_app(
             compaction_provider=compaction_provider,
             compaction_model=compaction_model,
             compaction_thinking_level=compaction_thinking_level,
+            vision_enabled=vision_enabled,
+            vision_provider=vision_provider,
+            vision_model=vision_model,
             prompt_tool_usage_override=prompt_tool_usage_override,
             prompt_history_override=prompt_history_override,
             default_tool_usage=DEFAULT_TOOL_USAGE_BLOCK,

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -42,7 +42,7 @@
     }
     window.showToast = showToast;
 
-    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel) {
+    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel) {
       const currentProvider = provider || 'anthropic';
       return {
         providerOptions: [
@@ -110,6 +110,11 @@
         compactionModel: compactionModel || 'claude-haiku-4-5',
         compactionResult: '',
         compactionResultOk: false,
+        visionEnabled: visionEnabled === 'true' || visionEnabled === true,
+        visionProvider: visionProvider || 'anthropic',
+        visionModel: visionModel || 'claude-haiku-4-5',
+        visionResult: '',
+        visionResultOk: false,
         result: '',
         resultOk: false,
         tests: {
@@ -177,6 +182,44 @@
           if (!id) return false;
           return ['opus', 'sonnet', 'thinking', 'pro', 'deep-think', 'reasoner', 'grok-4']
             .some(pat => id.includes(pat));
+        },
+        // ponytail: mirror of model_supports_vision() in core/llm.py — keep in
+        // sync. True when the model reads images natively (no fallback needed).
+        modelSupportsVision(modelId, prov) {
+          const id = (modelId || '').toLowerCase();
+          if (!id) return false;
+          if (id.includes('deepseek')) return false;
+          if (prov === 'anthropic' || prov === 'google') return true;
+          return ['claude', 'gpt-4o', 'gpt-4.1', 'gpt-5', 'o1', 'o3', 'o4',
+                  'gemini', 'grok-4', 'grok-2-vision', 'vision', 'llava', 'pixtral']
+            .some(pat => id.includes(pat));
+        },
+        // One-tap from the model picker: turn the fallback on (seeding a default
+        // vision model if blank) and persist — no trip to the Vision card needed.
+        enableVisionFallback() {
+          this.visionEnabled = true;
+          if (!this.visionModel) { this.visionModel = 'claude-haiku-4-5'; }
+          this.saveVision();
+        },
+        saveVision() {
+          fetch('/config', {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+            },
+            body: JSON.stringify({values: {
+              'vision.enabled': this.visionEnabled ? 'true' : 'false',
+              'vision.provider': this.visionProvider,
+              'vision.model': this.visionModel
+            }})
+          })
+            .then(r => { this.visionResultOk = r.ok; return r.json(); })
+            .then(d => {
+              this.visionResult = this.visionResultOk ? 'Vision settings saved' : (d.detail || 'Error');
+              if (this.visionResultOk && window.showToast) { window.showToast('Vision settings saved'); }
+            })
+            .catch(e => { this.visionResultOk = false; this.visionResult = e.message; });
         },
         // Effort values offered in the thinking-level datalist. Anthropic can be
         // enriched live via "Fetch levels"; others fall back to the common set.

--- a/api/templates/partials/llm.html
+++ b/api/templates/partials/llm.html
@@ -60,7 +60,10 @@
   {{ consolidation_thinking_level|default('', true)|tojson|forceescape }},
   {{ gd_thinking_level|default('', true)|tojson|forceescape }},
   {{ tr_thinking_level|default('', true)|tojson|forceescape }},
-  {{ compaction_thinking_level|default('', true)|tojson|forceescape }}
+  {{ compaction_thinking_level|default('', true)|tojson|forceescape }},
+  {{ vision_enabled|default('false', true)|tojson|forceescape }},
+  {{ vision_provider|default('anthropic', true)|tojson|forceescape }},
+  {{ vision_model|default('claude-haiku-4-5', true)|tojson|forceescape }}
 )">
   <div class="card">
     <h2 class="text-base mb-1">System Prompt Controls</h2>
@@ -207,6 +210,22 @@
           </template>
         </datalist>
         <p class="text-muted text-xs mt-1">Type any model id, or pick from the list. Use “Fetch models” in the provider card below to load the live list from the API.</p>
+
+        {# Native-vision indicator + one-tap vision-fallback prompt. #}
+        <p class="text-muted text-xs mt-1" x-show="model && modelSupportsVision(model, provider)">
+          🖼️ This model reads images natively.
+        </p>
+        <div class="mt-2 rounded border border-warn-dim/40 bg-warn-dim/20 px-3 py-2"
+             x-show="model && !modelSupportsVision(model, provider)">
+          <p class="text-xs" style="color: var(--color-warn)">
+            <span x-show="!visionEnabled">This model can’t read images. Set up a vision fallback so photos still work?</span>
+            <span x-show="visionEnabled">Vision fallback is on — images are captioned by <span x-text="visionModel"></span>.</span>
+          </p>
+          <button type="button" class="btn-primary btn-sm mt-2" x-show="!visionEnabled"
+                  @click="enableVisionFallback()">
+            Enable vision fallback
+          </button>
+        </div>
       </div>
 
 {{ think('thinkingLevel', 'provider', 'model', 'dl-think-main') }}
@@ -515,6 +534,48 @@
     </div>
     <template x-if="compactionResult">
       <div :class="compactionResultOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="compactionResult"></div>
+    </template>
+  </div>
+
+  <div class="card">
+    <h2 class="text-base mb-1">Vision Fallback</h2>
+    <p class="text-muted text-xs mb-4">When the active model can’t read images, route image attachments to this model for a text description / OCR, injected in place of the image. Off by default; engages only when the active model lacks native vision. Reuses the provider keys configured below.</p>
+
+    <form class="space-y-4" @submit.prevent>
+      <div class="flex items-center gap-2">
+        <label class="label mb-0">Enabled</label>
+        <input type="checkbox" x-model="visionEnabled" class="rounded border-border">
+      </div>
+
+      <div>
+        <label class="label">Provider</label>
+        <select class="input-sm" style="max-width:500px" x-model="visionProvider" :disabled="!visionEnabled" x-effect="$el.value = visionProvider">
+          <template x-for="item in providerOptions" :key="'vis-' + item.value">
+            <option :value="item.value" :selected="item.value === visionProvider" x-text="item.label"></option>
+          </template>
+        </select>
+      </div>
+      <div>
+        <label class="label">Model</label>
+        <input type="text" class="input-sm" style="max-width:500px" x-model="visionModel" :disabled="!visionEnabled"
+               list="dl-model-vision" placeholder="Type or pick a model">
+        <datalist id="dl-model-vision">
+          <template x-for="item in modelOptions(visionProvider)" :key="'vis-m-' + item.value">
+            <option :value="item.value"></option>
+          </template>
+        </datalist>
+        <p class="text-amber-600 text-xs mt-1" x-show="visionModel && !modelSupportsVision(visionModel, visionProvider)">
+          Heads up: “<span x-text="visionModel"></span>” isn’t a recognized vision model — pick one that can read images, or captioning will fail.
+        </p>
+        <p class="text-muted text-xs mt-1">A small, cheap vision model is recommended (captioning is a single short call).</p>
+      </div>
+    </form>
+
+    <div class="flex items-center gap-2 mt-4">
+      <button class="btn-primary btn-sm" @click="saveVision()">Save vision fallback</button>
+    </div>
+    <template x-if="visionResult">
+      <div :class="visionResultOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="visionResult"></div>
     </template>
   </div>
 

--- a/api/templates/wizard/llm.html
+++ b/api/templates/wizard/llm.html
@@ -34,6 +34,7 @@
   fetchedModels: {anthropic: [], openai: [], google: [], grok: [], deepseek: []},
   fetchingModels: {anthropic: false, openai: false, google: false, grok: false, deepseek: false},
   fetchModelsResult: {anthropic: '', openai: '', google: '', grok: '', deepseek: ''},
+  visionFallback: true,
   init() {
     const savedModel = this.model;
     this.$nextTick(() => { this.model = savedModel; });
@@ -42,6 +43,17 @@
     const fetched = this.fetchedModels[prov];
     if (fetched && fetched.length) { return fetched.map(id => ({value: id, label: id})); }
     return this.models[prov] || [];
+  },
+  // Mirror of model_supports_vision() in core/llm.py — true when the model
+  // reads images natively, so the fallback prompt only shows when it can't.
+  modelSupportsVision(modelId, prov) {
+    const id = (modelId || '').toLowerCase();
+    if (!id) return false;
+    if (id.includes('deepseek')) return false;
+    if (prov === 'anthropic' || prov === 'google') return true;
+    return ['claude', 'gpt-4o', 'gpt-4.1', 'gpt-5', 'o1', 'o3', 'o4',
+            'gemini', 'grok-4', 'grok-2-vision', 'vision', 'llava', 'pixtral']
+      .some(pat => id.includes(pat));
   },
   resetModel() {
     if (this.model) return;
@@ -100,6 +112,15 @@
     </template>
   </datalist>
   <p class="hint">Type any model id, or pick from the list. Use “Fetch models” in the provider section below to load the live list.</p>
+
+  <p class="hint mt-2" x-show="model && modelSupportsVision(model, provider)">🖼️ This model reads images natively.</p>
+  <div class="mt-2 rounded border border-warn-dim/40 bg-warn-dim/20 px-3 py-2"
+       x-show="model && !modelSupportsVision(model, provider)">
+    <label class="inline-flex items-center gap-2 text-xs" style="color: var(--color-warn)">
+      <input type="checkbox" x-model="visionFallback">
+      This model can’t read images. Set up a vision fallback (recommended) so photos still work — captioned by claude-haiku-4-5.
+    </label>
+  </div>
 
   </div>
 
@@ -375,22 +396,31 @@
               const googleBaseUrlValue = googleBaseUrl || 'https://generativelanguage.googleapis.com/v1beta/openai';
               const grokBaseUrlValue = grokBaseUrl || 'https://api.x.ai/v1';
               const deepseekBaseUrlValue = deepseekBaseUrl || 'https://api.deepseek.com';
+              const modelValue = document.getElementById('w-model').value;
+              const vals = {
+                step: 'identity',
+                'values[agent.llm_provider]': provider,
+                'values[agent.anthropic_api_key]': anthropicKey,
+                'values[agent.openai_api_key]': openaiKey,
+                'values[agent.openai_base_url]': openaiBaseUrl,
+                'values[agent.google_api_key]': googleKey,
+                'values[agent.google_base_url]': googleBaseUrlValue,
+                'values[agent.grok_api_key]': grokKey,
+                'values[agent.grok_base_url]': grokBaseUrlValue,
+                'values[agent.deepseek_api_key]': deepseekKey,
+                'values[agent.deepseek_base_url]': deepseekBaseUrlValue,
+                'values[agent.model]': modelValue
+              };
+              // One-tap inline: enable the vision fallback when the picked model
+              // can't read images and the box is left checked.
+              if (this.visionFallback && !this.modelSupportsVision(modelValue, provider)) {
+                vals['values[vision.enabled]'] = 'true';
+                vals['values[vision.provider]'] = 'anthropic';
+                vals['values[vision.model]'] = 'claude-haiku-4-5';
+              }
               htmx.ajax('POST', '/setup/step', {
                 target: '#wizard-step', swap: 'innerHTML',
-                values: {
-                  step: 'identity',
-                  'values[agent.llm_provider]': provider,
-                  'values[agent.anthropic_api_key]': anthropicKey,
-                  'values[agent.openai_api_key]': openaiKey,
-                  'values[agent.openai_base_url]': openaiBaseUrl,
-                  'values[agent.google_api_key]': googleKey,
-                  'values[agent.google_base_url]': googleBaseUrlValue,
-                  'values[agent.grok_api_key]': grokKey,
-                  'values[agent.grok_base_url]': grokBaseUrlValue,
-                  'values[agent.deepseek_api_key]': deepseekKey,
-                  'values[agent.deepseek_base_url]': deepseekBaseUrlValue,
-                  'values[agent.model]': document.getElementById('w-model').value
-                }
+                values: vals
               })
             ">
       Next

--- a/config.yml.example
+++ b/config.yml.example
@@ -69,6 +69,15 @@ search:
   api_key: "${TAVILY_API_KEY}"
   max_results: 5
 
+# Vision fallback — when the active model can't read images, route image
+# attachments to this model for a text description / OCR. Off by default;
+# engages only when the active model lacks native vision. Reuses the provider
+# API keys configured under `agent`.
+vision:
+  enabled: false
+  provider: "anthropic"
+  model: "claude-haiku-4-5"
+
 history:
   db_path: "data/agent.db"
   max_turns: 10  # number of user-assistant pairs (not individual messages)

--- a/core/agent.py
+++ b/core/agent.py
@@ -562,15 +562,17 @@ class AgentCore:
         """Caption a single image via the vision model. Task-aware: the user's
         message steers what to extract (e.g. OCR vs. scene description)."""
         block = att.to_anthropic_block() if llm.provider == "anthropic" else att.to_openai_block()
-        ask = (
-            "Describe this image so someone who cannot see it understands it. "
-            "Transcribe any visible text verbatim (OCR). Be concise but complete."
+        system = (
+            "You caption images for a model that cannot see them. "
+            "Describe the image so the reader understands it, and transcribe any "
+            "visible text verbatim (OCR). Be concise but complete."
         )
+        ask = "Describe this image."
         if user_text.strip():
-            ask += f'\n\nThe user sent it with this message: "{user_text.strip()}" — '
+            ask += f' The user sent it with this message: "{user_text.strip()}" — '
             ask += "focus on what is relevant to that."
         messages = [{"role": "user", "content": [block, {"type": "text", "text": ask}]}]
-        response = await llm.generate(model=model, system="", messages=messages, tools=[])
+        response = await llm.generate(model=model, system=system, messages=messages, tools=[])
         return response.text.strip() or "(no description available)"
 
     def _vision_llm(self, provider: str) -> LLMClient:

--- a/core/agent.py
+++ b/core/agent.py
@@ -9,7 +9,7 @@ import json
 import logging
 import shlex
 import uuid
-from collections import deque
+from collections import OrderedDict, deque
 from datetime import datetime
 from typing import Any, cast
 from zoneinfo import ZoneInfo
@@ -23,7 +23,7 @@ from core.executor import ToolExecutor
 from core.goal_decomposition import DecomposedGoal, classify_complexity, decompose_goal
 from core.history import ConversationHistory
 from core.job_store import JobStore
-from core.llm import LLMClient, LLMToolCall
+from core.llm import LLMClient, LLMToolCall, model_supports_vision
 from core.memory import MemoryStore
 from core.models import AgentResponse, Attachment
 from core.permissions import PermissionEngine, PermissionLevel, format_approval_message
@@ -36,6 +36,10 @@ from core.tools import tool_env
 from voice.pipeline import VoicePipeline
 
 log = logging.getLogger(__name__)
+
+# Vision fallback caption cache cap (per process). Captions are keyed by image
+# hash so repeated identical images don't re-hit the vision model.
+_VISION_CACHE_MAX = 256
 
 
 def _shell_quote(s: str) -> str:
@@ -296,6 +300,8 @@ class AgentCore:
         config_db = "data/config.db"
         self.permissions = PermissionEngine(db_path=config_db)
         self.prompt_capture: deque[dict[str, str]] = deque(maxlen=20)
+        # Vision fallback caption cache (image hash -> "[Image: ...]"), LRU-bounded.
+        self._vision_cache: OrderedDict[str, str] = OrderedDict()
 
         # Web search (Tavily)
         if config.search.enabled and config.search.api_key:
@@ -480,7 +486,7 @@ class AgentCore:
             "I summarized the earlier part to free up space; recent messages are kept as-is."
         )
 
-    def _build_user_message(
+    async def _build_user_message(
         self,
         message: str,
         attachments: list[Attachment] | None = None,
@@ -490,10 +496,20 @@ class AgentCore:
 
         ``preamble`` (live date/time + optional execution plan) is prepended to
         the message text so the agent always knows 'now' for the current turn.
+
+        When the active model can't see images and a vision fallback is
+        configured, images are captioned by a secondary model and the text is
+        injected in place of the image blocks so the model can still "see".
         """
         text = f"{preamble}\n\n{message}" if preamble else message
         image_attachments = [a for a in (attachments or []) if a.is_image]
         if image_attachments:
+            if self._vision_fallback_active():
+                captions = await self._caption_images(image_attachments, message)
+                if captions:
+                    text = "\n\n".join([text, *captions]) if text else "\n\n".join(captions)
+                    return {"role": "user", "content": text}
+                # Captioning failed entirely — fall through to native image blocks.
             content_blocks: list[dict] = []
             if text:
                 content_blocks.append({"type": "text", "text": text})
@@ -504,6 +520,62 @@ class AgentCore:
                     content_blocks.append(att.to_openai_block())
             return {"role": "user", "content": content_blocks}
         return {"role": "user", "content": text}
+
+    def _vision_fallback_active(self) -> bool:
+        """True when the active model lacks vision and a fallback is enabled."""
+        return self.config.vision.enabled and not model_supports_vision(
+            self.llm.provider, self.config.agent.model
+        )
+
+    async def _caption_images(self, images: list[Attachment], user_text: str) -> list[str]:
+        """Caption each image with a task-aware prompt, returning ``[Image: ...]``
+        strings. Returns ``[]`` on any failure so the caller can fall back to
+        passing the raw image blocks through. Captions are cached by image hash.
+        """
+        vis = self.config.vision
+        llm = self._vision_llm(vis.provider)
+        out: list[str] = []
+        for att in images:
+            key = hashlib.sha256(att.data).hexdigest()
+            cached = self._vision_cache.get(key)
+            if cached is not None:
+                self._vision_cache.move_to_end(key)
+                out.append(cached)
+                continue
+            try:
+                caption = await self._caption_one(llm, vis.model, att, user_text)
+            except Exception:
+                log.exception("Vision fallback captioning failed")
+                return []
+            entry = f"[Image: {caption}]"
+            self._vision_cache[key] = entry
+            # ponytail: bounded LRU, drop oldest past the cap — fine for a single
+            # process; swap for a shared store only if multi-instance dedup matters.
+            if len(self._vision_cache) > _VISION_CACHE_MAX:
+                self._vision_cache.popitem(last=False)
+            out.append(entry)
+        return out
+
+    async def _caption_one(
+        self, llm: LLMClient, model: str, att: Attachment, user_text: str
+    ) -> str:
+        """Caption a single image via the vision model. Task-aware: the user's
+        message steers what to extract (e.g. OCR vs. scene description)."""
+        block = att.to_anthropic_block() if llm.provider == "anthropic" else att.to_openai_block()
+        ask = (
+            "Describe this image so someone who cannot see it understands it. "
+            "Transcribe any visible text verbatim (OCR). Be concise but complete."
+        )
+        if user_text.strip():
+            ask += f'\n\nThe user sent it with this message: "{user_text.strip()}" — '
+            ask += "focus on what is relevant to that."
+        messages = [{"role": "user", "content": [block, {"type": "text", "text": ask}]}]
+        response = await llm.generate(model=model, system="", messages=messages, tools=[])
+        return response.text.strip() or "(no description available)"
+
+    def _vision_llm(self, provider: str) -> LLMClient:
+        """Return an LLM client for image captioning (mirrors ``_memory_llm``)."""
+        return self._background_llm(provider)
 
     async def _process_injection(
         self,
@@ -528,7 +600,7 @@ class AgentCore:
                 messages.append({"role": turn["role"], "content": turn["content"]})
 
         # The actual current request — always the last user message.
-        messages.append(self._build_user_message(message, attachments, preamble))
+        messages.append(await self._build_user_message(message, attachments, preamble))
 
         log.info(
             "Processing message (injection) from %s/%s/%s: %s",
@@ -629,7 +701,7 @@ class AgentCore:
         session = await self.history.get_session(channel, user_id, chat_id)
 
         # Append the new user message (with the live date/time preamble)
-        user_msg = self._build_user_message(message, attachments, preamble)
+        user_msg = await self._build_user_message(message, attachments, preamble)
         await self.history.append_session_message(channel, user_id, user_msg, chat_id)
 
         log.info(

--- a/core/config.py
+++ b/core/config.py
@@ -220,6 +220,16 @@ class SearchConfig(BaseModel):
     max_results: int = 5
 
 
+class VisionConfig(BaseModel):
+    """Vision fallback — caption images via a secondary vision-capable model
+    when the active model can't see images. Off by default; engages only when
+    the active model lacks vision and an image is present."""
+
+    enabled: bool = False
+    provider: str = "anthropic"
+    model: str = "claude-haiku-4-5"
+
+
 class YouConfig(BaseModel):
     personalia: str = ""
 
@@ -255,6 +265,7 @@ class Config(BaseModel):
     task_reflection: TaskReflectionConfig = TaskReflectionConfig()
     compaction: CompactionConfig = CompactionConfig()
     search: SearchConfig = SearchConfig()
+    vision: VisionConfig = VisionConfig()
     you: YouConfig = YouConfig()
     prompt: PromptConfig = PromptConfig()
     tools: ToolsConfig = ToolsConfig()

--- a/core/llm.py
+++ b/core/llm.py
@@ -25,6 +25,42 @@ _ANTHROPIC_MODEL_ALIASES = {
     "claude-4-5-haiku": "claude-haiku-4-5",
 }
 
+# Vision-capable model heuristic — single source of truth for "can this model
+# read images natively". Mirrored client-side by modelSupportsVision() in the
+# admin UI (api/templates/base.html + wizard/llm.html); keep the two in sync.
+# ponytail: substring heuristic, extend as model ids change. The fallback only
+# engages when this returns False, so a wrong "True" just means no captioning.
+_VISION_TEXT_ONLY = ("deepseek",)  # families with no image input
+_VISION_CAPABLE_PATTERNS = (
+    "claude",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-5",
+    "o1",
+    "o3",
+    "o4",
+    "gemini",
+    "grok-4",
+    "grok-2-vision",
+    "vision",
+    "llava",
+    "pixtral",
+)
+
+
+def model_supports_vision(provider: str, model: str) -> bool:
+    """True when (provider, model) accepts image input natively."""
+    mid = (model or "").lower()
+    if not mid:
+        return False
+    if any(p in mid for p in _VISION_TEXT_ONLY):
+        return False
+    # Anthropic and Google line-ups have no text-only chat models, so trust the
+    # provider even for an unrecognized id; others fall back to name patterns.
+    if _normalize_provider(provider) in ("anthropic", "google"):
+        return True
+    return any(p in mid for p in _VISION_CAPABLE_PATTERNS)
+
 
 @dataclass
 class LLMToolCall:

--- a/core/llm.py
+++ b/core/llm.py
@@ -156,7 +156,7 @@ class LLMClient:
         self.thinking_level = (thinking_level or "").strip().lower()
         self._client: Any
         if self.provider == "anthropic":
-            self._client = AsyncAnthropic(api_key=api_key)
+            self._client = AsyncAnthropic(api_key=api_key, timeout=60)
         else:
             resolved_base = base_url or _DEFAULT_BASE_URLS.get(self.provider)
             try:
@@ -167,6 +167,7 @@ class LLMClient:
             client_kwargs: dict[str, Any] = {
                 "api_key": api_key,
                 "base_url": resolved_base or None,
+                "timeout": 60,
             }
             self._client = cast(Any, client_class)(**client_kwargs)  # type: ignore[call-arg]
 

--- a/core/repl.py
+++ b/core/repl.py
@@ -15,12 +15,14 @@ from __future__ import annotations
 import asyncio
 import itertools
 import logging
+import mimetypes
 import os
 import sys
 import time
 
 from core.agent import AgentCore
 from core.config_store import ConfigStore
+from core.models import Attachment
 
 try:  # POSIX-only: lets us watch for an ESC keypress mid-turn
     import termios
@@ -145,6 +147,31 @@ class ReplChannel:
         self.spinner.start()
 
 
+def _clipboard_image() -> tuple[bytes | None, str]:
+    """Grab a PNG/JPEG image off the system clipboard, returning (data, mime).
+
+    Tries the usual clipboard CLIs in order; returns (None, "") if none yield
+    image bytes. ponytail: shell-outs over a clipboard dep — wl-paste/xclip/
+    pbpaste already cover Wayland/X11/macOS.
+    """
+    import shutil
+    import subprocess
+
+    for mime in ("image/png", "image/jpeg"):
+        if shutil.which("wl-paste"):
+            cmd = ["wl-paste", "-t", mime]
+        elif shutil.which("xclip"):
+            cmd = ["xclip", "-selection", "clipboard", "-t", mime, "-o"]
+        elif shutil.which("pbpaste"):
+            cmd = ["pbpaste"]  # macOS: only reliably yields PNG
+        else:
+            return None, ""
+        out = subprocess.run(cmd, capture_output=True).stdout
+        if out:
+            return out, mime
+    return None, ""
+
+
 def _setup_logging(spinner: Spinner) -> None:
     handler = _SpinnerHandler(spinner)
     root = logging.getLogger()
@@ -175,13 +202,22 @@ def _print_debug_config(config, persona=None) -> None:
     print(f"\n{_CYAN}── REPL debug config ──{_RESET}")
     for k, v in rows:
         print(f"  {_DIM}{k:>10}{_RESET}  {v}")
-    print("\nESC interrupts a turn · /clear resets context · Ctrl-D or /exit quits.\n")
+    print(
+        "\nESC interrupts a turn · /img PATH [caption] or /paste [caption] sends "
+        "an image · /clear resets context · Ctrl-D or /exit quits.\n"
+    )
 
 
-async def _run_turn(agent: AgentCore, spinner: Spinner, text: str):
+async def _run_turn(agent: AgentCore, spinner: Spinner, text: str, attachments=None):
     """Run one turn, cancellable by pressing ESC. Returns None if interrupted."""
     proc = asyncio.create_task(
-        agent.process(message=text, channel="repl", user_id=USER_ID, chat_id=USER_ID)
+        agent.process(
+            message=text,
+            channel="repl",
+            user_id=USER_ID,
+            chat_id=USER_ID,
+            attachments=attachments,
+        )
     )
     fd = sys.stdin.fileno()
     loop = asyncio.get_running_loop()
@@ -286,7 +322,26 @@ async def main() -> None:
             await agent.history.clear("repl", USER_ID, USER_ID)
             print("[context cleared]\n")
             continue
-        response = await _run_turn(agent, spinner, text)
+        attachments = None
+        if text.startswith("/img "):
+            path, _, caption = text[len("/img ") :].strip().partition(" ")
+            path = os.path.expanduser(path)
+            try:
+                data = open(path, "rb").read()
+            except OSError as e:
+                print(f"[can't read image: {e}]\n")
+                continue
+            mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
+            attachments = [Attachment(data=data, mime_type=mime, filename=os.path.basename(path))]
+            text = caption.strip() or "What's in this image?"
+        elif text == "/paste" or text.startswith("/paste "):
+            data, mime = _clipboard_image()
+            if not data:
+                print("[no image in clipboard]\n")
+                continue
+            attachments = [Attachment(data=data, mime_type=mime, filename="clipboard")]
+            text = text[len("/paste") :].strip() or "What's in this image?"
+        response = await _run_turn(agent, spinner, text, attachments)
         if response is None:
             print("\n[interrupted]\n")
             continue

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -105,6 +105,11 @@ search:
   api_key: "${TAVILY_API_KEY}"
   max_results: 5
 
+vision:
+  enabled: false
+  provider: "anthropic"
+  model: "claude-haiku-4-5"
+
 history:
   db_path: "data/agent.db"
   max_turns: 10
@@ -149,6 +154,10 @@ Admin UI settings. The API key is required for authentication.
 #### `search`
 
 Web search configuration via Tavily.
+
+#### `vision`
+
+Vision fallback. When the active model can't read images, image attachments are routed to `model` (on `provider`, reusing that provider's `agent` API key) for a text description / OCR, injected in place of the image so non-multimodal models can still "see". Off by default; engages only when the active model lacks native vision. The admin LLM tab and the setup wizard surface a one-tap enable prompt when you select a model that can't read images.
 
 #### `history`
 

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -213,6 +213,15 @@ class TestPartialRoutes:
         assert "text/html" in resp.headers["content-type"]
         assert "run_command" in resp.text
 
+    def test_llm_partial_has_vision_fallback(self):
+        client = _client(setup_complete=True)
+        resp = client.get("/partials/llm", headers=AUTH)
+        assert resp.status_code == 200
+        assert "Vision Fallback" in resp.text
+        # One-tap enable prompt + capability indicator are wired in.
+        assert "enableVisionFallback()" in resp.text
+        assert "modelSupportsVision" in resp.text
+
     def test_logs_partial(self):
         client = _client(setup_complete=True)
         resp = client.get("/partials/logs", headers=AUTH)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -133,16 +133,18 @@ def test_turn_preamble_carries_datetime(agent) -> None:
     assert "execution_plan" not in preamble
 
 
-def test_build_user_message_prepends_preamble(agent) -> None:
+@pytest.mark.asyncio
+async def test_build_user_message_prepends_preamble(agent) -> None:
     preamble = agent._turn_preamble(None)
-    msg = agent._build_user_message("hello", None, preamble)
+    msg = await agent._build_user_message("hello", None, preamble)
     assert msg["role"] == "user"
     assert msg["content"].startswith(preamble)
     assert msg["content"].endswith("hello")
 
 
-def test_build_user_message_no_preamble_is_plain(agent) -> None:
-    msg = agent._build_user_message("hello", None, "")
+@pytest.mark.asyncio
+async def test_build_user_message_no_preamble_is_plain(agent) -> None:
+    msg = await agent._build_user_message("hello", None, "")
     assert msg["content"] == "hello"
 
 

--- a/tests/test_vision_fallback.py
+++ b/tests/test_vision_fallback.py
@@ -1,0 +1,106 @@
+"""Vision fallback: caption images on non-vision models, cache, pass through natives."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.config import Config
+from core.llm import LLMResponse, model_supports_vision
+from core.models import Attachment
+
+
+def test_model_supports_vision_heuristic() -> None:
+    assert not model_supports_vision("deepseek", "deepseek-v4-flash")
+    assert not model_supports_vision("deepseek", "deepseek-chat")
+    assert not model_supports_vision("openai", "gpt-3.5-turbo")
+    assert not model_supports_vision("anthropic", "")  # unknown / empty
+    assert model_supports_vision("anthropic", "claude-haiku-4-5")
+    assert model_supports_vision("openai", "gpt-4o")
+    assert model_supports_vision("grok", "grok-4-latest")
+    assert model_supports_vision("google", "gemini-flash-latest")
+
+
+class _FakeLLM:
+    """Stand-in vision model: counts calls, returns a fixed caption."""
+
+    def __init__(self, provider: str = "anthropic") -> None:
+        self.provider = provider
+        self.calls = 0
+
+    async def generate(self, *, model, system, messages, tools) -> LLMResponse:
+        self.calls += 1
+        return LLMResponse(text="a red bicycle leaning on a wall", tool_calls=[])
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from core.agent import AgentCore
+
+    cfg = Config()
+    cfg.agent.llm_provider = "deepseek"
+    cfg.agent.model = "deepseek-v4-flash"  # no native vision
+    cfg.vision.enabled = True
+    return AgentCore(cfg)
+
+
+def _img() -> Attachment:
+    return Attachment(data=b"\x89PNG-fake-bytes", mime_type="image/png", filename="x.png")
+
+
+@pytest.mark.asyncio
+async def test_non_vision_model_gets_caption_injected(agent, monkeypatch) -> None:
+    fake = _FakeLLM()
+    monkeypatch.setattr(agent, "_vision_llm", lambda provider: fake)
+
+    msg = await agent._build_user_message("what is this?", [_img()], "")
+
+    # Plain text content (no image blocks), with the caption injected.
+    assert isinstance(msg["content"], str)
+    assert "[Image: a red bicycle leaning on a wall]" in msg["content"]
+    assert "what is this?" in msg["content"]
+    assert fake.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_repeated_identical_image_hits_cache(agent, monkeypatch) -> None:
+    fake = _FakeLLM()
+    monkeypatch.setattr(agent, "_vision_llm", lambda provider: fake)
+
+    await agent._build_user_message("first", [_img()], "")
+    await agent._build_user_message("second", [_img()], "")
+
+    # Same image bytes → captioned once, served from cache the second time.
+    assert fake.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_native_vision_model_passes_images_through(agent, monkeypatch) -> None:
+    # Switch active model to a vision-capable one → no captioning call at all.
+    agent.config.agent.llm_provider = "anthropic"
+    agent.config.agent.model = "claude-4-6-sonnet"
+    agent.llm.provider = "anthropic"
+    fake = _FakeLLM()
+    monkeypatch.setattr(agent, "_vision_llm", lambda provider: fake)
+
+    msg = await agent._build_user_message("what is this?", [_img()], "")
+
+    blocks = msg["content"]
+    assert isinstance(blocks, list)
+    assert any(b.get("type") == "image" for b in blocks)
+    assert fake.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_caption_failure_falls_back_to_raw_image(agent, monkeypatch) -> None:
+    class _BoomLLM(_FakeLLM):
+        async def generate(self, *, model, system, messages, tools):
+            raise RuntimeError("vision model down")
+
+    monkeypatch.setattr(agent, "_vision_llm", lambda provider: _BoomLLM())
+
+    msg = await agent._build_user_message("what is this?", [_img()], "")
+
+    # Captioning blew up → raw image blocks are passed through unchanged.
+    assert isinstance(msg["content"], list)
+    assert any(b.get("type") == "image_url" for b in msg["content"])  # deepseek→openai block


### PR DESCRIPTION
Closes #18

## What

When the active model has no native image support, image attachments are now routed to a small vision-capable model to produce a text description / OCR, and that text is injected in place of the image — so non-multimodal models can still "see".

## How

- **`core/config.py`** — new `vision` config block (`enabled` / `provider` / `model`), mirroring `search` / `voice`. Off by default.
- **`core/llm.py`** — `model_supports_vision(provider, model)`, a provider+model heuristic that is the single source of truth for "can this model read images natively".
- **`core/agent.py`** — hooks the existing seam in `_build_user_message`: when the active model lacks vision and the fallback is enabled, each image is captioned with a **task-aware** prompt (the user's text steers OCR vs. description) and `[Image: <description>]` is injected in place of the image block. Reuses the existing secondary-model pattern (`_vision_llm` → `_background_llm`, like `_memory_llm`). Captions are cached by image hash (LRU-bounded). On any captioning failure it falls through to the raw image blocks unchanged.

## UX & onboarding

- **Mostly invisible** — it just works when needed. With a native-vision model, images pass through unchanged with **no extra call**.
- **Admin LLM tab** — a `Vision Fallback` card (enable / provider / model, reusing the model picker), plus an indicator on the model picker showing whether the active model sees images natively, and a **one-tap "Enable vision fallback"** prompt when it can't. Touch-friendly, reuses the existing settings components.
- **Setup wizard** — the same prompt inline at model selection (recommended, on by default for non-vision models), carrying the `vision.*` config forward — not a separate chore.
- **On the go (Telegram)** — photos already flow in as attachments, so sending a photo from a phone on a non-vision model now yields a sensible answer.

## Acceptance criteria

- [x] Non-vision model + fallback enabled → image yields a useful text description injected into context.
- [x] Selecting a non-vision model surfaces a one-tap prompt to enable the fallback; a photo from mobile then yields a useful response.
- [x] Native-vision model → images pass through unchanged (no extra call).
- [x] Repeated identical images hit the cache.

## Tests

`tests/test_vision_fallback.py` covers the heuristic, caption injection, cache hit, native pass-through, and graceful fallback on captioning failure. Admin UI test asserts the Vision Fallback section + one-tap prompt render. Full suite green (335 passed).
