### PR TITLE
feat: optional headless browser automation (#16)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,16 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev --no-install-project
 
-# Optionally bundle Chromium for the browser tool (Tools tab: browser, issue #16).
-# OFF by default to keep the image lean — the tool is disabled by default and a
-# lean deployment can point it at a sidecar Chromium via tools.browser.cdp_url.
-# Bundle it with:  docker build --build-arg INSTALL_BROWSER=true .
-ARG INSTALL_BROWSER=false
+# Bundle full Chromium for the browser tool (Tools tab: browser, issue #16).
+# ON by default: a self-contained image avoids the runtime `playwright install`
+# fetch, which flakes on remote hosts with spotty networking. Adds ~500-700MB.
+# We install the FULL chromium (not chromium-headless-shell): its "new headless"
+# mode renders more faithfully and is far less bot-detectable than the old
+# headless shell — important since the browser/vision tooling targets exactly the
+# janky, JS-heavy, sometimes bot-protected sites where the shell gets served
+# degraded content. Opt out for a lean/sidecar deploy (point tools.browser.cdp_url
+# at a remote Chromium):  docker build --build-arg INSTALL_BROWSER=false .
+ARG INSTALL_BROWSER=true
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN if [ "$INSTALL_BROWSER" = "true" ]; then \
       uv run playwright install --with-deps chromium && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,17 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev --no-install-project
 
+# Optionally bundle Chromium for the browser tool (Tools tab: browser, issue #16).
+# OFF by default to keep the image lean — the tool is disabled by default and a
+# lean deployment can point it at a sidecar Chromium via tools.browser.cdp_url.
+# Bundle it with:  docker build --build-arg INSTALL_BROWSER=true .
+ARG INSTALL_BROWSER=false
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN if [ "$INSTALL_BROWSER" = "true" ]; then \
+      uv run playwright install --with-deps chromium && \
+      chmod -R a+rx /ms-playwright; \
+    fi
+
 # Create non-root user
 RUN groupadd --gid 10001 mpa && \
     useradd --uid 10001 --gid 10001 --create-home --shell /bin/bash mpa

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help:
 	@echo "  Development:"
 	@echo "    make repl         Chat with the agent from the terminal (no Telegram)"
 	@echo "                      (make repl PERSONA=fitness-coach to test a persona)"
+	@echo "                      (make repl YOLO=1 to auto-approve all permissions)"
 	@echo "    make dev          Show instructions for running dev services"
 	@echo "    make dev-agent    Run agent with auto-reload"
 	@echo "    make dev-css      Run Tailwind CSS watcher"
@@ -91,7 +92,7 @@ run:
 
 # Local REPL — chat with the agent from the terminal (no Telegram)
 repl:
-	$(PYTHON) -m core.repl $(if $(PERSONA),--persona $(PERSONA),)
+	$(PYTHON) -m core.repl $(if $(PERSONA),--persona $(PERSONA),) $(if $(YOLO),--yolo,)
 
 # Run in dev mode: instructions for running services in separate shells
 dev:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Scheduled tasks** — Cron-based jobs for morning briefings, email checks, contact sync, and custom tasks
 - **Voice** — Speech-to-text (faster-whisper) and text-to-speech (edge-tts)
 - **Web search** — Tavily integration for real-time information
+- **Browser automation** — Optional headless browser (Playwright) to read JS-heavy pages and act on sites, with persistent logged-in profiles and per-domain approval (off by default)
 - **Permissions** — Glob-pattern rules (ALWAYS/ASK/NEVER) with interactive Telegram approval for write actions
 - **Admin UI** — Web dashboard for configuration, skills editing, memory inspection, job management, and agent lifecycle control
 - **Skills** — Teach the agent new capabilities by writing markdown files instead of code
@@ -153,6 +154,7 @@ Example skills included:
 - `voice.md` — Voice response conventions
 - `weather.md` — Weather lookups
 - `jq.md` — JSON processing
+- `browser.md` — Headless browser: read JS-heavy pages and act on sites
 
 Create new skills by adding `.md` files to `skills/`, through the admin UI's skill editor, or via the skills CLI:
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -166,6 +166,10 @@ async def _wizard_step_context(step: str, config_store: ConfigStore) -> dict[str
             val = await config_store.get(key)
             if val:
                 ctx[var] = val
+    elif step == "browser":
+        enabled = await config_store.get("tools.browser.enabled")
+        if enabled is not None:
+            ctx["browser_enabled"] = enabled
     elif step == "calendar":
         raw = await config_store.get("calendar.providers")
         if raw:

--- a/api/admin.py
+++ b/api/admin.py
@@ -13,7 +13,9 @@ import collections
 import hashlib
 import json
 import logging
+import os
 import secrets
+import sys
 import urllib.parse
 from base64 import urlsafe_b64encode
 from contextlib import asynccontextmanager
@@ -940,17 +942,51 @@ def create_admin_app(
             prompt_capture_enabled=prompt_capture_enabled,
         )
 
+    def _browser_rules() -> list[dict]:
+        """Per-domain browser `act` rules (excludes the generic default rule)."""
+        agent = agent_state.agent
+        if not agent:
+            return []
+        marker = "browser.py act*"
+        out: list[dict] = []
+        for pattern, level in agent.permissions.rules.items():
+            if marker not in pattern:
+                continue
+            domain = pattern.split(marker, 1)[1].rstrip("*")
+            if not domain:
+                continue  # the generic "ask for all acts" default, not a per-domain rule
+            out.append({"domain": domain, "pattern": pattern, "level": level})
+        return out
+
     @app.get("/partials/tools", dependencies=[Depends(auth)])
     async def partial_tools() -> HTMLResponse:
-        """Tools tab partial — manage optional external CLI tools (e.g. gh)."""
+        """Tools tab partial — manage optional external CLI tools (gh, browser)."""
         gh_enabled = await config_store.get("tools.gh.enabled")
         gh_enabled = gh_enabled if gh_enabled is not None else "false"
         gh_token = await config_store.get("tools.gh.token") or ""
+
+        browser_enabled = await config_store.get("tools.browser.enabled")
+        browser_enabled = browser_enabled if browser_enabled is not None else "false"
+        browser_headless = await config_store.get("tools.browser.headless")
+        browser_headless = browser_headless if browser_headless is not None else "true"
+        browser_cdp = await config_store.get("tools.browser.cdp_url") or ""
+        try:
+            from tools.browser import cmd_profiles
+
+            browser_profiles = cmd_profiles(None).get("profiles", [])
+        except Exception:
+            browser_profiles = []
+
         return _render_partial(
             "partials/tools.html",
             tools=tool_registry(),
             gh_enabled=gh_enabled,
             gh_token=gh_token,
+            browser_enabled=browser_enabled,
+            browser_headless=browser_headless,
+            browser_cdp=browser_cdp,
+            browser_profiles=browser_profiles,
+            browser_rules=_browser_rules(),
         )
 
     @app.post("/tools/gh/test", dependencies=[Depends(auth)])
@@ -982,6 +1018,68 @@ def create_admin_app(
                 "error": "Token rejected by GitHub (invalid or insufficient scope).",
             }
         return {"ok": False, "error": f"GitHub returned HTTP {resp.status_code}."}
+
+    @app.post("/tools/browser/test", dependencies=[Depends(auth)])
+    async def test_browser_tool(request: Request) -> dict:
+        """Load a page via the browser CLI to confirm Chromium works (and a profile)."""
+        body = await request.json()
+        url = str(body.get("url", "")).strip() or "https://example.com"
+        profile = str(body.get("profile", "")).strip() or "default"
+        root = Path(__file__).resolve().parent.parent
+        # Subprocess, not in-process: the sync Playwright API can't run in this event loop.
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                "tools/browser.py",
+                "read",
+                "--url",
+                url,
+                "--profile",
+                profile,
+                cwd=str(root),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env={**os.environ, "BROWSER_HEADLESS": "1"},
+            )
+            out, err = await asyncio.wait_for(proc.communicate(), timeout=60)
+        except TimeoutError:
+            return {"ok": False, "error": "Browser test timed out (60s)."}
+        except Exception as exc:  # noqa: BLE001 — surface any error to the UI
+            return {"ok": False, "error": str(exc)}
+        try:
+            data = json.loads(out.decode() or "{}")
+        except json.JSONDecodeError:
+            return {"ok": False, "error": (err.decode() or "no output")[:300]}
+        if data.get("error"):
+            return {"ok": False, "error": data["error"]}
+        return {"ok": True, "title": data.get("title", ""), "url": data.get("url", "")}
+
+    @app.post("/tools/browser/rules", dependencies=[Depends(auth)])
+    async def add_browser_rule(request: Request) -> dict:
+        """Pre-approve/ask/block browser actions on a domain (a permission rule)."""
+        agent = agent_state.agent
+        if not agent:
+            raise HTTPException(503, "Agent not running")
+        body = await request.json()
+        domain = str(body.get("domain", "")).strip()
+        level = str(body.get("level", "ALWAYS")).strip().upper()
+        if not domain:
+            return {"ok": False, "error": "Domain is required."}
+        if level not in ("ALWAYS", "ASK", "NEVER"):
+            level = "ASK"
+        agent.permissions.add_rule(f"run_command:*browser.py act*{domain}*", level)
+        return {"ok": True, "rules": _browser_rules()}
+
+    @app.post("/tools/browser/rules/delete", dependencies=[Depends(auth)])
+    async def delete_browser_rule(request: Request) -> dict:
+        agent = agent_state.agent
+        if not agent:
+            raise HTTPException(503, "Agent not running")
+        body = await request.json()
+        pattern = str(body.get("pattern", ""))
+        if pattern:
+            agent.permissions.remove_rule(pattern)
+        return {"ok": True, "rules": _browser_rules()}
 
     @app.get("/partials/search", dependencies=[Depends(auth)])
     async def partial_search() -> HTMLResponse:

--- a/api/admin.py
+++ b/api/admin.py
@@ -974,6 +974,7 @@ def create_admin_app(
         browser_headless = await config_store.get("tools.browser.headless")
         browser_headless = browser_headless if browser_headless is not None else "true"
         browser_cdp = await config_store.get("tools.browser.cdp_url") or ""
+        browser_ua = await config_store.get("tools.browser.user_agent") or ""
         try:
             from tools.browser import cmd_profiles
 
@@ -989,6 +990,7 @@ def create_admin_app(
             browser_enabled=browser_enabled,
             browser_headless=browser_headless,
             browser_cdp=browser_cdp,
+            browser_ua=browser_ua,
             browser_profiles=browser_profiles,
             browser_rules=_browser_rules(),
         )

--- a/api/templates/partials/tools.html
+++ b/api/templates/partials/tools.html
@@ -99,6 +99,155 @@
       <div :class="testResult.startsWith('Authenticated') ? 'alert-success' : 'alert-error'" class="mt-2" x-text="testResult"></div>
     </template>
   </div>
+
+  {# Browser automation #}
+  <div class="card" x-data="browserTab(
+    {{ browser_enabled|default('false', true)|tojson|forceescape }},
+    {{ browser_headless|default('true', true)|tojson|forceescape }},
+    {{ browser_cdp|default('', true)|tojson|forceescape }},
+    {{ browser_profiles|default([], true)|tojson|forceescape }},
+    {{ browser_rules|default([], true)|tojson|forceescape }}
+  )">
+    <div class="flex items-center justify-between gap-3 mb-1">
+      <h3 class="text-sm text-accent">Browser automation</h3>
+      <div class="flex items-center gap-2">
+        <label class="label mb-0">Enabled</label>
+        <input type="checkbox" x-model="enabled">
+      </div>
+    </div>
+    <p class="text-muted text-xs mb-3">
+      Let the agent read JS-heavy pages and act on sites via a headless browser
+      (Playwright/Chromium). Reading runs without asking; actions (click/fill/submit)
+      ask for approval each time — on Telegram the approval shows a screenshot so you
+      can follow along and approve from your phone.
+    </p>
+    <div class="alert-info text-xs mb-4">
+      <strong>What works:</strong> most sites, including logged-in sessions you set up
+      once. <strong>May be blocked:</strong> sites behind strong bot-management or
+      interactive challenges. Prefer an official API/CLI when one exists.
+    </div>
+
+    {# Settings #}
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <label class="flex items-center gap-2">
+        <input type="checkbox" x-model="headless">
+        <span class="label mb-0">Headless (no visible window)</span>
+      </label>
+      <div>
+        <label class="label">Sidecar CDP URL <span class="text-muted">(optional)</span></label>
+        <input type="text" class="input-sm" style="max-width:100%" x-model="cdp"
+               placeholder="ws://browser:9222 — empty = run locally">
+        <p class="text-muted text-xs mt-1">
+          Empty launches Chromium locally (works in the REPL). Set to connect to a
+          sidecar Chromium and keep the main image lean.
+        </p>
+      </div>
+    </div>
+    <div class="flex items-center gap-2 mt-4">
+      <button class="btn-primary btn-sm" @click="save()">Save</button>
+    </div>
+    <template x-if="result">
+      <div :class="resultOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="result"></div>
+    </template>
+
+    {# Test #}
+    <div class="mt-5 pt-4 border-t border-[var(--color-border)]">
+      <h4 class="text-xs text-muted mb-2">Test</h4>
+      <div class="flex flex-wrap items-end gap-2">
+        <div class="grow" style="min-width:200px">
+          <label class="label">URL</label>
+          <input type="text" class="input-sm" style="max-width:100%" x-model="testUrl"
+                 placeholder="https://example.com">
+        </div>
+        <div style="width:140px">
+          <label class="label">Profile</label>
+          <input type="text" class="input-sm" style="max-width:100%" x-model="testProfile"
+                 placeholder="default">
+        </div>
+        <button class="btn btn-sm" :disabled="testing" @click="test()">
+          <span x-show="!testing">Load page</span>
+          <span x-show="testing">Loading…</span>
+        </button>
+      </div>
+      <template x-if="testResult">
+        <div :class="testOk ? 'alert-success' : 'alert-error'" class="mt-2 text-xs" x-text="testResult"></div>
+      </template>
+    </div>
+
+    {# Saved profiles #}
+    <div class="mt-5 pt-4 border-t border-[var(--color-border)]">
+      <h4 class="text-xs text-muted mb-2">Saved profiles</h4>
+      <p class="text-muted text-xs mb-2">
+        Each profile keeps its own cookies/session. To log in the first time, ask the
+        agent to open the site — it screenshots the login, you provide credentials and
+        approve, and the session is saved here for reuse.
+      </p>
+      <div class="overflow-x-auto">
+        <table class="table">
+          <thead><tr><th>Profile</th><th>Status</th><th>Updated</th></tr></thead>
+          <tbody>
+            <template x-for="p in profiles" :key="p.name">
+              <tr>
+                <td class="text-xs" x-text="p.name"></td>
+                <td class="text-xs">
+                  <span x-show="p.authenticated" class="badge-ok">Logged in</span>
+                  <span x-show="!p.authenticated" class="badge-off">No session</span>
+                </td>
+                <td class="text-xs text-muted" x-text="new Date(p.updated*1000).toLocaleString()"></td>
+              </tr>
+            </template>
+            <template x-if="profiles.length === 0">
+              <tr><td colspan="3" class="text-xs text-muted">No profiles yet.</td></tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    {# Per-domain action rules #}
+    <div class="mt-5 pt-4 border-t border-[var(--color-border)]">
+      <h4 class="text-xs text-muted mb-2">Per-domain action rules</h4>
+      <p class="text-muted text-xs mb-2">
+        Actions ask for approval by default. Pre-approve (Allow) or Block a domain here.
+      </p>
+      <div class="overflow-x-auto">
+        <table class="table">
+          <thead><tr><th>Domain</th><th>Action</th><th class="w-16"></th></tr></thead>
+          <tbody>
+            <template x-for="r in rules" :key="r.pattern">
+              <tr>
+                <td class="text-xs" x-text="r.domain"></td>
+                <td class="text-xs" x-text="r.level"></td>
+                <td><button class="btn-danger btn-sm" @click="delRule(r.pattern)">Remove</button></td>
+              </tr>
+            </template>
+            <template x-if="rules.length === 0">
+              <tr><td colspan="3" class="text-xs text-muted">No per-domain rules.</td></tr>
+            </template>
+          </tbody>
+        </table>
+      </div>
+      <div class="flex flex-wrap items-end gap-2 mt-2">
+        <div class="grow" style="min-width:180px">
+          <label class="label">Domain</label>
+          <input type="text" class="input-sm" style="max-width:100%" x-model="newDomain"
+                 placeholder="github.com">
+        </div>
+        <div style="width:140px">
+          <label class="label">Action</label>
+          <select class="select input-sm" style="max-width:100%" x-model="newLevel">
+            <option value="ALWAYS">Allow</option>
+            <option value="ASK">Ask</option>
+            <option value="NEVER">Block</option>
+          </select>
+        </div>
+        <button class="btn btn-sm" @click="addRule()">Add</button>
+      </div>
+      <template x-if="ruleResult">
+        <div class="alert-error mt-2 text-xs" x-text="ruleResult"></div>
+      </template>
+    </div>
+  </div>
 </div>
 
 <script>
@@ -110,6 +259,69 @@
       resultOk: false,
       testing: false,
       testResult: ''
+    };
+  }
+
+  function browserTab(enabled, headless, cdp, profiles, rules) {
+    const truthy = (v) => v === true || v === 'true';
+    return {
+      enabled: truthy(enabled),
+      headless: truthy(headless),
+      cdp: cdp || '',
+      profiles: profiles || [],
+      rules: rules || [],
+      result: '', resultOk: false,
+      testUrl: 'https://example.com', testProfile: 'default',
+      testing: false, testResult: '', testOk: false,
+      newDomain: '', newLevel: 'ALWAYS', ruleResult: '',
+      _hdr() {
+        return {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+        };
+      },
+      save() {
+        const vals = {
+          'tools.browser.enabled': String(this.enabled),
+          'tools.browser.headless': String(this.headless),
+          'tools.browser.cdp_url': this.cdp
+        };
+        fetch('/config', { method: 'PATCH', headers: this._hdr(), body: JSON.stringify({values: vals}) })
+          .then(r => { this.resultOk = r.ok; return r.json(); })
+          .then(d => {
+            this.result = this.resultOk ? 'Browser settings saved' : (d.detail || 'Error');
+            if (this.resultOk && window.showToast) { window.showToast('Browser settings saved'); }
+          })
+          .catch(e => { this.resultOk = false; this.result = e.message; });
+      },
+      test() {
+        this.testing = true; this.testResult = '';
+        fetch('/tools/browser/test', { method: 'POST', headers: this._hdr(),
+          body: JSON.stringify({ url: this.testUrl, profile: this.testProfile }) })
+          .then(r => r.json())
+          .then(d => {
+            this.testOk = !!d.ok;
+            this.testResult = d.ok ? ('Loaded: ' + (d.title || d.url || 'ok')) : ('Failed: ' + (d.error || 'unknown'));
+          })
+          .catch(e => { this.testOk = false; this.testResult = 'Error: ' + e.message; })
+          .finally(() => { this.testing = false; });
+      },
+      addRule() {
+        if (!this.newDomain) { this.ruleResult = 'Domain is required'; return; }
+        this.ruleResult = '';
+        fetch('/tools/browser/rules', { method: 'POST', headers: this._hdr(),
+          body: JSON.stringify({ domain: this.newDomain, level: this.newLevel }) })
+          .then(r => r.json())
+          .then(d => { if (d.ok) { this.rules = d.rules; this.newDomain = ''; } else { this.ruleResult = d.error || 'Error'; } })
+          .catch(e => { this.ruleResult = e.message; });
+      },
+      delRule(pattern) {
+        fetch('/tools/browser/rules/delete', { method: 'POST', headers: this._hdr(),
+          body: JSON.stringify({ pattern }) })
+          .then(r => r.json())
+          .then(d => { if (d.ok) { this.rules = d.rules; } })
+          .catch(() => {});
+      }
     };
   }
 </script>

--- a/api/templates/partials/tools.html
+++ b/api/templates/partials/tools.html
@@ -151,7 +151,7 @@
     </template>
 
     {# Test #}
-    <div class="mt-5 pt-4 border-t border-[var(--color-border)]">
+    <div class="mt-5 pt-4 border-t border-border">
       <h4 class="text-xs text-muted mb-2">Test</h4>
       <div class="flex flex-wrap items-end gap-2">
         <div class="grow" style="min-width:200px">
@@ -175,7 +175,7 @@
     </div>
 
     {# Saved profiles #}
-    <div class="mt-5 pt-4 border-t border-[var(--color-border)]">
+    <div class="mt-5 pt-4 border-t border-border">
       <h4 class="text-xs text-muted mb-2">Saved profiles</h4>
       <p class="text-muted text-xs mb-2">
         Each profile keeps its own cookies/session. To log in the first time, ask the
@@ -205,7 +205,7 @@
     </div>
 
     {# Per-domain action rules #}
-    <div class="mt-5 pt-4 border-t border-[var(--color-border)]">
+    <div class="mt-5 pt-4 border-t border-border">
       <h4 class="text-xs text-muted mb-2">Per-domain action rules</h4>
       <p class="text-muted text-xs mb-2">
         Actions ask for approval by default. Pre-approve (Allow) or Block a domain here.

--- a/api/templates/partials/tools.html
+++ b/api/templates/partials/tools.html
@@ -105,6 +105,7 @@
     {{ browser_enabled|default('false', true)|tojson|forceescape }},
     {{ browser_headless|default('true', true)|tojson|forceescape }},
     {{ browser_cdp|default('', true)|tojson|forceescape }},
+    {{ browser_ua|default('', true)|tojson|forceescape }},
     {{ browser_profiles|default([], true)|tojson|forceescape }},
     {{ browser_rules|default([], true)|tojson|forceescape }}
   )">
@@ -140,6 +141,15 @@
         <p class="text-muted text-xs mt-1">
           Empty launches Chromium locally (works in the REPL). Set to connect to a
           sidecar Chromium and keep the main image lean.
+        </p>
+      </div>
+      <div class="sm:col-span-2">
+        <label class="label">User-Agent <span class="text-muted">(optional)</span></label>
+        <input type="text" class="input-sm" style="max-width:100%" x-model="userAgent"
+               placeholder="empty = built-in desktop Chrome UA">
+        <p class="text-muted text-xs mt-1">
+          Override the browser's User-Agent string. Leave empty for the default
+          desktop Chrome UA. Ignored when reusing an existing sidecar session.
         </p>
       </div>
     </div>
@@ -262,12 +272,13 @@
     };
   }
 
-  function browserTab(enabled, headless, cdp, profiles, rules) {
+  function browserTab(enabled, headless, cdp, userAgent, profiles, rules) {
     const truthy = (v) => v === true || v === 'true';
     return {
       enabled: truthy(enabled),
       headless: truthy(headless),
       cdp: cdp || '',
+      userAgent: userAgent || '',
       profiles: profiles || [],
       rules: rules || [],
       result: '', resultOk: false,
@@ -284,7 +295,8 @@
         const vals = {
           'tools.browser.enabled': String(this.enabled),
           'tools.browser.headless': String(this.headless),
-          'tools.browser.cdp_url': this.cdp
+          'tools.browser.cdp_url': this.cdp,
+          'tools.browser.user_agent': this.userAgent
         };
         fetch('/config', { method: 'PATCH', headers: this._hdr(), body: JSON.stringify({values: vals}) })
           .then(r => { this.resultOk = r.ok; return r.json(); })

--- a/api/templates/wizard/admin.html
+++ b/api/templates/wizard/admin.html
@@ -31,7 +31,7 @@
   <div class="flex justify-between mt-4">
     <button class="btn"
             hx-post="/setup/step" hx-target="#wizard-step" hx-swap="innerHTML"
-            hx-vals='{"step": "search", "values": {}}'>
+            hx-vals='{"step": "browser", "values": {}}'>
       Back
     </button>
     <button class="btn-primary"

--- a/api/templates/wizard/browser.html
+++ b/api/templates/wizard/browser.html
@@ -1,0 +1,54 @@
+<div class="card" x-data="{ enabled: {{ 'true' if step_ctx.browser_enabled == 'true' else 'false' }} }">
+  <h2 class="text-base mb-3">Browser automation <span class="text-muted font-normal text-xs">(optional)</span></h2>
+
+  <p class="hint mb-3">
+    Let the agent read JS-heavy pages and act on sites via a headless browser
+    (Chromium). Off by default — you can enable it later and add per-domain rules
+    in Settings → Tools.
+  </p>
+
+  <label class="flex items-center gap-2">
+    <input type="checkbox" x-model="enabled">
+    <span class="label mb-0">Enable browser automation</span>
+  </label>
+
+  <div class="alert-info text-xs mt-3">
+    <strong>What works:</strong> most sites, including logged-in sessions you set up
+    once. <strong>May be blocked:</strong> sites behind strong bot-management or
+    interactive challenges.
+  </div>
+
+  <p class="hint mt-3">
+    First-time login is guided and mobile-followable: ask the agent to open a site,
+    it sends a screenshot, you provide credentials and approve from your phone, and
+    the session is saved for reuse. Reading runs without asking; actions ask for
+    approval each time.
+  </p>
+
+  <div class="flex justify-between mt-4">
+    <button class="btn"
+            hx-post="/setup/step" hx-target="#wizard-step" hx-swap="innerHTML"
+            hx-vals='{"step": "search", "values": {}}'>
+      Back
+    </button>
+    <div class="flex gap-2">
+      <button class="btn"
+              hx-post="/setup/step" hx-target="#wizard-step" hx-swap="innerHTML"
+              hx-vals='{"step": "admin", "values": {}}'>
+        Skip
+      </button>
+      <button class="btn-primary"
+              @click="
+                htmx.ajax('POST', '/setup/step', {
+                  target: '#wizard-step', swap: 'innerHTML',
+                  values: {
+                    step: 'admin',
+                    'values[tools.browser.enabled]': enabled ? 'true' : 'false'
+                  }
+                })
+              ">
+        Next
+      </button>
+    </div>
+  </div>
+</div>

--- a/api/templates/wizard/search.html
+++ b/api/templates/wizard/search.html
@@ -37,7 +37,7 @@
     <div class="flex gap-2">
       <button class="btn"
               hx-post="/setup/step" hx-target="#wizard-step" hx-swap="innerHTML"
-              hx-vals='{"step": "admin", "values": {}}'>
+              hx-vals='{"step": "browser", "values": {}}'>
         Skip
       </button>
       <button class="btn-primary"
@@ -46,7 +46,7 @@
                 htmx.ajax('POST', '/setup/step', {
                   target: '#wizard-step', swap: 'innerHTML',
                   values: {
-                    step: 'admin',
+                    step: 'browser',
                     'values[search.enabled]': key ? 'true' : 'false',
                     'values[search.api_key]': key,
                     'values[search.provider]': 'tavily'

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -216,8 +216,14 @@ class TelegramChannel:
                 return
             raise
 
-    async def send_approval_request(self, user_id: str, request_id: str, description: str) -> None:
-        """Send a permission approval prompt with Approve/Deny inline buttons."""
+    async def send_approval_request(
+        self, user_id: str, request_id: str, description: str, image_path: str | None = None
+    ) -> None:
+        """Send a permission approval prompt with Approve/Deny inline buttons.
+
+        When ``image_path`` is given (e.g. a browser screenshot), send it as a
+        photo with the buttons so the user can watch and approve from their phone.
+        """
         target_id = int(user_id)
         chat_id = self._last_chat_for_user.get(target_id, target_id)
         keyboard = InlineKeyboardMarkup(
@@ -231,11 +237,18 @@ class TelegramChannel:
                 ]
             ]
         )
-        await self.app.bot.send_message(
-            chat_id,
-            f"Permission request:\n\n{description}",
-            reply_markup=keyboard,
-        )
+        text = f"Permission request:\n\n{description}"
+        if image_path:
+            try:
+                with open(image_path, "rb") as photo:
+                    # Telegram caption hard limit is 1024 chars.
+                    await self.app.bot.send_photo(
+                        chat_id, photo, caption=text[:1024], reply_markup=keyboard
+                    )
+                return
+            except Exception:
+                log.exception("Failed to send approval screenshot; falling back to text")
+        await self.app.bot.send_message(chat_id, text, reply_markup=keyboard)
 
     # -- Helpers -------------------------------------------------------------
 

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import time
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from telegram import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Update
@@ -278,6 +280,58 @@ class TelegramChannel:
             except asyncio.CancelledError:
                 pass
 
+    @asynccontextmanager
+    async def _progress(self, chat_id: int):
+        """Mirror an in-flight `browser.py explore` run into ONE edited message.
+
+        explore writes a per-step line to data/browser/last/explore.status; we
+        poll it and edit a single Telegram message in place (the chat equivalent
+        of the REPL's self-updating spinner line). No-op when nothing is running.
+        """
+        status = Path("/app/data" if Path("/app/data").exists() else "data")
+        status = status / "browser" / "last" / "explore.status"
+        message_id: int | None = None
+        last = None
+
+        async def _poll():
+            nonlocal message_id, last
+            while True:
+                await asyncio.sleep(3)
+                try:
+                    if time.time() - status.stat().st_mtime > 10:
+                        continue  # stale → no run active
+                    text = "🌐 " + status.read_text().strip()[:120]
+                except OSError:
+                    continue
+                if text == last:
+                    continue  # Telegram rejects no-op edits
+                last = text
+                try:
+                    if message_id is None:
+                        msg = await self.app.bot.send_message(chat_id, text)
+                        message_id = msg.message_id
+                    else:
+                        await self.app.bot.edit_message_text(
+                            text, chat_id=chat_id, message_id=message_id
+                        )
+                except Exception:
+                    pass  # transient edit/rate-limit error — keep polling
+
+        task = asyncio.create_task(_poll(), name=f"tg-progress-{chat_id}")
+        try:
+            yield
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            if message_id is not None:  # tidy the progress message away
+                try:
+                    await self.app.bot.delete_message(chat_id, message_id)
+                except Exception:
+                    pass
+
     def _is_allowed(self, user_id: int) -> bool:
         if self.config.allowed_user_ids and user_id not in self.config.allowed_user_ids:
             log.warning("Ignoring message from unauthorized user %s", user_id)
@@ -285,7 +339,7 @@ class TelegramChannel:
         return True
 
     async def _handle_text(self, text: str, user_id: int, chat_id: int) -> None:
-        async with self._typing(chat_id):
+        async with self._typing(chat_id), self._progress(chat_id):
             response = await self.agent.process(
                 message=text,
                 channel="telegram",
@@ -297,7 +351,7 @@ class TelegramChannel:
     async def _handle_voice(
         self, file_id: str, user_id: int, chat_id: int, reply_context: str
     ) -> None:
-        async with self._typing(chat_id):
+        async with self._typing(chat_id), self._progress(chat_id):
             file = await self.app.bot.get_file(file_id)
             audio_bytes = await file.download_as_bytearray()
 
@@ -340,7 +394,7 @@ class TelegramChannel:
     ) -> None:
         from core.models import IMAGE_MIME_TYPES, Attachment
 
-        async with self._typing(chat_id):
+        async with self._typing(chat_id), self._progress(chat_id):
             attachments: list[Attachment] = []
             for file_id, mime_type in file_ids:
                 file = await self.app.bot.get_file(file_id)

--- a/channels/whatsapp.py
+++ b/channels/whatsapp.py
@@ -42,7 +42,11 @@ class WhatsAppChannel:
             error = res.get("error", "Unknown wacli error")
             raise RuntimeError(f"wacli send failed: {error}")
 
-    async def send_approval_request(self, user_id: str, request_id: str, description: str) -> None:
+    async def send_approval_request(
+        self, user_id: str, request_id: str, description: str, image_path: str | None = None
+    ) -> None:
+        # ponytail: WhatsApp media send not wired — the screenshot path is in the
+        # description. Add bot media upload here if mobile WhatsApp follow matters.
         message = (
             f"Permission request:\n\n{description}\n\n"
             f"Reply with:\n"

--- a/core/agent.py
+++ b/core/agent.py
@@ -1306,6 +1306,31 @@ class AgentCore:
         for sig, _ in pending:
             write_decisions[sig] = decision
 
+    def _approval_image(self, tool_name: str | None, params: dict | None) -> str | None:
+        """Screenshot to attach to a browser `act` approval (mobile follow-along).
+
+        The agent is told to screenshot the page before acting, which writes the
+        per-profile preview; we surface it so the user sees the page next to the
+        Approve/Deny buttons. Returns None for non-browser actions or no preview.
+        """
+        if tool_name != "run_command" or not isinstance(params, dict):
+            return None
+        cmd = params.get("command", "")
+        if "browser.py act" not in cmd:
+            return None
+        import shlex
+
+        from tools.browser import _preview_path
+
+        parts = shlex.split(cmd)
+        profile = "default"
+        if "--profile" in parts:
+            i = parts.index("--profile")
+            if i + 1 < len(parts):
+                profile = parts[i + 1]
+        path = _preview_path(profile)
+        return str(path) if path.exists() else None
+
     async def _await_approval(
         self,
         description: str,
@@ -1329,7 +1354,12 @@ class AgentCore:
 
         # Send the approval prompt via the channel
         try:
-            await ch.send_approval_request(user_id, request_id, description)
+            await ch.send_approval_request(
+                user_id,
+                request_id,
+                description,
+                image_path=self._approval_image(tool_name, params),
+            )
         except AttributeError:
             # Channel doesn't support approval requests — auto-approve
             log.warning("Channel %r doesn't support approvals, auto-approving", channel)

--- a/core/agent.py
+++ b/core/agent.py
@@ -1318,8 +1318,6 @@ class AgentCore:
         cmd = params.get("command", "")
         if "browser.py act" not in cmd:
             return None
-        import shlex
-
         from tools.browser import _preview_path
 
         parts = shlex.split(cmd)

--- a/core/config.py
+++ b/core/config.py
@@ -246,10 +246,21 @@ class GhToolConfig(BaseModel):
     token: str = ""  # GitHub PAT, injected as GH_TOKEN when running `gh`
 
 
+class BrowserToolConfig(BaseModel):
+    """Headless browser automation (Playwright/Chromium) — see tools/browser.py."""
+
+    enabled: bool = False
+    headless: bool = True
+    # Optional CDP endpoint of a sidecar Chromium. Empty = launch locally (works
+    # in the local REPL with no extra services). Set to keep the main image lean.
+    cdp_url: str = ""
+
+
 class ToolsConfig(BaseModel):
     """Optional external CLI tools the agent can use (see core/tools.py)."""
 
     gh: GhToolConfig = GhToolConfig()
+    browser: BrowserToolConfig = BrowserToolConfig()
 
 
 class Config(BaseModel):

--- a/core/config.py
+++ b/core/config.py
@@ -254,6 +254,8 @@ class BrowserToolConfig(BaseModel):
     # Optional CDP endpoint of a sidecar Chromium. Empty = launch locally (works
     # in the local REPL with no extra services). Set to keep the main image lean.
     cdp_url: str = ""
+    # Override the browser User-Agent. Empty = built-in desktop Chrome UA.
+    user_agent: str = ""
 
 
 class ToolsConfig(BaseModel):

--- a/core/config_store.py
+++ b/core/config_store.py
@@ -82,6 +82,7 @@ SETUP_STEPS = [
     "email",
     "calendar",
     "search",
+    "browser",
     "admin",
     "done",
 ]

--- a/core/executor.py
+++ b/core/executor.py
@@ -84,6 +84,10 @@ class ToolExecutor:
             return {
                 "error": f"Command not allowed. Must start with one of: {self.ALLOWED_PREFIXES}"
             }
+        # `browser.py explore` runs an inner LLM loop (many page steps) and needs
+        # minutes, not the 30s default — otherwise it's always killed mid-booking.
+        if "browser.py explore" in command:
+            timeout = max(timeout, 480)
         return await self._exec(self._resolve_command(command), timeout)
 
     async def run_command_trusted(self, command: str, timeout: int = 30) -> dict:

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -181,6 +181,31 @@ class PermissionEngine:
             return f"run_command:{params['command']}"
         return tool_name
 
+    @staticmethod
+    def _rule_pattern(match_key: str) -> str:
+        """Generalize a concrete command into a reusable glob rule for "always".
+
+        Keeps the leading program/script/subcommand tokens (e.g.
+        `python3 /app/tools/browser.py explore`) and wildcards the arguments, so
+        approving once covers every later call of the same command shape. Stops at
+        the first flag/URL/quoted/redirect token and caps at 3 tokens so the rule
+        is neither over-narrow (the whole command) nor over-broad (just the
+        interpreter). Non run_command keys are returned unchanged.
+        """
+        prefix = "run_command:"
+        if not match_key.startswith(prefix):
+            return match_key
+        kept: list[str] = []
+        for tok in match_key[len(prefix) :].split():
+            if tok.startswith("-") or "://" in tok or tok[:1] in "\"'" or tok in "|<>;&":
+                break
+            kept.append(tok)
+            if len(kept) == 3:
+                break
+        if not kept:
+            return match_key  # nothing safe to generalize → keep exact
+        return prefix + " ".join(kept) + "*"
+
     def match_key(self, tool_name: str, params: dict | None = None) -> str:
         """Public helper to build the match key for a tool call."""
         return self._build_match_key(tool_name, params)
@@ -301,8 +326,13 @@ class PermissionEngine:
             return False
         if always_allow:
             match_key = entry.get("match_key")
-            if isinstance(match_key, str) and match_key not in self.rules:
-                self.add_rule(match_key, PermissionLevel.ALWAYS)
+            if isinstance(match_key, str):
+                # Persist a GENERALIZED pattern, not the exact command — otherwise
+                # "always" only ever matches that one verbatim invocation and the
+                # next (different --url/--task/args) prompts again. See _rule_pattern.
+                pattern = self._rule_pattern(match_key)
+                if pattern not in self.rules:
+                    self.add_rule(pattern, PermissionLevel.ALWAYS)
         if skipped:
             future.set_result("skipped")
         elif approved:

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -107,6 +107,13 @@ DEFAULT_RULES: dict[str, str] = {
     "run_command:gh*issue create*": "ASK",
     "run_command:gh*pr create*": "ASK",
     "run_command:gh*release create*": "ASK",
+    # Browser automation — reading is safe, acting (click/fill/submit) asks.
+    # Per-domain rules work because every command carries `--url`, e.g. add
+    # "run_command:*browser.py act*github.com*": "ALWAYS" via the admin UI.
+    "run_command:*browser.py read*": "ALWAYS",
+    "run_command:*browser.py screenshot*": "ALWAYS",
+    "run_command:*browser.py profiles*": "ALWAYS",
+    "run_command:*browser.py act*": "ASK",
     "run_command:git*push*": "ASK",
     "run_command:git*commit*": "ASK",
     "web_search": "ALWAYS",

--- a/core/repl.py
+++ b/core/repl.py
@@ -140,9 +140,10 @@ class Spinner:
 class ReplChannel:
     """Minimal channel: prints approval prompts and reads a y/n from stdin."""
 
-    def __init__(self, agent: AgentCore, spinner: Spinner):
+    def __init__(self, agent: AgentCore, spinner: Spinner, yolo: bool = False):
         self.agent = agent
         self.spinner = spinner
+        self.yolo = yolo  # auto-approve every permission prompt (--yolo)
         # Set per-turn by _run_turn: release/reclaim stdin from the ESC watcher
         # so the approval prompt can read it (else _on_key eats the keystrokes).
         self.pause_keys = None
@@ -154,6 +155,11 @@ class ReplChannel:
     async def send_approval_request(
         self, user_id: str, request_id: str, description: str, image_path: str | None = None
     ) -> None:
+        if self.yolo:  # --yolo: approve everything, no prompt (this call only, no rule)
+            sys.stderr.write(f"\r\033[K\033[2m  · [yolo] auto-approved: {description}\033[0m\n")
+            sys.stderr.flush()
+            self.agent.permissions.resolve_approval(request_id, approved=True)
+            return
         await self.spinner.stop()  # don't fight the prompt for the line
         if self.pause_keys:
             self.pause_keys()
@@ -301,6 +307,11 @@ async def main() -> None:
         default=None,
         help="Test with a specific persona active (overrides agent.active_persona).",
     )
+    parser.add_argument(
+        "--yolo",
+        action="store_true",
+        help="Auto-approve every permission prompt (no rules saved). Local testing only.",
+    )
     args = parser.parse_args()
 
     spinner = Spinner()
@@ -323,7 +334,9 @@ async def main() -> None:
         config.agent.active_persona = args.persona
 
     agent = AgentCore(config)
-    agent.channels["repl"] = ReplChannel(agent, spinner)
+    agent.channels["repl"] = ReplChannel(agent, spinner, yolo=args.yolo)
+    if args.yolo:
+        print(f"{_DIM}⚠ --yolo: auto-approving all tool permissions this session.{_RESET}")
 
     if args.persona is not None:
         # Session mode snapshots the system prompt per chat, so a stale session

--- a/core/repl.py
+++ b/core/repl.py
@@ -19,6 +19,7 @@ import mimetypes
 import os
 import sys
 import time
+from pathlib import Path
 
 from core.agent import AgentCore
 from core.config_store import ConfigStore
@@ -80,11 +81,27 @@ class Spinner:
         self._start = 0.0
         self._frame = "⠋"
 
+    # Live progress file written by `tools/browser.py explore` (best-effort tail).
+    _EXPLORE_STATUS = Path("/app/data" if Path("/app/data").exists() else "data") / (
+        "browser/last/explore.status"
+    )
+
     def redraw(self) -> None:
         if self._task is None:  # not running — startup/idle log records mustn't draw it
             return
-        sys.stderr.write(f"\r\033[K\033[2m{self._frame} thinking… {self._elapsed():.0f}s\033[0m")
+        label = self._explore_label() or "thinking…"
+        sys.stderr.write(f"\r\033[K\033[2m{self._frame} {label} {self._elapsed():.0f}s\033[0m")
         sys.stderr.flush()
+
+    def _explore_label(self) -> str | None:
+        """If an `explore` run is updating its status file right now, show that."""
+        try:
+            p = self._EXPLORE_STATUS
+            if time.time() - p.stat().st_mtime < 10:
+                return f"🌐 explore: {p.read_text().strip()[:70]} ·"
+        except OSError:
+            pass
+        return None
 
     def _elapsed(self) -> float:
         return time.monotonic() - self._start

--- a/core/repl.py
+++ b/core/repl.py
@@ -39,6 +39,7 @@ except ImportError:  # pragma: no cover - non-POSIX
 log = logging.getLogger(__name__)
 
 USER_ID = "repl"
+_PROMPT = "> "
 
 # Loggers whose INFO output is the agent's "chain of thought" / activity trail.
 _THOUGHT_LOGGERS = ("core.agent", "core.executor", "core.llm.reasoning")
@@ -67,6 +68,11 @@ class _SpinnerHandler(logging.Handler):
         color = _DIM if record.name == "core.llm.reasoning" else _CYAN
         line = f"  {color}· {record.getMessage()}{_RESET}"
         sys.stderr.write("\r\033[K" + line + "\n")
+        # A background task (memory/reflection) can log AFTER the input prompt is
+        # drawn; the \r\033[K above wiped it, so redraw the prompt + any typed text.
+        if self.spinner.awaiting_input:
+            buf = readline.get_line_buffer() if readline else ""
+            sys.stderr.write(_PROMPT + buf)
         sys.stderr.flush()
         self.spinner.redraw()
 
@@ -80,6 +86,9 @@ class Spinner:
         self._task: asyncio.Task | None = None
         self._start = 0.0
         self._frame = "⠋"
+        # True while the main loop blocks on input(), so a late background log line
+        # knows to redraw the prompt it clobbered.
+        self.awaiting_input = False
 
     # Live progress file written by `tools/browser.py explore` (best-effort tail).
     _EXPLORE_STATUS = Path("/app/data" if Path("/app/data").exists() else "data") / (
@@ -330,10 +339,13 @@ async def main() -> None:
     _print_debug_config(config, persona)
 
     while True:
+        spinner.awaiting_input = True
         try:
-            text = await asyncio.to_thread(input, "> ")
+            text = await asyncio.to_thread(input, _PROMPT)
         except EOFError:
             break
+        finally:
+            spinner.awaiting_input = False
         text = text.strip()
         if not text:
             continue

--- a/core/repl.py
+++ b/core/repl.py
@@ -125,14 +125,18 @@ class ReplChannel:
     async def send(self, chat_id, text: str) -> None:
         print(f"\n{text}\n")
 
-    async def send_approval_request(self, user_id: str, request_id: str, description: str) -> None:
+    async def send_approval_request(
+        self, user_id: str, request_id: str, description: str, image_path: str | None = None
+    ) -> None:
         await self.spinner.stop()  # don't fight the prompt for the line
         if self.pause_keys:
             self.pause_keys()
         hist_len = readline.get_current_history_length() if readline else 0
+        # No inline images in a terminal — print the path so you can open it.
+        shot = f"\n[screenshot] {image_path}" if image_path else ""
         try:
             ans = await asyncio.to_thread(
-                input, f"\n[approval] {description}\nApprove? Always|Yes|[No] "
+                input, f"\n[approval] {description}{shot}\nApprove? Always|Yes|[No] "
             )
         finally:
             if self.resume_keys:

--- a/core/tools.py
+++ b/core/tools.py
@@ -38,6 +38,29 @@ target repository. Use `-o json` / `gh api` and parse JSON when you need fields.
 </tool>"""
 
 
+# Advertisement injected into the system prompt when `browser` is active.
+_BROWSER_PROMPT = """<tool name="browser">
+A headless browser (`tools/browser.py`, Playwright) is available via `run_command`
+for JS-heavy pages and acting on the user's behalf. Prefer an existing API/CLI
+over the browser whenever one exists — it is a last resort.
+Verbs (always pass `--url`; add `--profile NAME` to reuse a logged-in session):
+  python3 tools/browser.py read --url URL                  # readable page text
+  python3 tools/browser.py screenshot --url URL -o shot.png # save a PNG
+  python3 tools/browser.py act --url URL --profile P --steps JSON
+  python3 tools/browser.py profiles                         # list saved sessions
+`read`/`screenshot` run without asking. `act` changes state (click/fill/submit)
+so it asks for approval each time; on chat channels the approval shows a
+screenshot of the page. `--steps` is an ordered JSON array of single-key objects:
+  [{"fill":["#user","alice"]},{"fill":["#pass","s3cr3t"]},{"click":"#login"}]
+Steps: fill[sel,val], click[sel], select[sel,val], press[sel,key], wait[ms|sel], goto[url].
+Guided first-time login: screenshot the login page so the user can follow along,
+ask the user for credentials (never store them), then `act` to fill+submit. If
+2FA appears, screenshot it and ask the user for the code, then `act` again. After
+login the `--profile` session persists, so later visits skip the login.
+Some sites with strong bot-management may still block headless automation.
+</tool>"""
+
+
 @dataclass(frozen=True)
 class ToolSpec:
     """Describes an optional external tool the agent can use."""
@@ -59,6 +82,16 @@ def _gh_env(config: Config) -> dict[str, str]:
     return {}
 
 
+def _browser_env(config: Config) -> dict[str, str]:
+    browser = config.tools.browser
+    if not browser.enabled:
+        return {}
+    env = {"BROWSER_HEADLESS": "1" if browser.headless else "0"}
+    if browser.cdp_url:
+        env["BROWSER_CDP_URL"] = browser.cdp_url
+    return env
+
+
 _REGISTRY: tuple[ToolSpec, ...] = (
     ToolSpec(
         key="gh",
@@ -66,6 +99,13 @@ _REGISTRY: tuple[ToolSpec, ...] = (
         summary="Let the agent query and act on GitHub (issues, PRs, repos, API).",
         env=_gh_env,
         prompt=lambda _cfg: _GH_PROMPT,
+    ),
+    ToolSpec(
+        key="browser",
+        label="Browser automation",
+        summary="Let the agent read JS-heavy pages and act on sites via a headless browser.",
+        env=_browser_env,
+        prompt=lambda _cfg: _BROWSER_PROMPT,
     ),
 )
 

--- a/core/tools.py
+++ b/core/tools.py
@@ -45,7 +45,7 @@ for JS-heavy pages and acting on the user's behalf. Prefer an existing API/CLI
 over the browser whenever one exists — it is a last resort.
 Verbs (always pass `--url`; add `--profile NAME` to reuse a logged-in session):
   python3 tools/browser.py read --url URL                  # readable page text
-  python3 tools/browser.py screenshot --url URL -o shot.png # save a PNG
+  python3 tools/browser.py screenshot --url URL            # save a PNG to ~/Downloads
   python3 tools/browser.py act --url URL --profile P --steps JSON
   python3 tools/browser.py profiles                         # list saved sessions
 `read`/`screenshot` run without asking. `act` changes state (click/fill/submit)

--- a/core/tools.py
+++ b/core/tools.py
@@ -78,6 +78,10 @@ How to use it well:
 - Quote its returned `answer` (and screenshot path) back to the user. If it
   reports a pending/awaiting-approval status, say so — don't upgrade it to
   "confirmed".
+- If the result has `done:false` and a `reason`, the flow could NOT be completed
+  (stuck, control not found, dead end). Tell the user what blocked it and share
+  the screenshot — do NOT claim success and do NOT blindly re-run the same task;
+  the loop already gave up on purpose to avoid wasting effort.
 `read`/`screenshot` run without asking. `act` changes state (click/fill/submit)
 so it asks for approval each time; on chat channels the approval shows a
 screenshot of the page. `--steps` is an ordered JSON array of single-key objects:

--- a/core/tools.py
+++ b/core/tools.py
@@ -45,7 +45,7 @@ for JS-heavy pages and acting on the user's behalf. Prefer an existing API/CLI
 over the browser whenever one exists — it is a last resort.
 Verbs (always pass `--url`; add `--profile NAME` to reuse a logged-in session):
   python3 /app/tools/browser.py read --url URL                  # readable page text
-  python3 /app/tools/browser.py screenshot --url URL            # save a PNG to ~/Downloads
+  python3 /app/tools/browser.py screenshot --url URL            # save a PNG (path in result)
   python3 /app/tools/browser.py act --url URL --profile P --steps JSON
   python3 /app/tools/browser.py explore --url URL --task "..."  # self-driving loop
   python3 /app/tools/browser.py profiles                        # list saved sessions

--- a/core/tools.py
+++ b/core/tools.py
@@ -47,7 +47,12 @@ Verbs (always pass `--url`; add `--profile NAME` to reuse a logged-in session):
   python3 /app/tools/browser.py read --url URL                  # readable page text
   python3 /app/tools/browser.py screenshot --url URL            # save a PNG to ~/Downloads
   python3 /app/tools/browser.py act --url URL --profile P --steps JSON
+  python3 /app/tools/browser.py explore --url URL --task "..."  # self-driving loop
   python3 /app/tools/browser.py profiles                        # list saved sessions
+Use `explore` for open-ended "find X / navigate to Y and tell me Z" tasks: one
+browser stays open and an inner loop clicks/types on its own until done, then
+returns an answer — far cheaper than you re-driving `read`/`act` round by round.
+Use `read`/`screenshot` when you already know the exact URL.
 `read`/`screenshot` run without asking. `act` changes state (click/fill/submit)
 so it asks for approval each time; on chat channels the approval shows a
 screenshot of the page. `--steps` is an ordered JSON array of single-key objects:

--- a/core/tools.py
+++ b/core/tools.py
@@ -123,6 +123,8 @@ def _browser_env(config: Config) -> dict[str, str]:
     env = {"BROWSER_HEADLESS": "1" if browser.headless else "0"}
     if browser.cdp_url:
         env["BROWSER_CDP_URL"] = browser.cdp_url
+    if browser.user_agent:
+        env["BROWSER_USER_AGENT"] = browser.user_agent
     return env
 
 

--- a/core/tools.py
+++ b/core/tools.py
@@ -40,14 +40,14 @@ target repository. Use `-o json` / `gh api` and parse JSON when you need fields.
 
 # Advertisement injected into the system prompt when `browser` is active.
 _BROWSER_PROMPT = """<tool name="browser">
-A headless browser (`tools/browser.py`, Playwright) is available via `run_command`
+A headless browser (`/app/tools/browser.py`, Playwright) is available via `run_command`
 for JS-heavy pages and acting on the user's behalf. Prefer an existing API/CLI
 over the browser whenever one exists — it is a last resort.
 Verbs (always pass `--url`; add `--profile NAME` to reuse a logged-in session):
-  python3 tools/browser.py read --url URL                  # readable page text
-  python3 tools/browser.py screenshot --url URL            # save a PNG to ~/Downloads
-  python3 tools/browser.py act --url URL --profile P --steps JSON
-  python3 tools/browser.py profiles                         # list saved sessions
+  python3 /app/tools/browser.py read --url URL                  # readable page text
+  python3 /app/tools/browser.py screenshot --url URL            # save a PNG to ~/Downloads
+  python3 /app/tools/browser.py act --url URL --profile P --steps JSON
+  python3 /app/tools/browser.py profiles                        # list saved sessions
 `read`/`screenshot` run without asking. `act` changes state (click/fill/submit)
 so it asks for approval each time; on chat channels the approval shows a
 screenshot of the page. `--steps` is an ordered JSON array of single-key objects:

--- a/core/tools.py
+++ b/core/tools.py
@@ -55,15 +55,29 @@ browser stays open and an inner loop sees every frame and clicks/types on its
 own until done, then returns an answer. It is the ONLY verb that can drive
 embedded widgets and payment iframes; `read`/`act` only see the top page and
 will fail on them.
+CRITICAL: every browser command starts a BRAND-NEW browser that reloads `--url`
+from scratch — there is NO shared session or page state between calls. So you
+CANNOT do a flow step-by-step across several commands; each call would restart
+from the beginning and lose all progress. A whole interactive flow MUST be ONE
+explore call that carries the entire task.
 How to use it well:
-- Put the ENTIRE task in one `--task`, with every concrete value the flow needs
-  (product, dates/times, name, email, phone, full card number/expiry/CVC/ZIP).
-  It cannot ask you mid-run, so give it everything up front.
-- It runs autonomously for up to a few minutes and returns ONE JSON result with
-  an `answer`. That is expected — do NOT treat the wait as a hang, do NOT retry
-  it, and do NOT fall back to `read`/`act`. Call it once and wait.
-- Quote its returned `answer` (and screenshot path) back to the user.
-Use `read`/`screenshot` only for static pages where you already know the URL.
+- Put the ENTIRE task in one `--task`, as numbered steps, with every concrete
+  value the flow needs (product, dates/times, name, email, phone, full card
+  number/expiry/CVC/ZIP). It cannot ask you mid-run, so give it everything up
+  front. Example for a booking:
+  python3 /app/tools/browser.py explore --url https://shop.example/book --task \
+    "1) click 'Book now'. 2) select the Single Kayak product. 3) set pickup and
+     return date 2026-06-26, start 09:00, end 10:00. 4) click Next through each
+     step. 5) fill name Matteo Merola, email m@x.com, phone +41770000000.
+     6) at payment fill card 4242424242424242 exp 03/29 cvc 736 zip 8000 and
+     click Pay. 7) report the confirmation."
+- It runs autonomously for a few minutes and returns ONE JSON result with an
+  `answer`. That is expected — do NOT treat the wait as a hang, do NOT split the
+  task, do NOT retry, and do NOT fall back to `read`/`act` (they only see the top
+  page, never the widget/iframe, and will mislead you with stale content).
+- Quote its returned `answer` (and screenshot path) back to the user. If it
+  reports a pending/awaiting-approval status, say so — don't upgrade it to
+  "confirmed".
 `read`/`screenshot` run without asking. `act` changes state (click/fill/submit)
 so it asks for approval each time; on chat channels the approval shows a
 screenshot of the page. `--steps` is an ordered JSON array of single-key objects:

--- a/core/tools.py
+++ b/core/tools.py
@@ -49,10 +49,21 @@ Verbs (always pass `--url`; add `--profile NAME` to reuse a logged-in session):
   python3 /app/tools/browser.py act --url URL --profile P --steps JSON
   python3 /app/tools/browser.py explore --url URL --task "..."  # self-driving loop
   python3 /app/tools/browser.py profiles                        # list saved sessions
-Use `explore` for open-ended "find X / navigate to Y and tell me Z" tasks: one
-browser stays open and an inner loop clicks/types on its own until done, then
-returns an answer — far cheaper than you re-driving `read`/`act` round by round.
-Use `read`/`screenshot` when you already know the exact URL.
+PREFER `explore` for ANYTHING interactive — clicking buttons, opening modals/
+widgets, multi-step forms, bookings, checkouts, anything inside an iframe. One
+browser stays open and an inner loop sees every frame and clicks/types on its
+own until done, then returns an answer. It is the ONLY verb that can drive
+embedded widgets and payment iframes; `read`/`act` only see the top page and
+will fail on them.
+How to use it well:
+- Put the ENTIRE task in one `--task`, with every concrete value the flow needs
+  (product, dates/times, name, email, phone, full card number/expiry/CVC/ZIP).
+  It cannot ask you mid-run, so give it everything up front.
+- It runs autonomously for up to a few minutes and returns ONE JSON result with
+  an `answer`. That is expected — do NOT treat the wait as a hang, do NOT retry
+  it, and do NOT fall back to `read`/`act`. Call it once and wait.
+- Quote its returned `answer` (and screenshot path) back to the user.
+Use `read`/`screenshot` only for static pages where you already know the URL.
 `read`/`screenshot` run without asking. `act` changes state (click/fill/submit)
 so it asks for approval each time; on chat channels the approval shows a
 screenshot of the page. `--steps` is an ordered JSON array of single-key objects:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,10 @@ services:
       - ./skills:/app/skills:ro
     env_file: .env
     # Browser tool (issue #16). Two options:
-    #  - All-in-one: build with `--build-arg INSTALL_BROWSER=true` to bundle Chromium.
-    #  - Lean core: run the sidecar below and set tools.browser.cdp_url to its CDP
-    #    endpoint (admin UI). Profiles persist on the shared ./data volume.
+    #  - All-in-one (default): Chromium is bundled in the image (~500-700MB), so no
+    #    runtime download. Opt out with `--build-arg INSTALL_BROWSER=false`.
+    #  - Lean core: build with INSTALL_BROWSER=false, run the sidecar below, and set
+    #    tools.browser.cdp_url to its CDP endpoint. Profiles persist on ./data.
     # environment:
     #   - BROWSER_CDP_URL=ws://browser:3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,20 @@ services:
       - ./personalia.md:/app/personalia.md
       - ./skills:/app/skills:ro
     env_file: .env
+    # Browser tool (issue #16). Two options:
+    #  - All-in-one: build with `--build-arg INSTALL_BROWSER=true` to bundle Chromium.
+    #  - Lean core: run the sidecar below and set tools.browser.cdp_url to its CDP
+    #    endpoint (admin UI). Profiles persist on the shared ./data volume.
+    # environment:
+    #   - BROWSER_CDP_URL=ws://browser:3000
+
+  # Optional headless-Chromium sidecar (keeps the main image lean). Start with:
+  #   docker compose --profile browser up
+  # Exposes a CDP endpoint; point tools.browser.cdp_url at ws://browser:3000.
+  # browser:
+  #   image: browserless/chrome:latest
+  #   container_name: mpa-browser
+  #   restart: unless-stopped
+  #   profiles: ["browser"]
+  #   environment:
+  #     - MAX_CONCURRENT_SESSIONS=2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "vobject>=0.9.9",
     "fastembed",
     "numpy",
+    "playwright",
 ]
 
 [dependency-groups]

--- a/skills/browser.md
+++ b/skills/browser.md
@@ -1,0 +1,74 @@
+# Browser Automation (headless)
+
+A headless browser (Playwright/Chromium) for reading JS-heavy pages and acting on
+sites on the user's behalf. **Disabled by default** — only available when the user
+enables it in Settings → Tools.
+
+**Last resort.** Prefer an existing API or CLI (e.g. `gh`, `himalaya`, calendar
+tools) whenever one exists. Reach for the browser only when there is no better way.
+
+Every command is a fresh process: cookies/sessions persist via `--profile`, but the
+open page does **not**. So a multi-step interaction (e.g. a login) must be a single
+`act` call.
+
+## Reading a page
+
+```bash
+# Readable text (waits for JS to settle) — runs without asking
+python3 ./tools/browser.py read --url https://example.com
+
+# Save a screenshot (PNG) — runs without asking
+python3 ./tools/browser.py screenshot --url https://example.com -o /app/data/browser/shot.png
+```
+
+`read` returns `{"url", "title", "text"}`. `screenshot` returns `{"url", "title", "path"}`.
+
+## Acting on a page
+
+```bash
+python3 ./tools/browser.py act --url https://site/login --profile acme \
+  --steps '[{"fill":["#user","alice"]},{"fill":["#pass","s3cr3t"]},{"click":"#login"}]'
+```
+
+`act` changes state, so it **asks for approval each time**. On chat channels the
+approval shows a screenshot of the page — so always `screenshot` the page first, so
+the user can follow along. `--steps` is an ordered JSON array of single-key objects:
+
+| Step | Meaning |
+|------|---------|
+| `{"fill":["sel","value"]}` | type `value` into the element |
+| `{"click":"sel"}` | click the element |
+| `{"select":["sel","value"]}` | choose a `<select>` option |
+| `{"press":["sel","Key"]}` | press a key (e.g. `Enter`) in the element |
+| `{"wait": 1000}` | wait N milliseconds |
+| `{"wait": "sel"}` | wait until the element appears |
+| `{"goto":"url"}` | navigate within the same call |
+
+`act` returns `{"url", "title", "steps", "screenshot"}`.
+
+## Profiles (logged-in sessions)
+
+A `--profile NAME` keeps its own cookies/session under `data/browser/profiles/NAME`,
+so you log in once and reuse it. List them:
+
+```bash
+python3 ./tools/browser.py profiles   # [{"name","authenticated","updated"}]
+```
+
+## Guided first-time login (mobile-followable)
+
+1. `screenshot` the login page and send it to the user so they can follow along.
+2. Ask the user for their credentials. **Never store or log credentials.**
+3. `act` to fill the username/password and submit (this asks for approval; the user
+   sees the screenshot + Approve/Deny).
+4. If 2FA appears: `screenshot` it, ask the user for the code, then `act` to enter it.
+5. Done — the `--profile` session is saved; later visits to that site skip the login.
+
+A user can also pre-seed a profile by dropping an exported Playwright
+`storage_state.json` into `data/browser/profiles/NAME/`.
+
+## Limitations
+
+Sites behind strong bot-management or interactive challenges may block headless
+automation. Persistent sessions help with the common cases but not the hardest tier.
+Tell the user plainly when a site looks blocked rather than retrying endlessly.

--- a/tests/test_browser_admin.py
+++ b/tests/test_browser_admin.py
@@ -16,12 +16,12 @@ def _client(tmp_path):
     store = ConfigStore(db_path=str(tmp_path / "config.db"))  # fresh -> auth open
     state = AgentState(agent=AgentCore(Config()), status="RUNNING")
     app, _ = create_admin_app(state, store)
-    return TestClient(app), state.agent
+    return TestClient(app), state.agent, store
 
 
 def test_tools_partial_includes_browser_card(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
-    client, _ = _client(tmp_path)
+    client, _, _ = _client(tmp_path)
     r = client.get("/partials/tools")
     assert r.status_code == 200
     assert "Browser automation" in r.text
@@ -30,7 +30,7 @@ def test_tools_partial_includes_browser_card(tmp_path, monkeypatch) -> None:
 
 def test_per_domain_rule_add_affects_permissions_then_delete(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
-    client, agent = _client(tmp_path)
+    client, agent, _ = _client(tmp_path)
 
     r = client.post("/tools/browser/rules", json={"domain": "github.com", "level": "ALWAYS"})
     assert r.status_code == 200 and r.json()["ok"]
@@ -52,6 +52,24 @@ def test_per_domain_rule_add_affects_permissions_then_delete(tmp_path, monkeypat
 
 def test_add_rule_requires_domain(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
-    client, _ = _client(tmp_path)
+    client, _, _ = _client(tmp_path)
     r = client.post("/tools/browser/rules", json={"domain": "", "level": "ALWAYS"})
     assert r.status_code == 200 and r.json()["ok"] is False
+
+
+def test_wizard_browser_step_saves_enabled(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    client, _, store = _client(tmp_path)
+
+    # Arrive at the browser step (from search), then advance to admin enabling it.
+    r = client.post("/setup/step", json={"step": "browser", "values": {}})
+    assert r.status_code == 200 and "Browser automation" in r.text
+    r = client.post(
+        "/setup/step", json={"step": "admin", "values": {"tools.browser.enabled": "true"}}
+    )
+    assert r.status_code == 200
+
+    # The value persisted to the config store.
+    import asyncio
+
+    assert asyncio.run(store.get("tools.browser.enabled")) == "true"

--- a/tests/test_browser_admin.py
+++ b/tests/test_browser_admin.py
@@ -1,0 +1,57 @@
+"""Integration test for the admin browser card routes (no network/browser)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.admin import AgentState, create_admin_app
+from core.config import Config
+from core.config_store import ConfigStore
+from core.permissions import PermissionLevel
+
+
+def _client(tmp_path):
+    from core.agent import AgentCore
+
+    store = ConfigStore(db_path=str(tmp_path / "config.db"))  # fresh -> auth open
+    state = AgentState(agent=AgentCore(Config()), status="RUNNING")
+    app, _ = create_admin_app(state, store)
+    return TestClient(app), state.agent
+
+
+def test_tools_partial_includes_browser_card(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    client, _ = _client(tmp_path)
+    r = client.get("/partials/tools")
+    assert r.status_code == 200
+    assert "Browser automation" in r.text
+    assert "browserTab(" in r.text
+
+
+def test_per_domain_rule_add_affects_permissions_then_delete(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    client, agent = _client(tmp_path)
+
+    r = client.post("/tools/browser/rules", json={"domain": "github.com", "level": "ALWAYS"})
+    assert r.status_code == 200 and r.json()["ok"]
+    rules = r.json()["rules"]
+    match = [x for x in rules if x["domain"] == "github.com"]
+    assert match and match[0]["level"] == "ALWAYS"
+
+    # The rule really changes the permission decision for that domain.
+    decision = agent.permissions.check(
+        "run_command",
+        {"command": "python3 tools/browser.py act --url https://github.com/x --steps []"},
+    )
+    assert decision == PermissionLevel.ALWAYS
+
+    r = client.post("/tools/browser/rules/delete", json={"pattern": match[0]["pattern"]})
+    assert r.status_code == 200 and r.json()["ok"]
+    assert all(x["domain"] != "github.com" for x in r.json()["rules"])
+
+
+def test_add_rule_requires_domain(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    client, _ = _client(tmp_path)
+    r = client.post("/tools/browser/rules", json={"domain": "", "level": "ALWAYS"})
+    assert r.status_code == 200 and r.json()["ok"] is False

--- a/tests/test_browser_explore.py
+++ b/tests/test_browser_explore.py
@@ -24,20 +24,32 @@ class _FakePage:
     def __init__(self):
         self.calls = []
 
-    def click(self, sel, timeout=None):
+    def click(self, sel, timeout=None, force=False):
         self.calls.append(("click", sel))
 
     def fill(self, sel, text, timeout=None):
         self.calls.append(("fill", sel, text))
 
 
-def test_apply_action_dispatches_to_indexed_selector():
-    page = _FakePage()
-    note = _apply_action(page, {"action": "click", "index": 3}, 1000)
-    assert page.calls == [("click", '[data-bu-idx="3"]')]
+def test_apply_action_dispatches_into_owning_frame():
+    frame = _FakePage()
+    # frame_map routes index 3 to its owning frame; selector is frame-local.
+    note = _apply_action({3: frame}, {"action": "click", "index": 3}, 1000)
+    assert frame.calls == [("click", '[data-bu-idx="3"]')]
     assert note == "clicked [3]"
 
 
 def test_apply_action_rejects_unknown_verb():
     with pytest.raises(ValueError):
-        _apply_action(_FakePage(), {"action": "teleport"}, 1000)
+        _apply_action({0: _FakePage()}, {"action": "teleport", "index": 0}, 1000)
+
+
+def test_format_state_marks_frames():
+    out = _format_state(
+        "u",
+        "t",
+        "x",
+        [{"idx": 5, "tag": "input", "type": "text", "label": "Card", "frame": "js.stripe.com"}],
+    )
+    assert "in frame: js.stripe.com" in out
+    assert "[5] input(text) 'Card'" in out

--- a/tests/test_browser_explore.py
+++ b/tests/test_browser_explore.py
@@ -1,0 +1,43 @@
+"""Offline checks for the `explore` verb's pure logic (no browser, no LLM)."""
+
+import pytest
+
+from tools.browser import _apply_action, _format_state
+
+
+def test_format_state_lists_indexed_elements():
+    out = _format_state(
+        "https://x.test/",
+        "Title",
+        "body text",
+        [{"idx": 0, "tag": "button", "type": "", "label": "Book"}],
+    )
+    assert "URL: https://x.test/" in out
+    assert "[0] button 'Book'" in out
+
+
+def test_format_state_handles_empty():
+    assert "(none found)" in _format_state("u", "t", "x", [])
+
+
+class _FakePage:
+    def __init__(self):
+        self.calls = []
+
+    def click(self, sel, timeout=None):
+        self.calls.append(("click", sel))
+
+    def fill(self, sel, text, timeout=None):
+        self.calls.append(("fill", sel, text))
+
+
+def test_apply_action_dispatches_to_indexed_selector():
+    page = _FakePage()
+    note = _apply_action(page, {"action": "click", "index": 3}, 1000)
+    assert page.calls == [("click", '[data-bu-idx="3"]')]
+    assert note == "clicked [3]"
+
+
+def test_apply_action_rejects_unknown_verb():
+    with pytest.raises(ValueError):
+        _apply_action(_FakePage(), {"action": "teleport"}, 1000)

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from core.config import Config
@@ -110,3 +112,28 @@ def test_parse_steps() -> None:
     for bad in ["{}", "[]", "not json", '[{"a":1,"b":2}]']:
         with pytest.raises(ValueError):
             _parse_steps(bad)
+
+
+# ---------------------------------------------------------------------------
+# Approval screenshot — browser `act` surfaces the per-profile preview
+# ---------------------------------------------------------------------------
+
+
+def test_approval_image_for_browser_act(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    from core.agent import AgentCore
+
+    agent = AgentCore(Config())
+    preview = tmp_path / "data" / "browser" / "last" / "acme.png"
+    preview.parent.mkdir(parents=True, exist_ok=True)
+    preview.write_bytes(b"\x89PNG")
+
+    act_cmd = {"command": "python3 tools/browser.py act --url https://x --profile acme --steps []"}
+    got = agent._approval_image("run_command", act_cmd)
+    assert got is not None and Path(got).resolve() == preview.resolve()
+    # No preview file -> None; read command -> None; non-run_command -> None.
+    other = {"command": "python3 tools/browser.py act --url https://x --profile ghost --steps []"}
+    assert agent._approval_image("run_command", other) is None
+    read_cmd = {"command": "python3 tools/browser.py read --url https://x"}
+    assert agent._approval_image("run_command", read_cmd) is None
+    assert agent._approval_image("send_email", {"to": "a"}) is None

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -1,0 +1,112 @@
+"""Tests for the optional browser tool: gating, permissions, CLI helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.config import Config
+from core.permissions import PermissionEngine, PermissionLevel
+from core.tools import active_tool_prompts, tool_env
+
+# ---------------------------------------------------------------------------
+# Registry gating — invisible when disabled, advertised + wired when enabled
+# ---------------------------------------------------------------------------
+
+
+def test_browser_inactive_by_default() -> None:
+    cfg = Config()
+    assert "browser" not in " ".join(active_tool_prompts(cfg))
+    assert "BROWSER_HEADLESS" not in tool_env(cfg)
+
+
+def test_browser_advertised_and_env_when_enabled() -> None:
+    cfg = Config()
+    cfg.tools.browser.enabled = True
+    blocks = "\n".join(active_tool_prompts(cfg))
+    assert "browser.py" in blocks
+    env = tool_env(cfg)
+    assert env["BROWSER_HEADLESS"] == "1"
+    assert "BROWSER_CDP_URL" not in env  # only present when a sidecar is configured
+
+
+def test_browser_headless_and_cdp_env() -> None:
+    cfg = Config()
+    cfg.tools.browser.enabled = True
+    cfg.tools.browser.headless = False
+    cfg.tools.browser.cdp_url = "ws://sidecar:9222"
+    env = tool_env(cfg)
+    assert env["BROWSER_HEADLESS"] == "0"
+    assert env["BROWSER_CDP_URL"] == "ws://sidecar:9222"
+
+
+# ---------------------------------------------------------------------------
+# Permissions — read is pre-approved, act asks, per-domain overrides win
+# ---------------------------------------------------------------------------
+
+
+def _level(engine: PermissionEngine, command: str) -> str:
+    return engine.check("run_command", {"command": command})
+
+
+def test_browser_read_is_always_act_asks(tmp_path) -> None:
+    eng = PermissionEngine(db_path=str(tmp_path / "c.db"))
+    assert (
+        _level(eng, "python3 tools/browser.py read --url https://x.com") == PermissionLevel.ALWAYS
+    )
+    assert (
+        _level(eng, "python3 tools/browser.py screenshot --url https://x.com")
+        == PermissionLevel.ALWAYS
+    )
+    assert (
+        _level(eng, "python3 tools/browser.py act --url https://x.com --steps []")
+        == PermissionLevel.ASK
+    )
+
+
+def test_browser_act_is_write_action(tmp_path) -> None:
+    eng = PermissionEngine(db_path=str(tmp_path / "c.db"))
+    # act must re-ask every time (write), read must not.
+    assert eng.is_write_action(
+        "run_command", {"command": "python3 tools/browser.py act --url https://x.com --steps []"}
+    )
+    assert not eng.is_write_action(
+        "run_command", {"command": "python3 tools/browser.py read --url https://x.com"}
+    )
+
+
+def test_per_domain_rule_overrides_default(tmp_path) -> None:
+    eng = PermissionEngine(db_path=str(tmp_path / "c.db"))
+    eng.add_rule("run_command:*browser.py act*github.com*", PermissionLevel.ALWAYS)
+    # github.com is now pre-approved; other domains still ask.
+    assert (
+        _level(eng, "python3 tools/browser.py act --url https://github.com/x --steps []")
+        == PermissionLevel.ALWAYS
+    )
+    assert (
+        _level(eng, "python3 tools/browser.py act --url https://evil.com/x --steps []")
+        == PermissionLevel.ASK
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers (no browser needed)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_profile() -> None:
+    from tools.browser import _validate_profile
+
+    assert _validate_profile("Acme") == "acme"
+    for bad in ["", "a/b", "../x", "a b"]:
+        with pytest.raises(ValueError):
+            _validate_profile(bad)
+
+
+def test_parse_steps() -> None:
+    from tools.browser import _parse_steps
+
+    steps = _parse_steps('[{"fill":["#u","a"]},{"click":"#go"}]')
+    assert steps == [{"fill": ["#u", "a"]}, {"click": "#go"}]
+    for bad in ["{}", "[]", "not json", '[{"a":1,"b":2}]']:
+        with pytest.raises(ValueError):
+            _parse_steps(bad)

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -268,37 +268,84 @@ def cmd_act(args) -> dict:
 # observes the page as indexed elements and issues ONE action per step until it
 # reports `done`. Built for openai-compatible providers (deepseek default).
 
-# JS: tag every visible, enabled interactive element with data-bu-idx and return
-# a compact [{idx, tag, type, label}] list. Selectors are then [data-bu-idx="N"].
+# JS: per-frame, tag every visible/enabled interactive element with data-bu-idx
+# (numbered from `offset` so indices are unique across frames) and return
+# {count, elements}. Selectors are then [data-bu-idx="N"] within that frame.
 _ENUM_JS = """
-() => {
-  const sel = 'a,button,input,textarea,select,[role=button],[role=link],[onclick]';
+(offset) => {
+  const sel = 'a,button,input,textarea,select,[role=button],[role=link],[role=radio],'
+    + '[role=checkbox],[role=tab],[onclick],[contenteditable=true]';
   const out = []; let i = 0;
   for (const el of document.querySelectorAll(sel)) {
     if (!el.getClientRects().length) continue;
     const st = getComputedStyle(el);
     if (st.visibility === 'hidden' || st.display === 'none') continue;
-    if (el.disabled) continue;
-    el.setAttribute('data-bu-idx', i);
-    const label = (el.innerText || el.value || el.getAttribute('placeholder') ||
-      el.getAttribute('aria-label') || el.name || '').trim().replace(/\\s+/g, ' ').slice(0, 80);
-    out.push({idx: i, tag: el.tagName.toLowerCase(), type: el.getAttribute('type') || '', label});
+    const tag = el.tagName.toLowerCase();
+    let label = (el.innerText || el.getAttribute('aria-label') || el.getAttribute('placeholder') ||
+      el.getAttribute('name') || el.getAttribute('title') || el.value ||
+      '').trim().replace(/\\s+/g, ' ').slice(0, 80);
+    // Skip pure-decoration anchors with no label/href target text.
+    if (!label && tag === 'a') continue;
+    const idx = offset + i;
+    el.setAttribute('data-bu-idx', String(idx));
+    const rec = {idx, tag, type: el.getAttribute('type') || '', label};
+    // Keep disabled controls visible (marked) — a disabled "Next" button tells the
+    // model a prerequisite field is still missing, instead of vanishing silently.
+    if (el.disabled) rec.disabled = true;
+    if (tag === 'input' || tag === 'textarea') rec.value = (el.value || '').slice(0, 40);
+    if (el.type === 'radio' || el.type === 'checkbox') rec.checked = el.checked;
+    if (tag === 'select') {
+      rec.value = el.value;
+      // Show the option VALUE, plus its label in parens only when they differ —
+      // a "value:text" join breaks for values that contain ':' (e.g. times).
+      rec.options = [...el.options].slice(0, 12).map(o => {
+        const v = o.value, t = o.text.trim().slice(0, 24);
+        return v === t ? v : `${v} (${t})`;
+      });
+    }
+    const exp = el.getAttribute('aria-expanded');
+    if (exp !== null) rec.expanded = exp;
+    out.push(rec);
     i++;
   }
-  return out;
+  return {count: i, elements: out};
 }
 """
 
 _EXPLORE_SYSTEM = """You are a web-automation agent driving a real browser.
-Each turn you receive the current page: its URL, title, a text excerpt, and a
-numbered list of interactive elements. Achieve the user's TASK by calling
-`browser_action` exactly ONCE per turn.
+Each turn you receive the current page: URL, title, a text excerpt, a list of
+the actions you took so far, and a numbered list of interactive ELEMENTS
+(across all frames, including embedded widgets and payment iframes). Achieve the
+user's TASK by calling `browser_action` exactly ONCE per turn.
+
 Actions: click(index), fill(index,text), select(index,text), goto(url),
 scroll(text="down"|"up"), done(answer).
-Element indices are reassigned after every action — always use the indices from
-the LATEST page state, never an old one. Work efficiently; steps are limited.
-When the task is complete (or you have the answer), call done with the result in
-`answer`."""
+
+Rules:
+- Element indices are RENUMBERED every turn. Always use indices from the LATEST
+  ELEMENTS list, never an old one.
+- To advance a multi-step flow, click the button that moves forward (e.g.
+  "Next", "Continue", "Book now", "Pay").
+- Fill every required field before clicking the step's continue button.
+- For input(date) fill YYYY-MM-DD (pick a date a few days out); for input(time)
+  fill HH:MM. A dropdown showing options like ["Select date first..."] is
+  DISABLED until the date it depends on is filled — set the date input first,
+  then on the next turn its real options appear and you can select one.
+- A select shows its options inline as options=[value (label), ...]; pass the
+  bare VALUE (the part before any parenthesis) to select(index,value).
+- An input shows its current text as value=...; if it already holds what you
+  need, don't refill it.
+- An element marked DISABLED cannot be clicked yet — it is gated on a missing
+  field. Do not click it; find and complete the missing required field first
+  (an empty value=, an unselected radio/option), which will enable it.
+- If a NOTE says the page did not change, your last action had no effect — do
+  NOT repeat it. Pick a different element (you may need to scroll, set a
+  prerequisite field first, or click a radio/option). Do NOT navigate away with
+  goto to restart — stay in the flow and fix the current step.
+- Payment fields (card number, expiry, CVC) live in iframes but appear in the
+  ELEMENTS list like any other input — fill them normally.
+- Call done(answer) when the task is finished (e.g. a confirmation page shows),
+  describing the outcome. Don't call done prematurely."""
 
 _ACTION_TOOL = {
     "name": "browser_action",
@@ -321,29 +368,87 @@ _ACTION_TOOL = {
 
 
 def _format_state(url: str, title: str, excerpt: str, elements: list[dict]) -> str:
-    lines = [f"URL: {url}", f"TITLE: {title}", "", "EXCERPT:", excerpt.strip()[:800]]
+    lines = [f"URL: {url}", f"TITLE: {title}", "", "EXCERPT:", excerpt.strip()[:1400]]
     lines += ["", "ELEMENTS:"]
+    last_frame = None
     for e in elements:
+        fr = e.get("frame")
+        if fr and fr != last_frame:
+            lines.append(f"-- in frame: {fr} --")
+            last_frame = fr
         t = f"{e['tag']}" + (f"({e['type']})" if e.get("type") else "")
-        lines.append(f"[{e['idx']}] {t} {e.get('label', '')!r}")
+        extra = " DISABLED" if e.get("disabled") else ""
+        if e.get("checked") is not None:
+            extra += " CHECKED" if e["checked"] else ""
+        if e.get("value"):
+            extra += f" value={e['value']!r}"
+        if e.get("expanded") is not None:
+            extra += f" expanded={e['expanded']}"
+        if e.get("options"):
+            extra += f" options={e['options']}"
+        lines.append(f"[{e['idx']}] {t} {e.get('label', '')!r}{extra}")
     if not elements:
         lines.append("(none found)")
     return "\n".join(lines)
 
 
-def _apply_action(page, action: dict, timeout_ms: int) -> str:
-    """Execute one model action against the live page. Returns a short result note."""
+def _observe(page) -> tuple[str, dict]:
+    """Enumerate interactive elements across ALL frames (main + embedded widgets +
+    payment iframes). Returns (state_text, {index: frame}) so actions dispatch into
+    the frame that owns each element."""
+    elements: list[dict] = []
+    frame_map: dict = {}
+    texts: list[str] = []
+    offset = 0
+    for fr in page.frames:
+        try:
+            res = fr.evaluate(_ENUM_JS, offset)
+        except Exception:
+            continue  # frame detached / not ready — skip it this turn
+        items = res.get("elements", [])
+        # Label frames other than the main one so the model sees the widget split.
+        frame_label = "" if fr is page.main_frame else (fr.url.split("//")[-1][:40] or "iframe")
+        for it in items:
+            it["frame"] = frame_label
+            elements.append(it)
+            frame_map[it["idx"]] = fr
+        offset += res.get("count", 0)
+        # The real content often lives in the widget iframe, not the host page —
+        # pull a short text excerpt from each frame that has interactive elements.
+        if items:
+            try:
+                snippet = fr.inner_text("body").strip().replace("\n\n", "\n")[:600]
+            except Exception:
+                snippet = ""
+            if snippet:
+                texts.append((f"[{frame_label}]\n" if frame_label else "") + snippet)
+    excerpt = "\n---\n".join(texts)[:1400]
+    return _format_state(page.url, page.title(), excerpt, elements), frame_map
+
+
+def _apply_action(frame_map: dict, action: dict, timeout_ms: int, page=None) -> str:
+    """Execute one model action in the frame that owns the target element."""
     verb = action.get("action")
     idx = action.get("index")
+    target = frame_map.get(idx)
     sel = f'[data-bu-idx="{idx}"]'
     if verb == "click":
-        page.click(sel, timeout=timeout_ms)
+        # force=True skips Playwright's actionability wait (visibility/stability/
+        # overlay-intercept/in-viewport). Real sites bury the true control under a
+        # label or image and use sr-only radios — without force every click hangs
+        # the full timeout then fails. The JS-level click still fires change events.
+        target.click(sel, timeout=timeout_ms, force=True)
         return f"clicked [{idx}]"
     if verb == "fill":
-        page.fill(sel, action.get("text", ""), timeout=timeout_ms)
+        target.fill(sel, action.get("text", ""), timeout=timeout_ms)
         return f"filled [{idx}]"
     if verb == "select":
-        page.select_option(sel, action.get("text", ""), timeout=timeout_ms)
+        val = action.get("text", "")
+        try:
+            target.select_option(sel, value=val, timeout=timeout_ms)
+        except Exception:
+            # Model may have passed the visible label rather than the option value.
+            target.select_option(sel, label=val, timeout=timeout_ms)
         return f"selected [{idx}]"
     if verb == "goto":
         page.goto(action.get("url", ""), timeout=timeout_ms, wait_until="domcontentloaded")
@@ -399,21 +504,23 @@ def cmd_explore(args) -> dict:
     llm = LLMClient.from_agent_config(agent_cfg)
     model = agent_cfg.model
     aio = _Aio()
-
-    def observe(page) -> str:
-        elements = page.evaluate(_ENUM_JS)
-        excerpt = page.inner_text("body")
-        return _format_state(page.url, page.title(), excerpt, elements)
+    verbose = bool(os.environ.get("BROWSER_EXPLORE_VERBOSE"))
 
     trail: list[str] = []
+
+    def trail_block() -> str:
+        return "STEPS SO FAR: " + (", ".join(trail) if trail else "(none yet)")
+
     try:
         with _Session(profile, args.headless) as s:
             s.goto(args.url, args.timeout)
+            state, frame_map = _observe(s.page)
             messages: list[dict] = [
-                {"role": "user", "content": f"TASK: {args.task}\n\n{observe(s.page)}"}
+                {"role": "user", "content": f"TASK: {args.task}\n\n{trail_block()}\n\n{state}"}
             ]
             answer = None
-            for _ in range(args.max_steps):
+            prev_state = state
+            for step in range(args.max_steps):
                 resp = aio.run(
                     llm.generate(
                         model=model,
@@ -448,17 +555,45 @@ def cmd_explore(args) -> dict:
                     answer = action.get("answer", "")
                     trail.append("done")
                     break
+                # Short per-action timeout: a buried/wrong element should fail in
+                # seconds so the model can recover, not burn the whole budget on one
+                # 30s actionability wait. Navigation keeps the full timeout.
+                act_timeout = args.timeout if action.get("action") == "goto" else 6000
                 try:
-                    note = _apply_action(s.page, action, args.timeout)
+                    note = _apply_action(frame_map, action, act_timeout, page=s.page)
                 except Exception as exc:
-                    note = f"error: {type(exc).__name__}: {exc}"
-                trail.append(note)
-                _settle(s.page, args.timeout)
+                    msg = str(exc).split("\nCall log:")[0]  # drop Playwright's verbose log
+                    note = f"error: {type(exc).__name__}: {msg}"
+                if note.startswith("error"):
+                    label = note
+                elif action.get("action") in ("goto", "scroll"):
+                    label = note
+                else:
+                    label = f"{action.get('action')}[{action.get('index')}]"
+                trail.append(label)
+                _settle(s.page, 3500)
+                state, frame_map = _observe(s.page)
+                # No-progress guard: if the page looks identical, tell the model so
+                # it stops hammering the same dead element.
+                changed = state != prev_state
+                prev_state = state
+                hint = (
+                    ""
+                    if changed
+                    else (
+                        "\nNOTE: the page did NOT change after your action — it had no "
+                        "effect. Do not repeat it; try a different element (you may need "
+                        "to scroll, or click a radio/option first)."
+                    )
+                )
+                if verbose:
+                    tag = "" if changed else " (no change)"
+                    print(f"[step {step}] {label}{tag}", file=sys.stderr)
                 messages.append(
                     {
                         "role": "tool",
                         "tool_call_id": call.id,
-                        "content": f"{note}\n\n{observe(s.page)}",
+                        "content": f"{note}\n\n{trail_block()}{hint}\n\n{state}",
                     }
                 )
 

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -51,8 +51,7 @@ from urllib.parse import urlparse
 
 NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _DEFAULT_UA = (
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+    "Mozilla/5.0 (macOS; AArch64) Ladybird/1.0 Chrome/146.0.0.0 AppleWebKit/537.36 Safari/537.36"
 )
 
 

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -304,7 +304,8 @@ _ENUM_JS = """
     + '[role=checkbox],[role=tab],[onclick],[contenteditable=true]';
   const out = []; let i = 0;
   for (const el of document.querySelectorAll(sel)) {
-    if (!el.getClientRects().length) continue;
+    const rects = el.getClientRects();
+    if (!rects.length) continue;
     const st = getComputedStyle(el);
     if (st.visibility === 'hidden' || st.display === 'none') continue;
     const tag = el.tagName.toLowerCase();
@@ -332,6 +333,13 @@ _ENUM_JS = """
     }
     const exp = el.getAttribute('aria-expanded');
     if (exp !== null) rec.expanded = exp;
+    // Spatial signal (cheap stand-in for vision): on-screen position + whether the
+    // element is scrolled out of view + whether it currently has focus. Lets the
+    // model reason about "top-right", "scroll down to it", "which field is active".
+    const r = rects[0];
+    rec.rect = [Math.round(r.left), Math.round(r.top), Math.round(r.width), Math.round(r.height)];
+    if (r.bottom <= 0 || r.top >= innerHeight) rec.offscreen = true;
+    if (document.activeElement === el) rec.focused = true;
     out.push(rec);
     i++;
   }
@@ -362,6 +370,10 @@ Rules:
   bare VALUE (the part before any parenthesis) to select(index,value).
 - An input shows its current text as value=...; if it already holds what you
   need, don't refill it.
+- Each element may show its on-screen position as @x,y, FOCUSED if it currently
+  has focus, and off-screen if it is scrolled out of view. Use these for spatial
+  choices ("the button on the right" = larger x) and scroll toward off-screen
+  targets before acting on them.
 - An element marked DISABLED cannot be clicked yet — it is gated on a missing
   field. Do not click it; find and complete the missing required field first
   (an empty value=, an unselected radio/option), which will enable it.
@@ -417,6 +429,12 @@ def _format_state(url: str, title: str, excerpt: str, elements: list[dict]) -> s
             extra += f" expanded={e['expanded']}"
         if e.get("options"):
             extra += f" options={e['options']}"
+        if e.get("focused"):
+            extra += " FOCUSED"
+        if e.get("offscreen"):
+            extra += " off-screen"
+        if e.get("rect"):
+            extra += f" @{e['rect'][0]},{e['rect'][1]}"
         lines.append(f"[{e['idx']}] {t} {e.get('label', '')!r}{extra}")
     if not elements:
         lines.append("(none found)")
@@ -555,7 +573,10 @@ def cmd_explore(args) -> dict:
                 {"role": "user", "content": f"TASK: {args.task}\n\n{trail_block()}\n\n{state}"}
             ]
             answer = None
+            reason = None
             prev_state = state
+            stuck = 0  # consecutive steps with no page change → bail out (see below)
+            STUCK_LIMIT = 5
             for step in range(args.max_steps):
                 resp = aio.run(
                     llm.generate(
@@ -633,19 +654,40 @@ def cmd_explore(args) -> dict:
                         "content": f"{note}\n\n{trail_block()}{hint}\n\n{state}",
                     }
                 )
+                # Feasibility guard: if nothing the model tries changes the page for
+                # STUCK_LIMIT steps in a row, the flow is wedged (element not found,
+                # gated step, dead end). Bail with a reason instead of burning the
+                # whole budget — an impossible task must fail fast and cheap.
+                stuck = stuck + 1 if not changed else 0
+                if stuck >= STUCK_LIMIT:
+                    reason = (
+                        f"Stopped after {stuck} consecutive steps with no effect on the "
+                        f"page — the flow appears stuck (last actions: "
+                        f"{', '.join(trail[-stuck:])}). The task may not be completable "
+                        f"as described, or a required control could not be found."
+                    )
+                    break
 
             host = urlparse(s.page.url).netloc or "page"
             shot = Path.home() / "Downloads" / f"clio-{host}-{int(time.time())}.png"
             s.snapshot(shot, full_page=True)
             # Return only what the calling agent needs — the full step trail is
             # debugging noise in its context (use BROWSER_EXPLORE_VERBOSE to see it).
-            return {
+            result = {
                 "answer": answer,
                 "done": answer is not None,
                 "steps_taken": len(trail),
                 "url": s.page.url,
                 "screenshot": str(shot),
             }
+            if reason:  # stuck-abort verdict, or hit the step cap without finishing
+                result["reason"] = reason
+            elif answer is None:
+                result["reason"] = (
+                    f"Ran out of steps ({args.max_steps}) before the task reported "
+                    f"completion. Increase --max-steps or simplify the task."
+                )
+            return result
     finally:
         aio.close()
         try:

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -160,6 +160,18 @@ class _Session:
 
     def __init__(self, profile: str, headless: bool):
         self.profile = profile
+        # Headed Chromium needs an X/Wayland display. On a headless server (e.g.
+        # the Docker image) there is none, so a "show the browser" setting would
+        # crash the launch with "Missing X server or $DISPLAY". Fall back to
+        # headless instead of crashing. (CDP sidecar ignores this — it's remote.)
+        if (
+            not headless
+            and sys.platform.startswith("linux")
+            and not os.environ.get("DISPLAY")
+            and not os.environ.get("WAYLAND_DISPLAY")
+        ):
+            print("[browser] no display available — running headless", file=sys.stderr)
+            headless = True
         self.headless = headless
         self.is_cdp = False
         self._pw = None

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -338,6 +338,10 @@ Rules:
 - An element marked DISABLED cannot be clicked yet — it is gated on a missing
   field. Do not click it; find and complete the missing required field first
   (an empty value=, an unselected radio/option), which will enable it.
+- If a total/price stays 0 or reads "will be calculated"/"unavailable" after you
+  filled the fields, your CHOICE is invalid (e.g. that date range or duration is
+  not available), not the form — change the selection (try a shorter or
+  different date/time range) until a real price appears and the button enables.
 - If a NOTE says the page did not change, your last action had no effect — do
   NOT repeat it. Pick a different element (you may need to scroll, set a
   prerequisite field first, or click a radio/option). Do NOT navigate away with

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -47,6 +47,7 @@ import re
 import sys
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _DESKTOP_UA = (
@@ -235,7 +236,9 @@ def cmd_screenshot(args) -> dict:
     if args.output:
         dest = Path(args.output)
     else:
-        dest = _data_dir() / "browser" / "screenshots" / f"{profile}-{int(time.time())}.png"
+        # Default to ~/Downloads with a spottable name so a REPL user can find it.
+        host = urlparse(args.url).netloc or "page"
+        dest = Path.home() / "Downloads" / f"clio-{host}-{int(time.time())}.png"
     with _Session(profile, args.headless) as s:
         s.goto(args.url, args.timeout)
         s.snapshot(dest, full_page=args.full_page)

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -259,6 +259,224 @@ def cmd_act(args) -> dict:
         return {"url": s.page.url, "title": s.page.title(), "steps": done, "screenshot": str(dest)}
 
 
+# -- explore: one process, one live browser, deepseek drives the loop ---------
+#
+# The other verbs are one-shot: a fresh process re-navigates every call, so an
+# outer agent that wants to "look, decide, click, look again" ping-pongs and
+# re-loads the page each round. `explore` instead keeps ONE browser open and
+# runs an inner LLM loop (the project's own cheap model, vision OFF) that
+# observes the page as indexed elements and issues ONE action per step until it
+# reports `done`. Built for openai-compatible providers (deepseek default).
+
+# JS: tag every visible, enabled interactive element with data-bu-idx and return
+# a compact [{idx, tag, type, label}] list. Selectors are then [data-bu-idx="N"].
+_ENUM_JS = """
+() => {
+  const sel = 'a,button,input,textarea,select,[role=button],[role=link],[onclick]';
+  const out = []; let i = 0;
+  for (const el of document.querySelectorAll(sel)) {
+    if (!el.getClientRects().length) continue;
+    const st = getComputedStyle(el);
+    if (st.visibility === 'hidden' || st.display === 'none') continue;
+    if (el.disabled) continue;
+    el.setAttribute('data-bu-idx', i);
+    const label = (el.innerText || el.value || el.getAttribute('placeholder') ||
+      el.getAttribute('aria-label') || el.name || '').trim().replace(/\\s+/g, ' ').slice(0, 80);
+    out.push({idx: i, tag: el.tagName.toLowerCase(), type: el.getAttribute('type') || '', label});
+    i++;
+  }
+  return out;
+}
+"""
+
+_EXPLORE_SYSTEM = """You are a web-automation agent driving a real browser.
+Each turn you receive the current page: its URL, title, a text excerpt, and a
+numbered list of interactive elements. Achieve the user's TASK by calling
+`browser_action` exactly ONCE per turn.
+Actions: click(index), fill(index,text), select(index,text), goto(url),
+scroll(text="down"|"up"), done(answer).
+Element indices are reassigned after every action — always use the indices from
+the LATEST page state, never an old one. Work efficiently; steps are limited.
+When the task is complete (or you have the answer), call done with the result in
+`answer`."""
+
+_ACTION_TOOL = {
+    "name": "browser_action",
+    "description": "Take exactly one action on the page, or finish with done.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["click", "fill", "select", "goto", "scroll", "done"],
+            },
+            "index": {"type": "integer", "description": "target element index"},
+            "text": {"type": "string", "description": "text to fill / option / scroll dir"},
+            "url": {"type": "string", "description": "url for goto"},
+            "answer": {"type": "string", "description": "final result when action=done"},
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _format_state(url: str, title: str, excerpt: str, elements: list[dict]) -> str:
+    lines = [f"URL: {url}", f"TITLE: {title}", "", "EXCERPT:", excerpt.strip()[:800]]
+    lines += ["", "ELEMENTS:"]
+    for e in elements:
+        t = f"{e['tag']}" + (f"({e['type']})" if e.get("type") else "")
+        lines.append(f"[{e['idx']}] {t} {e.get('label', '')!r}")
+    if not elements:
+        lines.append("(none found)")
+    return "\n".join(lines)
+
+
+def _apply_action(page, action: dict, timeout_ms: int) -> str:
+    """Execute one model action against the live page. Returns a short result note."""
+    verb = action.get("action")
+    idx = action.get("index")
+    sel = f'[data-bu-idx="{idx}"]'
+    if verb == "click":
+        page.click(sel, timeout=timeout_ms)
+        return f"clicked [{idx}]"
+    if verb == "fill":
+        page.fill(sel, action.get("text", ""), timeout=timeout_ms)
+        return f"filled [{idx}]"
+    if verb == "select":
+        page.select_option(sel, action.get("text", ""), timeout=timeout_ms)
+        return f"selected [{idx}]"
+    if verb == "goto":
+        page.goto(action.get("url", ""), timeout=timeout_ms, wait_until="domcontentloaded")
+        return f"went to {action.get('url')}"
+    if verb == "scroll":
+        page.mouse.wheel(0, -800 if action.get("text", "").startswith("up") else 800)
+        return "scrolled"
+    raise ValueError(f"unknown action: {verb!r}")
+
+
+def _load_agent_config():
+    """Pull the agent's LLM config from the same store the app uses."""
+    import asyncio
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from core.config_store import ConfigStore
+
+    store = ConfigStore(str(_data_dir() / "config.db"))
+    return asyncio.run(store.export_to_config()).agent
+
+
+class _Aio:
+    """Run coroutines on a persistent background loop.
+
+    Playwright's sync API holds an event loop on the main thread, so `asyncio.run`
+    there raises "cannot be called from a running event loop". One long-lived loop
+    in its own thread sidesteps that and keeps the AsyncOpenAI client bound to a
+    single loop across calls.
+    """
+
+    def __init__(self):
+        import asyncio
+        import threading
+
+        self.loop = asyncio.new_event_loop()
+        threading.Thread(target=self.loop.run_forever, daemon=True).start()
+
+    def run(self, coro):
+        import asyncio
+
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result()
+
+    def close(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+
+
+def cmd_explore(args) -> dict:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from core.llm import LLMClient
+
+    profile = _validate_profile(args.profile)
+    agent_cfg = _load_agent_config()
+    llm = LLMClient.from_agent_config(agent_cfg)
+    model = agent_cfg.model
+    aio = _Aio()
+
+    def observe(page) -> str:
+        elements = page.evaluate(_ENUM_JS)
+        excerpt = page.inner_text("body")
+        return _format_state(page.url, page.title(), excerpt, elements)
+
+    trail: list[str] = []
+    try:
+        with _Session(profile, args.headless) as s:
+            s.goto(args.url, args.timeout)
+            messages: list[dict] = [
+                {"role": "user", "content": f"TASK: {args.task}\n\n{observe(s.page)}"}
+            ]
+            answer = None
+            for _ in range(args.max_steps):
+                resp = aio.run(
+                    llm.generate(
+                        model=model,
+                        system=_EXPLORE_SYSTEM,
+                        messages=messages,
+                        tools=[_ACTION_TOOL],
+                        max_tokens=1024,
+                    )
+                )
+                if not resp.tool_calls:
+                    answer = resp.text  # model answered in prose — treat as done
+                    break
+                call = resp.tool_calls[0]
+                action = call.arguments or {}
+                # openai-compatible assistant turn carrying exactly one tool_call, so
+                # the required tool-result message pairs up cleanly. ponytail: deepseek
+                # path only; anthropic tool threading differs (this verb is deepseek).
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": resp.text or "",
+                        "tool_calls": [
+                            {
+                                "id": call.id,
+                                "type": "function",
+                                "function": {"name": call.name, "arguments": json.dumps(action)},
+                            }
+                        ],
+                    }
+                )
+                if action.get("action") == "done":
+                    answer = action.get("answer", "")
+                    trail.append("done")
+                    break
+                try:
+                    note = _apply_action(s.page, action, args.timeout)
+                except Exception as exc:
+                    note = f"error: {type(exc).__name__}: {exc}"
+                trail.append(note)
+                _settle(s.page, args.timeout)
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call.id,
+                        "content": f"{note}\n\n{observe(s.page)}",
+                    }
+                )
+
+            host = urlparse(s.page.url).netloc or "page"
+            shot = Path.home() / "Downloads" / f"clio-{host}-{int(time.time())}.png"
+            s.snapshot(shot, full_page=True)
+            return {
+                "task": args.task,
+                "answer": answer,
+                "done": answer is not None,
+                "steps": trail,
+                "url": s.page.url,
+                "screenshot": str(shot),
+            }
+    finally:
+        aio.close()
+
+
 def cmd_profiles(_args) -> dict:
     """List saved profiles with a rough 'authenticated' hint (has a cookies DB)."""
     root = _data_dir() / "browser" / "profiles"
@@ -312,6 +530,12 @@ def main() -> None:
     p_act.add_argument("--profile", default="default")
     p_act.add_argument("--steps", required=True, help="JSON array of single-key step objects")
 
+    p_exp = sub.add_parser("explore", help="LLM-driven loop: one live browser, act until done")
+    p_exp.add_argument("--url", required=True)
+    p_exp.add_argument("--task", required=True, help="what to accomplish on the site")
+    p_exp.add_argument("--profile", default="default")
+    p_exp.add_argument("--max-steps", type=int, default=12, dest="max_steps")
+
     sub.add_parser("profiles", help="List saved profiles + auth hint")
 
     args = parser.parse_args()
@@ -319,6 +543,7 @@ def main() -> None:
         "read": cmd_read,
         "screenshot": cmd_screenshot,
         "act": cmd_act,
+        "explore": cmd_explore,
         "profiles": cmd_profiles,
     }
     try:

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Browser CLI — headless web automation via Playwright (Chromium).
+
+The agent drives this with the ``run_command`` tool, same as the other CLIs.
+Three verbs:
+
+  read       Load a page and return its readable text (for JS-heavy sites).
+  screenshot Load a page and save a PNG (the agent/you can then view it).
+  act        Load a page and run an ordered list of steps (click/fill/...).
+
+``read`` and ``screenshot`` are read-only (pre-approved). ``act`` changes state
+(it clicks/submits) so it asks for approval each time — and because every command
+carries ``--url``, per-domain permission rules work out of the box, e.g.
+``run_command:python3 tools/browser.py act*github.com*`` -> ALWAYS.
+
+Persistent profiles
+  Each ``--profile NAME`` reuses a Chromium ``user-data-dir`` under
+  ``data/browser/profiles/NAME``, so cookies/sessions survive between calls. Log
+  in once (via the guided ``act`` flow), then the session is reused.
+
+Why one verb does goto+steps: every ``run_command`` is a fresh process, so page
+state (the open page, form fields) does NOT survive between calls — only cookies
+do, via the profile. So a multi-step interaction (fill user, fill pass, submit)
+must be a single ``act`` invocation.
+  # ponytail: no live browser kept between calls — each verb re-navigates.
+  # Upgrade path if iterative "click around" sessions matter: a per-profile
+  # browser daemon / the BROWSER_CDP_URL sidecar below.
+
+Sidecar (optional, off by default)
+  If ``BROWSER_CDP_URL`` is set, connect to a remote Chromium over CDP instead of
+  launching one locally. Keeps the main image lean (no bundled Chromium). With
+  CDP the profile lives on the sidecar, so ``--profile`` is informational only.
+
+Usage examples
+  python3 tools/browser.py read --url https://example.com
+  python3 tools/browser.py screenshot --url https://example.com -o shot.png
+  python3 tools/browser.py act --url https://site/login --profile acme \\
+      --steps '[{"fill":["#user","alice"]},{"fill":["#pass","s3cr3t"]},{"click":"#login"}]'
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_DESKTOP_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+)
+
+
+def _data_dir() -> Path:
+    # Mirror the convention used by the other tools (tools/skills.py).
+    return Path("/app/data") if Path("/app/data").exists() else Path("data")
+
+
+def _validate_profile(name: str) -> str:
+    value = (name or "").strip().lower()
+    if not value:
+        raise ValueError("Profile name is required")
+    if not NAME_PATTERN.match(value):
+        raise ValueError("Profile name must be lowercase letters, digits, '-' or '_'")
+    return value
+
+
+def _profile_dir(name: str) -> Path:
+    return _data_dir() / "browser" / "profiles" / name
+
+
+def _state_file(name: str) -> Path:
+    # Playwright storage_state (cookies + localStorage). The user-data-dir alone
+    # drops *session* cookies on close, so we also persist them here — and a user
+    # can drop their own exported storage_state.json here to import a live login.
+    return _profile_dir(name) / "storage_state.json"
+
+
+def _preview_path(name: str) -> Path:
+    # Latest screenshot per profile — the approval flow attaches this so the user
+    # sees the page before approving an `act`. Kept outside the user-data-dir.
+    return _data_dir() / "browser" / "last" / f"{name}.png"
+
+
+def _parse_steps(raw: str) -> list[dict]:
+    try:
+        steps = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"--steps is not valid JSON: {exc}") from exc
+    if not isinstance(steps, list) or not steps:
+        raise ValueError("--steps must be a non-empty JSON array")
+    for step in steps:
+        if not isinstance(step, dict) or len(step) != 1:
+            raise ValueError('each step must be a single-key object, e.g. {"click":"#btn"}')
+    return steps
+
+
+# -- Playwright glue ---------------------------------------------------------
+
+
+def _settle(page, timeout_ms: int) -> None:
+    """Best-effort wait for the page to stop loading (JS-heavy sites)."""
+    try:
+        page.wait_for_load_state("networkidle", timeout=min(timeout_ms, 10_000))
+    except Exception:
+        pass  # networkidle never fires on some sites (long-poll/websockets) — fine.
+
+
+def _run_step(page, step: dict, timeout_ms: int) -> str:
+    verb, arg = next(iter(step.items()))
+    if verb == "click":
+        page.click(arg, timeout=timeout_ms)
+        return f"click {arg}"
+    if verb == "fill":
+        sel, val = arg
+        page.fill(sel, val, timeout=timeout_ms)
+        return f"fill {sel}"
+    if verb == "select":
+        sel, val = arg
+        page.select_option(sel, val, timeout=timeout_ms)
+        return f"select {sel}={val}"
+    if verb == "press":
+        sel, key = arg
+        page.press(sel, key, timeout=timeout_ms)
+        return f"press {sel} {key}"
+    if verb == "wait":
+        if isinstance(arg, int | float):
+            page.wait_for_timeout(arg)
+            return f"wait {arg}ms"
+        page.wait_for_selector(arg, timeout=timeout_ms)
+        return f"wait {arg}"
+    if verb == "goto":
+        page.goto(arg, timeout=timeout_ms, wait_until="domcontentloaded")
+        return f"goto {arg}"
+    raise ValueError(f"unknown step verb: {verb!r}")
+
+
+class _Session:
+    """A Chromium page bound to a persistent profile (or a CDP sidecar)."""
+
+    def __init__(self, profile: str, headless: bool):
+        self.profile = profile
+        self.headless = headless
+        self.is_cdp = False
+        self._pw = None
+        self._ctx = None
+        self._browser = None
+        self.page = None
+
+    def __enter__(self):
+        from playwright.sync_api import sync_playwright
+
+        self._pw = sync_playwright().start()
+        self.is_cdp = bool(os.environ.get("BROWSER_CDP_URL", "").strip())
+        if self.is_cdp:
+            # ponytail: CDP profile lives on the sidecar; --profile is advisory here.
+            cdp = os.environ["BROWSER_CDP_URL"].strip()
+            self._browser = self._pw.chromium.connect_over_cdp(cdp)
+            self._ctx = (
+                self._browser.contexts[0] if self._browser.contexts else self._browser.new_context()
+            )
+        else:
+            user_data_dir = _profile_dir(self.profile) / "udd"
+            user_data_dir.mkdir(parents=True, exist_ok=True)
+            self._ctx = self._pw.chromium.launch_persistent_context(
+                str(user_data_dir),
+                headless=self.headless,
+                user_agent=_DESKTOP_UA,
+                viewport={"width": 1280, "height": 800},
+            )
+            self._restore_session()
+        self.page = self._ctx.pages[0] if self._ctx.pages else self._ctx.new_page()
+        return self
+
+    def _restore_session(self) -> None:
+        """Re-add saved cookies (incl. session cookies the user-data-dir drops)."""
+        state = _state_file(self.profile)
+        if not state.exists():
+            return
+        try:
+            cookies = json.loads(state.read_text()).get("cookies", [])
+            if cookies:
+                self._ctx.add_cookies(cookies)
+        except Exception:
+            pass  # corrupt/foreign state file — fall back to whatever the udd has.
+
+    def __exit__(self, *exc):
+        try:
+            if not self.is_cdp and self._ctx:
+                # Persist cookies + localStorage (captures session cookies too).
+                try:
+                    self._ctx.storage_state(path=str(_state_file(self.profile)))
+                except Exception:
+                    pass
+            if self.is_cdp:
+                if self._browser:
+                    self._browser.close()
+            elif self._ctx:
+                self._ctx.close()
+        finally:
+            if self._pw:
+                self._pw.stop()
+
+    def goto(self, url: str, timeout_ms: int):
+        self.page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
+        _settle(self.page, timeout_ms)
+
+    def snapshot(self, dest: Path, full_page: bool = True) -> Path:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        self.page.screenshot(path=str(dest), full_page=full_page)
+        # Mirror to the per-profile preview the approval flow reads.
+        preview = _preview_path(self.profile)
+        preview.parent.mkdir(parents=True, exist_ok=True)
+        preview.write_bytes(dest.read_bytes())
+        return dest
+
+
+# -- Verbs -------------------------------------------------------------------
+
+
+def cmd_read(args) -> dict:
+    profile = _validate_profile(args.profile)
+    with _Session(profile, args.headless) as s:
+        s.goto(args.url, args.timeout)
+        text = s.page.inner_text("body")
+        return {"url": s.page.url, "title": s.page.title(), "text": text.strip()}
+
+
+def cmd_screenshot(args) -> dict:
+    profile = _validate_profile(args.profile)
+    if args.output:
+        dest = Path(args.output)
+    else:
+        dest = _data_dir() / "browser" / "screenshots" / f"{profile}-{int(time.time())}.png"
+    with _Session(profile, args.headless) as s:
+        s.goto(args.url, args.timeout)
+        s.snapshot(dest, full_page=args.full_page)
+        return {"url": s.page.url, "title": s.page.title(), "path": str(dest)}
+
+
+def cmd_act(args) -> dict:
+    profile = _validate_profile(args.profile)
+    steps = _parse_steps(args.steps)
+    done: list[str] = []
+    with _Session(profile, args.headless) as s:
+        s.goto(args.url, args.timeout)
+        for step in steps:
+            done.append(_run_step(s.page, step, args.timeout))
+        _settle(s.page, args.timeout)
+        dest = _data_dir() / "browser" / "screenshots" / f"{profile}-{int(time.time())}.png"
+        s.snapshot(dest, full_page=True)
+        return {"url": s.page.url, "title": s.page.title(), "steps": done, "screenshot": str(dest)}
+
+
+def cmd_profiles(_args) -> dict:
+    """List saved profiles with a rough 'authenticated' hint (has a cookies DB)."""
+    root = _data_dir() / "browser" / "profiles"
+    out = []
+    if root.exists():
+        for d in sorted(p for p in root.iterdir() if p.is_dir()):
+            state = d / "storage_state.json"
+            authed = False
+            if state.exists():
+                try:
+                    authed = bool(json.loads(state.read_text()).get("cookies"))
+                except Exception:
+                    authed = False
+            out.append(
+                {
+                    "name": d.name,
+                    # ponytail: "logged in" approximated by having saved cookies.
+                    "authenticated": authed,
+                    "updated": int(state.stat().st_mtime)
+                    if state.exists()
+                    else int(d.stat().st_mtime),
+                }
+            )
+    return {"profiles": out}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Headless browser automation (Playwright).")
+    # Default headless from the env injected by core/tools.py (config.tools.browser).
+    headless_default = os.environ.get("BROWSER_HEADLESS", "1") != "0"
+    parser.add_argument(
+        "--headless", dest="headless", action="store_true", default=headless_default
+    )
+    parser.add_argument("--headed", dest="headless", action="store_false")
+    parser.add_argument("--timeout", type=int, default=30_000, help="per-action timeout (ms)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_read = sub.add_parser("read", help="Load a page, return readable text")
+    p_read.add_argument("--url", required=True)
+    p_read.add_argument("--profile", default="default")
+
+    p_shot = sub.add_parser("screenshot", help="Load a page, save a PNG")
+    p_shot.add_argument("--url", required=True)
+    p_shot.add_argument("--profile", default="default")
+    p_shot.add_argument("-o", "--output", help="output PNG path")
+    p_shot.add_argument("--full-page", action="store_true", default=True)
+    p_shot.add_argument("--viewport-only", dest="full_page", action="store_false")
+
+    p_act = sub.add_parser("act", help="Load a page and run ordered steps")
+    p_act.add_argument("--url", required=True)
+    p_act.add_argument("--profile", default="default")
+    p_act.add_argument("--steps", required=True, help="JSON array of single-key step objects")
+
+    sub.add_parser("profiles", help="List saved profiles + auth hint")
+
+    args = parser.parse_args()
+    handlers = {
+        "read": cmd_read,
+        "screenshot": cmd_screenshot,
+        "act": cmd_act,
+        "profiles": cmd_profiles,
+    }
+    try:
+        result = handlers[args.command](args)
+        print(json.dumps(result, indent=2, default=str))
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}))
+        sys.exit(1)
+    except Exception as exc:  # Playwright errors, navigation failures, etc.
+        print(json.dumps({"error": f"{type(exc).__name__}: {exc}"}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -87,6 +87,21 @@ def _preview_path(name: str) -> Path:
     return _data_dir() / "browser" / "last" / f"{name}.png"
 
 
+def _status_path() -> Path:
+    # Live one-line progress for an in-flight `explore` run. The REPL spinner tails
+    # this so the user sees step-by-step progress during the (multi-minute) loop.
+    return _data_dir() / "browser" / "last" / "explore.status"
+
+
+def _write_status(text: str) -> None:
+    try:
+        p = _status_path()
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text)
+    except OSError:
+        pass  # progress display is best-effort; never let it break a run.
+
+
 def _parse_steps(raw: str) -> list[dict]:
     try:
         steps = json.loads(raw)
@@ -520,6 +535,7 @@ def cmd_explore(args) -> dict:
         return "STEPS SO FAR: " + (", ".join(trail) if trail else "(none yet)")
 
     try:
+        _write_status("loading page…")
         with _Session(profile, args.headless) as s:
             s.goto(args.url, args.timeout)
             state, frame_map = _observe(s.page)
@@ -594,8 +610,9 @@ def cmd_explore(args) -> dict:
                         "to scroll, or click a radio/option first)."
                     )
                 )
+                tag = "" if changed else " (no change)"
+                _write_status(f"step {step + 1}/{args.max_steps} · {label}{tag}")
                 if verbose:
-                    tag = "" if changed else " (no change)"
                     print(f"[step {step}] {label}{tag}", file=sys.stderr)
                 messages.append(
                     {
@@ -619,6 +636,10 @@ def cmd_explore(args) -> dict:
             }
     finally:
         aio.close()
+        try:
+            _status_path().unlink(missing_ok=True)  # done — let the spinner revert
+        except OSError:
+            pass
 
 
 def cmd_profiles(_args) -> dict:

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -93,6 +93,36 @@ def _status_path() -> Path:
     return _data_dir() / "browser" / "last" / "explore.status"
 
 
+def _shot_dir() -> Path:
+    """Where saved screenshots go.
+
+    Local dev/REPL: ~/Downloads so you can open the file. Server/Docker (/app/data
+    present): the data volume instead — nobody browses the container's home, and
+    Downloads isn't mounted, so a Downloads default would just bloat the container
+    layer invisibly.
+    """
+    downloads = Path.home() / "Downloads"
+    if not Path("/app/data").exists() and downloads.is_dir():
+        return downloads
+    return _data_dir() / "browser" / "screenshots"
+
+
+def _prune_old_shots(max_age_h: int = 24) -> None:
+    """Delete data-dir screenshots older than max_age_h so a long-running server
+    doesn't accumulate PNGs forever. Best-effort; only touches our own dir, never
+    a user's ~/Downloads."""
+    cutoff = time.time() - max_age_h * 3600
+    d = _data_dir() / "browser" / "screenshots"
+    if not d.is_dir():
+        return
+    for p in d.glob("*.png"):
+        try:
+            if p.stat().st_mtime < cutoff:
+                p.unlink()
+        except OSError:
+            pass
+
+
 def _write_status(text: str) -> None:
     try:
         p = _status_path()
@@ -260,12 +290,14 @@ def cmd_read(args) -> dict:
 
 def cmd_screenshot(args) -> dict:
     profile = _validate_profile(args.profile)
+    _prune_old_shots()
     if args.output:
         dest = Path(args.output)
     else:
-        # Default to ~/Downloads with a spottable name so a REPL user can find it.
+        # Spottable name in the env-appropriate dir (~/Downloads locally, the data
+        # volume on a server — see _shot_dir).
         host = urlparse(args.url).netloc or "page"
-        dest = Path.home() / "Downloads" / f"clio-{host}-{int(time.time())}.png"
+        dest = _shot_dir() / f"clio-{host}-{int(time.time())}.png"
     with _Session(profile, args.headless) as s:
         s.goto(args.url, args.timeout)
         s.snapshot(dest, full_page=args.full_page)
@@ -274,6 +306,7 @@ def cmd_screenshot(args) -> dict:
 
 def cmd_act(args) -> dict:
     profile = _validate_profile(args.profile)
+    _prune_old_shots()
     steps = _parse_steps(args.steps)
     done: list[str] = []
     with _Session(profile, args.headless) as s:
@@ -549,6 +582,7 @@ def cmd_explore(args) -> dict:
     from core.llm import LLMClient
 
     profile = _validate_profile(args.profile)
+    _prune_old_shots()
     agent_cfg = _load_agent_config()
     llm = LLMClient.from_agent_config(agent_cfg)
     # Each step is a small mechanical action pick over rich state — high "thinking"
@@ -669,7 +703,7 @@ def cmd_explore(args) -> dict:
                     break
 
             host = urlparse(s.page.url).netloc or "page"
-            shot = Path.home() / "Downloads" / f"clio-{host}-{int(time.time())}.png"
+            shot = _shot_dir() / f"clio-{host}-{int(time.time())}.png"
             s.snapshot(shot, full_page=True)
             # Return only what the calling agent needs — the full step trail is
             # debugging noise in its context (use BROWSER_EXPLORE_VERBOSE to see it).

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -50,10 +50,16 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-_DESKTOP_UA = (
+_DEFAULT_UA = (
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
 )
+
+
+def _user_agent() -> str:
+    # BROWSER_USER_AGENT (from config.tools.browser.user_agent) overrides the
+    # built-in default, so the UA is choosable without code changes.
+    return os.environ.get("BROWSER_USER_AGENT", "").strip() or _DEFAULT_UA
 
 
 def _data_dir() -> Path:
@@ -214,12 +220,16 @@ class _Session:
 
         self._pw = sync_playwright().start()
         self.is_cdp = bool(os.environ.get("BROWSER_CDP_URL", "").strip())
+        ua = _user_agent()
         if self.is_cdp:
             # ponytail: CDP profile lives on the sidecar; --profile is advisory here.
             cdp = os.environ["BROWSER_CDP_URL"].strip()
             self._browser = self._pw.chromium.connect_over_cdp(cdp)
+            # A reused sidecar context keeps its own UA; only a fresh one can take ours.
             self._ctx = (
-                self._browser.contexts[0] if self._browser.contexts else self._browser.new_context()
+                self._browser.contexts[0]
+                if self._browser.contexts
+                else self._browser.new_context(user_agent=ua)
             )
         else:
             user_data_dir = _profile_dir(self.profile) / "udd"
@@ -227,7 +237,7 @@ class _Session:
             self._ctx = self._pw.chromium.launch_persistent_context(
                 str(user_data_dir),
                 headless=self.headless,
-                user_agent=_DESKTOP_UA,
+                user_agent=ua,
                 viewport={"width": 1280, "height": 800},
             )
             self._restore_session()

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -506,6 +506,10 @@ def cmd_explore(args) -> dict:
     profile = _validate_profile(args.profile)
     agent_cfg = _load_agent_config()
     llm = LLMClient.from_agent_config(agent_cfg)
+    # Each step is a small mechanical action pick over rich state — high "thinking"
+    # just makes every step slow (and the whole loop time out). Force it low so a
+    # 25-step booking finishes in the time budget.
+    llm.thinking_level = "low"
     model = agent_cfg.model
     aio = _Aio()
     verbose = bool(os.environ.get("BROWSER_EXPLORE_VERBOSE"))
@@ -673,7 +677,7 @@ def main() -> None:
     p_exp.add_argument("--url", required=True)
     p_exp.add_argument("--task", required=True, help="what to accomplish on the site")
     p_exp.add_argument("--profile", default="default")
-    p_exp.add_argument("--max-steps", type=int, default=12, dest="max_steps")
+    p_exp.add_argument("--max-steps", type=int, default=35, dest="max_steps")
 
     sub.add_parser("profiles", help="List saved profiles + auth hint")
 

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -608,11 +608,12 @@ def cmd_explore(args) -> dict:
             host = urlparse(s.page.url).netloc or "page"
             shot = Path.home() / "Downloads" / f"clio-{host}-{int(time.time())}.png"
             s.snapshot(shot, full_page=True)
+            # Return only what the calling agent needs — the full step trail is
+            # debugging noise in its context (use BROWSER_EXPLORE_VERBOSE to see it).
             return {
-                "task": args.task,
                 "answer": answer,
                 "done": answer is not None,
-                "steps": trail,
+                "steps_taken": len(trail),
                 "url": s.page.url,
                 "screenshot": str(shot),
             }

--- a/uv.lock
+++ b/uv.lock
@@ -451,6 +451,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/fb/011c7c717213182caf78084a9bea51c8590b0afda98001f69d9f853a495b/greenlet-3.3.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:bd59acd8529b372775cd0fcbc5f420ae20681c5b045ce25bd453ed8455ab99b5", size = 275737, upload-time = "2026-01-23T15:32:16.889Z" },
     { url = "https://files.pythonhosted.org/packages/41/2e/a3a417d620363fdbb08a48b1dd582956a46a61bf8fd27ee8164f9dfe87c2/greenlet-3.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b31c05dd84ef6871dd47120386aed35323c944d86c3d91a17c4b8d23df62f15b", size = 646422, upload-time = "2026-01-23T16:01:00.354Z" },
     { url = "https://files.pythonhosted.org/packages/b4/09/c6c4a0db47defafd2d6bab8ddfe47ad19963b4e30f5bed84d75328059f8c/greenlet-3.3.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:02925a0bfffc41e542c70aa14c7eda3593e4d7e274bfcccca1827e6c0875902e", size = 658219, upload-time = "2026-01-23T16:05:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/89/b95f2ddcc5f3c2bc09c8ee8d77be312df7f9e7175703ab780f2014a0e781/greenlet-3.3.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3e0f3878ca3a3ff63ab4ea478585942b53df66ddde327b59ecb191b19dbbd62d", size = 671455, upload-time = "2026-01-23T16:15:57.232Z" },
     { url = "https://files.pythonhosted.org/packages/80/38/9d42d60dffb04b45f03dbab9430898352dba277758640751dc5cc316c521/greenlet-3.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34a729e2e4e4ffe9ae2408d5ecaf12f944853f40ad724929b7585bca808a9d6f", size = 660237, upload-time = "2026-01-23T15:32:53.967Z" },
     { url = "https://files.pythonhosted.org/packages/96/61/373c30b7197f9e756e4c81ae90a8d55dc3598c17673f91f4d31c3c689c3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:aec9ab04e82918e623415947921dea15851b152b822661cce3f8e4393c3df683", size = 1615261, upload-time = "2026-01-23T16:04:25.066Z" },
     { url = "https://files.pythonhosted.org/packages/fd/d3/ca534310343f5945316f9451e953dcd89b36fe7a19de652a1dc5a0eeef3f/greenlet-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:71c767cf281a80d02b6c1bdc41c9468e1f5a494fb11bc8688c360524e273d7b1", size = 1683719, upload-time = "2026-01-23T15:33:50.61Z" },
@@ -459,6 +460,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/24/cbbec49bacdcc9ec652a81d3efef7b59f326697e7edf6ed775a5e08e54c2/greenlet-3.3.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:3e63252943c921b90abb035ebe9de832c436401d9c45f262d80e2d06cc659242", size = 282706, upload-time = "2026-01-23T15:33:05.525Z" },
     { url = "https://files.pythonhosted.org/packages/86/2e/4f2b9323c144c4fe8842a4e0d92121465485c3c2c5b9e9b30a52e80f523f/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76e39058e68eb125de10c92524573924e827927df5d3891fbc97bd55764a8774", size = 651209, upload-time = "2026-01-23T16:01:01.517Z" },
     { url = "https://files.pythonhosted.org/packages/d9/87/50ca60e515f5bb55a2fbc5f0c9b5b156de7d2fc51a0a69abc9d23914a237/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9f9d5e7a9310b7a2f416dd13d2e3fd8b42d803968ea580b7c0f322ccb389b97", size = 654300, upload-time = "2026-01-23T16:05:32.199Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/25/c51a63f3f463171e09cb586eb64db0861eb06667ab01a7968371a24c4f3b/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9721549a95db96689458a1e0ae32412ca18776ed004463df3a9299c1b257ab", size = 662574, upload-time = "2026-01-23T16:15:58.364Z" },
     { url = "https://files.pythonhosted.org/packages/1d/94/74310866dfa2b73dd08659a3d18762f83985ad3281901ba0ee9a815194fb/greenlet-3.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92497c78adf3ac703b57f1e3813c2d874f27f71a178f9ea5887855da413cd6d2", size = 653842, upload-time = "2026-01-23T15:32:55.671Z" },
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
@@ -858,6 +860,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "playwright" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -891,6 +894,7 @@ requires-dist = [
     { name = "jinja2" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "playwright" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "python-multipart", specifier = ">=0.0.22" },
@@ -1080,6 +1084,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1226,6 +1249,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/a1/ae859ffac5a3338a66b74c5e29e244fd3a3cc483c89feaf9f56c39898d75/pydantic_settings-2.13.0.tar.gz", hash = "sha256:95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe", size = 222450, upload-time = "2026-02-15T12:11:23.476Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/1a/dd1b9d7e627486cf8e7523d09b70010e05a4bc41414f4ae6ce184cf0afb6/pydantic_settings-2.13.0-py3-none-any.whl", hash = "sha256:d67b576fff39cd086b595441bf9c75d4193ca9c0ed643b90360694d0f1240246", size = 58429, upload-time = "2026-02-15T12:11:22.133Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements #16 — an optional, quarantined headless-browser capability, disabled by default, in the existing "Python orchestrator + CLI tool" shape (same as the `gh` integration).

## What's included
- **`tools/browser.py`** — a `run_command` CLI with verbs `read`, `screenshot`, `act`, `profiles` (Playwright/Chromium).
  - Persistent per-`--profile` sessions via a Chromium `user-data-dir` **plus** a `storage_state.json`. The user-data-dir alone silently drops *session* cookies on close (verified), so we layer storage_state to make "log in once, reuse the session" actually reliable. A user can also drop an exported `storage_state.json` to import a live login.
  - Each `run_command` is a fresh process, so `act` does goto+steps in one call (a login = fill user, fill pass, submit).
  - Optional `BROWSER_CDP_URL` connects to a sidecar Chromium (lean core); default launches locally so the **local REPL works with no extra services**.
- **Gating** (`core/config.py`, `core/tools.py`) — `BrowserToolConfig` (off by default); advertised to the model + env-wired only when enabled. Invisible when disabled.
- **Permissions** (`core/permissions.py`) — `read`/`screenshot`/`profiles` = ALWAYS, `act` = ASK. Per-domain rules work natively because every command carries `--url` (e.g. `run_command:*browser.py act*github.com*` → ALWAYS).
- **Mobile follow-along** (`core/agent.py`, `channels/telegram.py`) — a browser `act` approval attaches a screenshot of the page next to the Approve/Deny buttons (Telegram `send_photo`); REPL prints the path; WhatsApp left as a follow-up.
- **Admin UI** (`partials/tools.html`, `api/admin.py`) — responsive browser card under the **Tools** tab: enable toggle, headless toggle, sidecar CDP URL, a what-works/what-may-be-blocked note, a **Test** action, a saved-profiles list with logged-in/no-session badges, and a per-domain action-rule editor (Allow/Ask/Block) backed by the permission engine.
- **Wizard** — optional `browser` step between `search` and `admin`.
- **Docs/infra** — `skills/browser.md`; `INSTALL_BROWSER` Dockerfile build arg (lean by default); documented sidecar compose example; README entries.

## Decisions (from the issue's open questions)
- **Login flow: (b) guided remote login** — agent screenshots the login, user supplies credentials + approves from their phone, session persists. Credentials are never stored (secrets vault is out of scope).
- **Runtime: inline Playwright by default** — chosen so local-REPL testing works out of the box; `BROWSER_CDP_URL` is a cheap escape hatch to the lean-core sidecar.

## Acceptance criteria
- ✅ Load + read/screenshot a page headlessly (verified against example.com).
- ✅ Authenticated action via a persisted profile (verified: a session cookie survives across separate processes via a named profile).
- ✅ First-time login through a documented, mobile-followable flow (guided login + screenshot-in-approval); admin browser settings usable at phone width.
- ✅ Invisible when disabled; writes require approval when enabled.

## Verification
- 342 tests pass (`uv run pytest`), incl. new unit + admin/wizard integration tests.
- Live: `read`/`screenshot` example.com; cross-process cookie persistence; the admin **Test** route end-to-end (HTTP → subprocess → Chromium → `{ok, title:"Example Domain"}`).

## Notes / deferrals
- Screenshot *reading* on non-vision models depends on the separate vision-fallback work.
- No live browser kept between calls (each verb re-navigates); upgrade path = per-profile daemon / the CDP sidecar. Marked with `ponytail:` comments.
- The web admin CSS is rebuilt from templates at Docker build (`@source`); for local non-Docker web UI run `make css`. The REPL path needs no CSS.
