### PR TITLE
Secrets vault: encrypted two-vault backend with per-persona access (#19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ ADMIN_API_KEY=
 # from the setup wizard), and ${vault:NAME} config references fall back to env.
 # Any string works (a passphrase is hashed to a key); a generated Fernet key is
 # used as-is. The persona/login vault is keyed by your admin password instead.
+#
+# Generate a strong key (no wizard needed) and paste it after the '=' below:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# In Docker:  docker compose run --rm mpa python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# Set it once and keep it — rotating it makes existing infra-vault secrets unreadable.
 #MPA_MASTER_KEY=
 # Base URL used in secure "provide a secret" links sent to you (defaults to
 # http://localhost:<admin port>). Set to your reachable admin URL.

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@ TELEGRAM_ALLOWED_USER_IDS=
 WHATSAPP_ALLOWED_NUMBERS=
 ADMIN_API_KEY=
 
+# Secrets vault (issue #19) — machine key for the *infra* vault.
+# Optional. If unset, MPA looks for a keyfile at data/master.key (auto-generated
+# from the setup wizard), and ${vault:NAME} config references fall back to env.
+# Any string works (a passphrase is hashed to a key); a generated Fernet key is
+# used as-is. The persona/login vault is keyed by your admin password instead.
+#MPA_MASTER_KEY=
+# Base URL used in secure "provide a secret" links sent to you (defaults to
+# http://localhost:<admin port>). Set to your reachable admin URL.
+#MPA_BASE_URL=
+
 # Web search (Tavily) — get a free API key at https://app.tavily.com
 TAVILY_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Voice** — Speech-to-text (faster-whisper) and text-to-speech (edge-tts)
 - **Web search** — Tavily integration for real-time information
 - **Browser automation** — Optional headless browser (Playwright) to read JS-heavy pages and act on sites, with persistent logged-in profiles and per-domain approval (off by default)
+- **Secrets vault** — Encrypted, two-tier secrets store: infrastructure keys (machine-key sealed, served into config via `${vault:NAME}`) and per-persona login/agent secrets (admin-password sealed, used by reference as `{{secret:NAME}}` in commands — values never enter the model's context). Bitwarden import + secure-link credential requests
 - **Permissions** — Glob-pattern rules (ALWAYS/ASK/NEVER) with interactive Telegram approval for write actions
 - **Admin UI** — Web dashboard for configuration, skills editing, memory inspection, job management, and agent lifecycle control
 - **Skills** — Teach the agent new capabilities by writing markdown files instead of code

--- a/api/admin.py
+++ b/api/admin.py
@@ -1603,6 +1603,7 @@ def create_admin_app(
             memories=memories,
             reflections=reflections,
             decomposed_goal=decomposed_goal,
+            secrets_available=secret_store is not None,
             include_memories=body.include_memories,
             include_reflections=body.include_reflections,
         )

--- a/api/admin.py
+++ b/api/admin.py
@@ -2958,10 +2958,14 @@ def create_admin_app(
         expires_at, max_uses = _duration_fields(
             str(form.get("duration", "forever")), str(form.get("until", ""))
         )
+        # "This persona only" with no requesting persona (base agent) is incoherent —
+        # it would orphan the secret (no owner, no grant, not shared → never resolvable).
+        # Treat it as global so the agent that asked can actually use it.
+        shared = scope == "all" or (scope == "this" and not req["persona"])
         await secret_store.set_secret(
             name,
             value,
-            shared=(scope == "all"),
+            shared=shared,
             owner=f"persona:{req['persona']}" if req["persona"] else "",
             description=req["reason"][:200],
             expires_at=expires_at,

--- a/api/admin.py
+++ b/api/admin.py
@@ -1643,13 +1643,19 @@ def create_admin_app(
             return {"ok": False, "error": "Both current and new passwords are required."}
         if not await config_store.verify_admin_password(current):
             return {"ok": False, "error": "Current password is incorrect."}
-        await config_store.set_admin_password(new_password)
-        # Re-wrap the persona vault DEK under the new password (preserves secrets).
+        # Re-wrap the persona vault DEK FIRST; only advance the admin password if
+        # it succeeds, so a rewrap failure can never orphan the vault (new auth
+        # password but DEK still wrapped under the old one).
         if secret_store is not None:
             try:
                 await secret_store.rotate_password(current, new_password)
             except Exception:
-                log.exception("Failed to rotate persona vault password")
+                log.exception("Vault rewrap failed; aborting password change")
+                return {
+                    "ok": False,
+                    "error": "Could not re-encrypt the secrets vault; password unchanged.",
+                }
+        await config_store.set_admin_password(new_password)
         return {"ok": True, "token": new_password}
 
     @app.post("/config/delete", dependencies=[Depends(auth)])
@@ -3032,6 +3038,11 @@ def create_admin_app(
     async def setup_save_secrets(request: Request) -> HTMLResponse:
         from core.config_store import SETUP_STEPS
         from core.vault import generate_and_save_machine_key
+
+        # Wizard-only endpoint: refuse once setup is complete so it can't be used
+        # post-setup to (re)generate a machine key or migrate config.
+        if await config_store.is_setup_complete():
+            raise HTTPException(403, "Setup already complete")
 
         form = await request.form()
         action = str(form.get("action", ""))

--- a/api/admin.py
+++ b/api/admin.py
@@ -45,6 +45,7 @@ from core.wacli import WacliManager
 
 if TYPE_CHECKING:
     from core.agent import AgentCore
+    from core.secret_store import SecretStore
     from core.skills import SkillsStore
 
 log = logging.getLogger(__name__)
@@ -191,6 +192,30 @@ async def _wizard_step_context(step: str, config_store: ConfigStore) -> dict[str
         val = await config_store.get("admin.password_hash")
         if val:
             ctx["admin_key"] = ""
+    elif step == "secrets":
+        import os as _os
+
+        from core.vault import load_machine_key
+
+        ctx["machine_key_present"] = bool(load_machine_key())  # type: ignore[assignment]
+        ctx["env_seed_present"] = bool(  # type: ignore[assignment]
+            _os.environ.get("ADMIN_PASSWORD") or _os.environ.get("ADMIN_API_KEY")
+        )
+        detected = []
+        for cfg_key in (
+            "agent.anthropic_api_key",
+            "agent.openai_api_key",
+            "agent.google_api_key",
+            "agent.grok_api_key",
+            "agent.deepseek_api_key",
+            "channels.telegram.bot_token",
+            "search.api_key",
+            "tools.gh.token",
+        ):
+            val = await config_store.get(cfg_key)
+            if val and not val.startswith("${"):
+                detected.append(cfg_key)
+        ctx["detected_secrets"] = detected  # type: ignore[assignment]
     return ctx
 
 
@@ -481,8 +506,13 @@ class PromptPreviewIn(BaseModel):
 _bearer = HTTPBearer(auto_error=False)
 
 
-def _make_auth_dependency(config_store: ConfigStore):
-    """Return a FastAPI dependency that validates the admin API key."""
+def _make_auth_dependency(config_store: ConfigStore, secret_store: SecretStore | None = None):
+    """Return a FastAPI dependency that validates the admin API key.
+
+    On a successful auth, if the persona secrets vault is still locked, the
+    bearer password is used to unseal it (issue #19) — so the first admin page
+    view after a boot caches the DEK for the agent runtime.
+    """
 
     async def _check_auth(
         credentials: HTTPAuthorizationCredentials | None = Depends(_bearer),
@@ -502,6 +532,13 @@ def _make_auth_dependency(config_store: ConfigStore):
         if not await config_store.verify_admin_password(credentials.credentials):
             raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
+        # Auth passed — unseal the persona vault if it isn't already.
+        if secret_store is not None and not secret_store.persona_unsealed():
+            try:
+                await secret_store.unseal_persona(credentials.credentials)
+            except Exception:
+                log.exception("Failed to unseal persona vault on auth")
+
     return _check_auth
 
 
@@ -514,6 +551,7 @@ def create_admin_app(
     agent_state: AgentState,
     config_store: ConfigStore,
     lifespan=None,
+    secret_store: SecretStore | None = None,
 ) -> tuple[FastAPI, object]:
     wacli = WacliManager()
 
@@ -541,7 +579,7 @@ def create_admin_app(
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
-    auth = _make_auth_dependency(config_store)
+    auth = _make_auth_dependency(config_store, secret_store)
 
     # Keys managed by dedicated tabs — excluded from the generic Config tab.
     _IDENTITY_KEYS = {
@@ -1606,6 +1644,12 @@ def create_admin_app(
         if not await config_store.verify_admin_password(current):
             return {"ok": False, "error": "Current password is incorrect."}
         await config_store.set_admin_password(new_password)
+        # Re-wrap the persona vault DEK under the new password (preserves secrets).
+        if secret_store is not None:
+            try:
+                await secret_store.rotate_password(current, new_password)
+            except Exception:
+                log.exception("Failed to rotate persona vault password")
         return {"ok": True, "token": new_password}
 
     @app.post("/config/delete", dependencies=[Depends(auth)])
@@ -2468,6 +2512,13 @@ def create_admin_app(
         if values:
             await config_store.set_many(values)
             log.info("Setup step %r: saved %d values", step, len(values))
+            # Initialise the persona vault DEK from the admin password set in the
+            # wizard (the plaintext is available here, before it is hashed at boot).
+            if secret_store is not None and values.get("admin.api_key"):
+                try:
+                    await secret_store.ensure_wrapped_dek(values["admin.api_key"])
+                except Exception:
+                    log.exception("Failed to initialise persona vault DEK from wizard")
 
         if step not in SETUP_STEPS:
             raise HTTPException(400, f"Unknown step: {step}")
@@ -2714,6 +2765,287 @@ def create_admin_app(
             "error": "Autodiscovery is only available for Anthropic — "
             "enter the effort value manually for this provider.",
         }
+
+    # ── Secrets vault (issue #19) ──────────────────────────────────────
+    # Config keys that hold a single infra secret, with their vault names. Used
+    # by the wizard's "import from .env" step (provider blobs are not auto-moved).
+    _INFRA_MIGRATE = {
+        "agent.anthropic_api_key": "ANTHROPIC_API_KEY",
+        "agent.openai_api_key": "OPENAI_API_KEY",
+        "agent.google_api_key": "GOOGLE_API_KEY",
+        "agent.grok_api_key": "GROK_API_KEY",
+        "agent.deepseek_api_key": "DEEPSEEK_API_KEY",
+        "channels.telegram.bot_token": "TELEGRAM_BOT_TOKEN",
+        "search.api_key": "TAVILY_API_KEY",
+        "tools.gh.token": "GH_TOKEN",
+    }
+
+    def _duration_fields(duration: str, until: str) -> tuple[str | None, int | None]:
+        """Map a UI duration choice to (expires_at, max_uses)."""
+        if duration == "once":
+            return None, 1
+        if duration == "until" and until.strip():
+            return f"{until.strip()}T23:59:59+00:00", None
+        return None, None
+
+    async def _grant_personae(names: list[str], secret_name: str, grant: bool = True) -> None:
+        persona_store = await _persona_store_from_config(config_store)
+        for pname in names:
+            pname = pname.strip()
+            if not pname:
+                continue
+            p = await persona_store.get(pname)
+            if not p:
+                continue
+            s = set(p.secrets)
+            s.add(secret_name) if grant else s.discard(secret_name)
+            p.secrets = sorted(s)
+            await persona_store.upsert(p)
+
+    async def _secrets_ctx() -> dict:
+        persona_store = await _persona_store_from_config(config_store)
+        personae = await persona_store.list_personae()
+        meta = await secret_store.list_secret_meta()
+        for m in meta:
+            holders = [p.name for p in personae if m["name"] in p.secrets]
+            m["holders"] = holders
+            m["personae"] = "all" if m["shared"] else (", ".join(holders) if holders else "—")
+        return {
+            "configured": True,
+            "unsealed": secret_store.persona_unsealed(),
+            "infra_available": secret_store.infra.available,
+            "secrets": meta,
+            "infra": await secret_store.list_infra_names(),
+            "personae": [p.name for p in personae],
+        }
+
+    def _no_vault_partial() -> HTMLResponse:
+        return _render_partial("partials/secrets.html", configured=False)
+
+    @app.get("/partials/secrets", response_class=HTMLResponse, dependencies=[Depends(auth)])
+    async def partial_secrets() -> HTMLResponse:
+        if secret_store is None:
+            return _no_vault_partial()
+        return _render_partial("partials/secrets.html", **(await _secrets_ctx()))
+
+    @app.post("/admin/secrets", response_class=HTMLResponse, dependencies=[Depends(auth)])
+    async def add_secret(request: Request) -> HTMLResponse:
+        if secret_store is None:
+            return _no_vault_partial()
+        form = await request.form()
+        name = str(form.get("name", "")).strip()
+        value = str(form.get("value", ""))
+        from core.secret_store import valid_name
+
+        if not valid_name(name):
+            ctx = await _secrets_ctx()
+            ctx["error"] = "Invalid name — use letters, digits, _ - : only."
+            return _render_partial("partials/secrets.html", **ctx)
+        if not secret_store.persona_unsealed():
+            ctx = await _secrets_ctx()
+            ctx["error"] = "Vault is locked — reload the page to unlock it with your password."
+            return _render_partial("partials/secrets.html", **ctx)
+        scope = str(form.get("scope", "this"))
+        personae = str(form.get("personae", "")).replace("\n", ",").split(",")
+        expires_at, max_uses = _duration_fields(
+            str(form.get("duration", "forever")), str(form.get("until", ""))
+        )
+        await secret_store.set_secret(
+            name,
+            value,
+            shared=(scope == "all"),
+            description=str(form.get("description", "")),
+            expires_at=expires_at,
+            max_uses=max_uses,
+        )
+        if scope == "personae":
+            await _grant_personae(personae, name)
+        return _render_partial("partials/secrets.html", **(await _secrets_ctx()))
+
+    @app.post("/admin/secrets/delete", response_class=HTMLResponse, dependencies=[Depends(auth)])
+    async def delete_secret(request: Request) -> HTMLResponse:
+        if secret_store is None:
+            return _no_vault_partial()
+        form = await request.form()
+        await secret_store.delete_secret(str(form.get("name", "")).strip())
+        return _render_partial("partials/secrets.html", **(await _secrets_ctx()))
+
+    @app.post("/admin/secrets/grant", response_class=HTMLResponse, dependencies=[Depends(auth)])
+    async def grant_secret(request: Request) -> HTMLResponse:
+        if secret_store is None:
+            return _no_vault_partial()
+        form = await request.form()
+        name = str(form.get("name", "")).strip()
+        persona = str(form.get("persona", "")).strip()
+        grant = str(form.get("grant", "true")) == "true"
+        await _grant_personae([persona], name, grant=grant)
+        return _render_partial("partials/secrets.html", **(await _secrets_ctx()))
+
+    @app.post("/admin/secrets/infra", response_class=HTMLResponse, dependencies=[Depends(auth)])
+    async def add_infra_secret(request: Request) -> HTMLResponse:
+        if secret_store is None:
+            return _no_vault_partial()
+        form = await request.form()
+        name = str(form.get("name", "")).strip()
+        from core.secret_store import valid_name
+
+        if not secret_store.infra.available:
+            ctx = await _secrets_ctx()
+            ctx["error"] = "No machine key configured (set MPA_MASTER_KEY or generate one)."
+            return _render_partial("partials/secrets.html", **ctx)
+        if not valid_name(name):
+            ctx = await _secrets_ctx()
+            ctx["error"] = "Invalid infra secret name."
+            return _render_partial("partials/secrets.html", **ctx)
+        await secret_store.set_infra_secret(
+            name, str(form.get("value", "")), str(form.get("description", ""))
+        )
+        return _render_partial("partials/secrets.html", **(await _secrets_ctx()))
+
+    # -- Secure-link credential fill flow --
+    @app.get("/vault/request/{token}", dependencies=[Depends(auth)])
+    async def vault_request_detail(token: str) -> dict:
+        if secret_store is None:
+            raise HTTPException(404, "Vault not configured")
+        req = await secret_store.get_request(token)
+        if not req:
+            raise HTTPException(404, "Request not found or expired")
+        return {
+            "name": req["name"],
+            "reason": req["reason"],
+            "persona": req["persona"],
+            "suggested_scope": req["suggested_scope"],
+        }
+
+    @app.get("/vault/fill/{token}", response_class=HTMLResponse)
+    async def vault_fill_page(token: str) -> HTMLResponse:
+        # The page shell is public; details + submit require admin auth (the
+        # page fetches them with the stored bearer, like the rest of the UI).
+        return _render("vault_fill.html", token=token)
+
+    @app.post("/vault/fill/{token}", dependencies=[Depends(auth)])
+    async def vault_fill_submit(token: str, request: Request) -> dict:
+        if secret_store is None:
+            raise HTTPException(404, "Vault not configured")
+        req = await secret_store.get_request(token)
+        if not req:
+            raise HTTPException(404, "Request not found or expired")
+        if not secret_store.persona_unsealed():
+            return {"ok": False, "error": "Vault is locked."}
+        form = await request.form()
+        name = req["name"]
+        # Structured if any login field beyond a bare value/password is present.
+        fields = {
+            k: str(form.get(k, ""))
+            for k in ("username", "password", "url", "totp")
+            if str(form.get(k, "")).strip()
+        }
+        bare = str(form.get("value", ""))
+        value: str | dict
+        if fields and not (len(fields) == 1 and "password" in fields and not bare):
+            value = fields
+        else:
+            value = bare or fields.get("password", "")
+        scope = str(form.get("scope", "this"))
+        personae = str(form.get("personae", "")).replace("\n", ",").split(",")
+        expires_at, max_uses = _duration_fields(
+            str(form.get("duration", "forever")), str(form.get("until", ""))
+        )
+        await secret_store.set_secret(
+            name,
+            value,
+            shared=(scope == "all"),
+            owner=f"persona:{req['persona']}" if req["persona"] else "",
+            description=req["reason"][:200],
+            expires_at=expires_at,
+            max_uses=max_uses,
+        )
+        if scope == "personae":
+            await _grant_personae(personae, name)
+        elif scope == "this" and req["persona"]:
+            await _grant_personae([req["persona"]], name)
+        await secret_store.resolve_request(token)
+        return {"ok": True, "name": name}
+
+    # -- Bitwarden import --
+    @app.post(
+        "/admin/secrets/import/parse", response_class=HTMLResponse, dependencies=[Depends(auth)]
+    )
+    async def import_parse(request: Request) -> HTMLResponse:
+        if secret_store is None:
+            return _no_vault_partial()
+        from core.secret_store import parse_bitwarden_export
+
+        form = await request.form()
+        upload = form.get("file")
+        try:
+            raw = await upload.read() if hasattr(upload, "read") else str(upload).encode()
+            data = json.loads(raw)
+            items = parse_bitwarden_export(data)
+        except Exception as exc:
+            ctx = await _secrets_ctx()
+            ctx["error"] = f"Could not parse export: {exc}"
+            return _render_partial("partials/secrets.html", **ctx)
+        persona_store = await _persona_store_from_config(config_store)
+        return _render_partial(
+            "partials/secrets_import.html",
+            items=items,
+            personae=[p.name for p in await persona_store.list_personae()],
+        )
+
+    @app.post(
+        "/admin/secrets/import/commit", response_class=HTMLResponse, dependencies=[Depends(auth)]
+    )
+    async def import_commit(request: Request) -> HTMLResponse:
+        if secret_store is None:
+            return _no_vault_partial()
+        if not secret_store.persona_unsealed():
+            ctx = await _secrets_ctx()
+            ctx["error"] = "Vault is locked."
+            return _render_partial("partials/secrets.html", **ctx)
+        form = await request.form()
+        selected = form.getlist("selected")
+        scope = str(form.get("scope", "this"))
+        personae = str(form.get("personae", "")).replace("\n", ",").split(",")
+        count = 0
+        for name in selected:
+            value = {
+                "username": str(form.get(f"username__{name}", "")),
+                "password": str(form.get(f"password__{name}", "")),
+                "url": str(form.get(f"url__{name}", "")),
+                "totp": str(form.get(f"totp__{name}", "")),
+            }
+            value = {k: v for k, v in value.items() if v}
+            if not value:
+                continue
+            store_val = value if len(value) > 1 else next(iter(value.values()))
+            await secret_store.set_secret(name, store_val, shared=(scope == "all"))
+            if scope == "personae":
+                await _grant_personae(personae, name)
+            count += 1
+        ctx = await _secrets_ctx()
+        ctx["flash"] = f"Imported {count} secret(s)."
+        return _render_partial("partials/secrets.html", **ctx)
+
+    # -- Wizard: master key + import-from-.env --
+    @app.post("/setup/step/secrets")
+    async def setup_save_secrets(request: Request) -> HTMLResponse:
+        from core.config_store import SETUP_STEPS
+        from core.vault import generate_and_save_machine_key
+
+        form = await request.form()
+        action = str(form.get("action", ""))
+        if action == "generate" and secret_store is not None:
+            key = generate_and_save_machine_key()
+            secret_store.infra = type(secret_store.infra)(key)  # reload infra vault
+        elif action == "import" and secret_store is not None and secret_store.infra.available:
+            for cfg_key, vname in _INFRA_MIGRATE.items():
+                val = await config_store.get(cfg_key)
+                if val and not val.startswith("${"):
+                    await secret_store.set_infra_secret(vname, val, f"migrated from {cfg_key}")
+                    await config_store.set(cfg_key, f"${{vault:{vname}}}")
+        ctx = await _wizard_step_context("secrets", config_store)
+        return _render_wizard_step("secrets", SETUP_STEPS, ctx)
 
     return app, auth
 

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -112,6 +112,10 @@
             @click="select('email')">
       Email
     </button>
+    <button class="tab-link" :class="tab === 'secrets' && 'tab-link-active'"
+            @click="select('secrets')">
+      Secrets
+    </button>
     <button class="tab-link" :class="tab === 'admin' && 'tab-link-active'"
             @click="select('admin')">
       Admin
@@ -695,6 +699,7 @@
       calendars: '/partials/calendars',
       contacts: '/partials/contacts',
       email: '/partials/email',
+      secrets: '/partials/secrets',
       admin: '/partials/admin',
       logs: '/partials/logs'
     };

--- a/api/templates/partials/secrets.html
+++ b/api/templates/partials/secrets.html
@@ -1,0 +1,147 @@
+{# Secrets vault tab (issue #19) — names + access matrix only, never values. #}
+{% if not configured %}
+<div class="card">
+  <h2 class="text-base mb-1">Secrets</h2>
+  <p class="text-muted text-sm">The secrets vault is not configured in this deployment.</p>
+</div>
+{% else %}
+<div class="space-y-6">
+  {% if flash %}<div class="alert-success">{{ flash }}</div>{% endif %}
+  {% if error %}<div class="alert-error">{{ error }}</div>{% endif %}
+  {% if not unsealed %}
+  <div class="alert-error">
+    The persona vault is <strong>locked</strong>. It unlocks automatically with your admin
+    password — if you see this, reload the page after logging in.
+  </div>
+  {% endif %}
+
+  {# ── Persona / login secrets ─────────────────────────────────── #}
+  <div class="card">
+    <h2 class="text-base mb-1">Persona &amp; login secrets</h2>
+    <p class="text-muted text-xs mb-4">
+      Values are write-only — only names, descriptions and recent use are ever shown.
+      Use a secret from <code>run_command</code> as <code>{% raw %}{{secret:NAME}}{% endraw %}</code>.
+    </p>
+
+    {% if secrets %}
+    <div class="overflow-x-auto">
+      <table class="w-full text-xs">
+        <thead>
+          <tr class="text-muted text-left border-b border-border">
+            <th class="py-1 pr-3">Name</th>
+            {% for p in personae %}<th class="py-1 px-2 text-center">{{ p }}</th>{% endfor %}
+            <th class="py-1 px-2 text-center">all</th>
+            <th class="py-1 pl-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for s in secrets %}
+          <tr class="border-b border-border align-top">
+            <td class="py-2 pr-3">
+              <div class="font-mono">{{ s.name }}{% if s.structured %} <span class="text-muted">(login)</span>{% endif %}</div>
+              {% if s.description %}<div class="text-muted">{{ s.description }}</div>{% endif %}
+              <div class="text-muted">
+                used {{ s.use_count }}×{% if s.last_used_at %}, last {{ s.last_used_at }}{% endif %}
+                {% if s.expires_at %} · expires {{ s.expires_at }}{% endif %}
+                {% if s.max_uses %} · single-use{% endif %}
+              </div>
+            </td>
+            {% for p in personae %}
+            <td class="py-2 px-2 text-center">
+              <input type="checkbox"
+                     {% if s.shared %}checked disabled{% elif p in s.holders %}checked{% endif %}
+                     hx-post="/admin/secrets/grant" hx-target="#tab-content" hx-swap="innerHTML"
+                     hx-vals='js:{name:"{{ s.name }}",persona:"{{ p }}",grant:event.target.checked}'>
+            </td>
+            {% endfor %}
+            <td class="py-2 px-2 text-center">{% if s.shared %}✓{% endif %}</td>
+            <td class="py-2 pl-2 text-right">
+              <button class="btn-danger btn-sm"
+                      hx-post="/admin/secrets/delete" hx-target="#tab-content" hx-swap="innerHTML"
+                      hx-confirm="Revoke secret '{{ s.name }}'?"
+                      hx-vals='{"name":"{{ s.name }}"}'>Revoke</button>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <p class="text-muted text-xs">No persona secrets yet.</p>
+    {% endif %}
+  </div>
+
+  {# ── Add a secret ─────────────────────────────────────────────── #}
+  <div class="card" x-data="{ scope: 'this', duration: 'forever' }">
+    <h3 class="text-sm text-accent mb-3">Add / rotate a secret</h3>
+    <form hx-post="/admin/secrets" hx-target="#tab-content" hx-swap="innerHTML" class="space-y-3">
+      <div>
+        <label class="label">Name</label>
+        <input class="input-sm" name="name" placeholder="STRIPE_KEY or persona:finance:acme" required style="max-width:420px">
+      </div>
+      <div>
+        <label class="label">Value <span class="text-muted">(write-only)</span></label>
+        <input type="password" class="input-sm" name="value" autocomplete="new-password" placeholder="secret value" style="max-width:420px">
+      </div>
+      <div>
+        <label class="label">Description</label>
+        <input class="input-sm" name="description" placeholder="what it's for (shown, never the value)" style="max-width:420px">
+      </div>
+      <div>
+        <label class="label">Scope</label>
+        <select class="input-sm" name="scope" x-model="scope" style="max-width:240px">
+          <option value="this">Specific persona(s)</option>
+          <option value="all">All personas (shared)</option>
+        </select>
+        <input class="input-sm mt-1" name="personae" placeholder="persona names, comma-separated"
+               x-show="scope === 'this'" style="max-width:420px">
+      </div>
+      <div>
+        <label class="label">Duration</label>
+        <select class="input-sm" name="duration" x-model="duration" style="max-width:240px">
+          <option value="forever">Forever</option>
+          <option value="until">Until a date</option>
+          <option value="once">Once (single use)</option>
+        </select>
+        <input type="date" class="input-sm mt-1" name="until" x-show="duration === 'until'" style="max-width:240px">
+      </div>
+      <button class="btn-primary btn-sm" type="submit">Save secret</button>
+    </form>
+  </div>
+
+  {# ── Import from Bitwarden ────────────────────────────────────── #}
+  <div class="card">
+    <h3 class="text-sm text-accent mb-2">Import from Bitwarden</h3>
+    <p class="text-muted text-xs mb-3">
+      Export your Bitwarden vault as JSON (<code>bw export --format json</code> or the web
+      vault → Export), then upload it here. Login items become secrets you can scope.
+    </p>
+    <form hx-post="/admin/secrets/import/parse" hx-target="#tab-content" hx-swap="innerHTML"
+          hx-encoding="multipart/form-data" class="flex items-center gap-2">
+      <input type="file" name="file" accept=".json,application/json" class="input-sm" required>
+      <button class="btn-sm" type="submit">Upload &amp; preview</button>
+    </form>
+  </div>
+
+  {# ── Infrastructure secrets ───────────────────────────────────── #}
+  <div class="card">
+    <h3 class="text-sm text-accent mb-1">Infrastructure secrets</h3>
+    <p class="text-muted text-xs mb-3">
+      Machine-key encrypted; read at boot via <code>${% raw %}{vault:NAME}{% endraw %}</code> in config
+      (with <code>.env</code> fallback).
+      {% if not infra_available %}<span class="text-warn">No machine key configured.</span>{% endif %}
+    </p>
+    {% if infra %}
+    <ul class="text-xs font-mono mb-3">
+      {% for i in infra %}<li>{{ i.name }} <span class="text-muted">— {{ i.description }}</span></li>{% endfor %}
+    </ul>
+    {% endif %}
+    <form hx-post="/admin/secrets/infra" hx-target="#tab-content" hx-swap="innerHTML" class="space-y-2">
+      <input class="input-sm" name="name" placeholder="ANTHROPIC_API_KEY" style="max-width:420px" required>
+      <input type="password" class="input-sm" name="value" autocomplete="new-password" placeholder="value" style="max-width:420px">
+      <input class="input-sm" name="description" placeholder="description" style="max-width:420px">
+      <button class="btn-sm" type="submit" {% if not infra_available %}disabled{% endif %}>Add infra secret</button>
+    </form>
+  </div>
+</div>
+{% endif %}

--- a/api/templates/partials/secrets_import.html
+++ b/api/templates/partials/secrets_import.html
@@ -1,0 +1,56 @@
+{# Bitwarden import — select which login items to bring into the vault. #}
+<div class="space-y-4" x-data="{ scope: 'this' }">
+  <div class="card">
+    <h2 class="text-base mb-1">Import logins</h2>
+    <p class="text-muted text-xs mb-3">
+      {{ items|length }} login item(s) found. Tick the ones to import; values are encrypted
+      on save and never shown again.
+    </p>
+    {% if not items %}
+    <p class="text-muted text-xs">No login items in this export.</p>
+    <button class="btn-sm" hx-get="/partials/secrets" hx-target="#tab-content" hx-swap="innerHTML">Back</button>
+    {% else %}
+    <form hx-post="/admin/secrets/import/commit" hx-target="#tab-content" hx-swap="innerHTML" class="space-y-3">
+      <div class="overflow-x-auto">
+        <table class="w-full text-xs">
+          <thead>
+            <tr class="text-muted text-left border-b border-border">
+              <th class="py-1 pr-2"></th><th class="py-1 pr-2">Name</th>
+              <th class="py-1 pr-2">Username</th><th class="py-1 pr-2">URL</th><th class="py-1 pr-2">TOTP</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for it in items %}
+            <tr class="border-b border-border">
+              <td class="py-1 pr-2"><input type="checkbox" name="selected" value="{{ it.name }}" checked></td>
+              <td class="py-1 pr-2 font-mono">{{ it.name }}
+                <input type="hidden" name="username__{{ it.name }}" value="{{ it.username }}">
+                <input type="hidden" name="password__{{ it.name }}" value="{{ it.password }}">
+                <input type="hidden" name="url__{{ it.name }}" value="{{ it.url }}">
+                <input type="hidden" name="totp__{{ it.name }}" value="{{ it.totp }}">
+              </td>
+              <td class="py-1 pr-2">{{ it.username }}</td>
+              <td class="py-1 pr-2 text-muted">{{ it.url }}</td>
+              <td class="py-1 pr-2">{% if it.totp %}✓{% endif %}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <label class="label">Scope</label>
+        <select class="input-sm" name="scope" x-model="scope" style="max-width:240px">
+          <option value="this">Specific persona(s)</option>
+          <option value="all">All personas (shared)</option>
+        </select>
+        <input class="input-sm mt-1" name="personae" placeholder="persona names, comma-separated"
+               x-show="scope === 'this'" style="max-width:420px">
+      </div>
+      <div class="flex gap-2">
+        <button class="btn-sm" type="button" hx-get="/partials/secrets" hx-target="#tab-content" hx-swap="innerHTML">Cancel</button>
+        <button class="btn-primary btn-sm" type="submit">Import selected</button>
+      </div>
+    </form>
+    {% endif %}
+  </div>
+</div>

--- a/api/templates/vault_fill.html
+++ b/api/templates/vault_fill.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block content %}
+{% block body %}
 <div class="max-w-md mx-auto mt-8" x-data="vaultFill('{{ token }}')" x-init="load()">
   <div class="card">
     <h1 class="text-base mb-1">Provide a secret</h1>

--- a/api/templates/vault_fill.html
+++ b/api/templates/vault_fill.html
@@ -1,0 +1,123 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="max-w-md mx-auto mt-8" x-data="vaultFill('{{ token }}')" x-init="load()">
+  <div class="card">
+    <h1 class="text-base mb-1">Provide a secret</h1>
+    <p class="text-muted text-xs mb-4">
+      Your agent asked for a secret. Enter the value below — it is encrypted on save and
+      never shown again. Nothing here is sent over chat.
+    </p>
+
+    <template x-if="needsLogin">
+      <div class="space-y-2 mb-4">
+        <label class="label">Admin password</label>
+        <input type="password" class="input" x-model="password" placeholder="admin password"
+               @keydown.enter="saveKeyAndLoad()">
+        <button class="btn-primary btn-sm" @click="saveKeyAndLoad()">Unlock</button>
+        <div class="alert-error" x-show="error" x-text="error"></div>
+      </div>
+    </template>
+
+    <template x-if="loaded && !needsLogin">
+      <div class="space-y-3">
+        <div class="text-sm">
+          Secret <span class="font-mono" x-text="req.name"></span>
+          <template x-if="req.reason"><span class="text-muted" x-text="' — ' + req.reason"></span></template>
+        </div>
+
+        <div>
+          <label class="label">Password / value</label>
+          <input type="password" class="input" x-model="password_val" autocomplete="new-password">
+        </div>
+        <details>
+          <summary class="text-muted text-xs cursor-pointer">Login fields (optional)</summary>
+          <div class="space-y-2 mt-2">
+            <input class="input-sm" x-model="username" placeholder="username">
+            <input class="input-sm" x-model="url" placeholder="url">
+            <input class="input-sm" x-model="totp" placeholder="TOTP secret">
+          </div>
+        </details>
+
+        <div>
+          <label class="label">Who can use it</label>
+          <select class="input-sm" x-model="scope">
+            <option value="this">This persona only</option>
+            <option value="personae">Specific persona(s)</option>
+            <option value="all">All personas</option>
+          </select>
+          <input class="input-sm mt-1" x-model="personae" placeholder="persona names, comma-separated"
+                 x-show="scope === 'personae'">
+        </div>
+
+        <div>
+          <label class="label">For how long</label>
+          <select class="input-sm" x-model="duration">
+            <option value="forever">Forever</option>
+            <option value="until">Until a date</option>
+            <option value="once">Once (single use)</option>
+          </select>
+          <input type="date" class="input-sm mt-1" x-model="until" x-show="duration === 'until'">
+        </div>
+
+        <button class="btn-primary" @click="submit()">Save secret</button>
+        <div class="alert-error" x-show="error" x-text="error"></div>
+        <div class="alert-success" x-show="done">Saved. You can close this page.</div>
+      </div>
+    </template>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function vaultFill(token) {
+  return {
+    token, req: {}, loaded: false, needsLogin: false, done: false, error: '',
+    password: '', password_val: '', username: '', url: '', totp: '',
+    scope: 'this', personae: '', duration: 'forever', until: '',
+    _key() { return localStorage.getItem('admin_api_key') || ''; },
+    async load() {
+      try {
+        const r = await fetch('/vault/request/' + this.token, {
+          headers: { 'Authorization': 'Bearer ' + this._key() }
+        });
+        if (r.status === 401) { this.needsLogin = true; return; }
+        if (!r.ok) { this.error = 'Request not found or expired.'; this.loaded = true; return; }
+        this.req = await r.json(); this.needsLogin = false; this.loaded = true;
+        if (this.req.suggested_scope) this.personae = this.req.suggested_scope;
+      } catch (e) { this.error = e.message; }
+    },
+    saveKeyAndLoad() {
+      if (!this.password.trim()) { this.error = 'Enter your admin password.'; return; }
+      localStorage.setItem('admin_api_key', this.password.trim());
+      this.error = ''; this.load();
+    },
+    async submit() {
+      this.error = ''; this.done = false;
+      const body = new URLSearchParams();
+      body.set('value', this.password_val);
+      if (this.username) body.set('username', this.username);
+      if (this.url) body.set('url', this.url);
+      if (this.totp) body.set('totp', this.totp);
+      body.set('scope', this.scope);
+      body.set('personae', this.personae);
+      body.set('duration', this.duration);
+      body.set('until', this.until);
+      try {
+        const r = await fetch('/vault/fill/' + this.token, {
+          method: 'POST',
+          headers: {
+            'Authorization': 'Bearer ' + this._key(),
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          body
+        });
+        const d = await r.json();
+        if (r.ok && d.ok) { this.done = true; }
+        else { this.error = d.error || ('Failed (' + r.status + ')'); }
+      } catch (e) { this.error = e.message; }
+    }
+  };
+}
+</script>
+{% endblock %}

--- a/api/templates/wizard/admin.html
+++ b/api/templates/wizard/admin.html
@@ -41,7 +41,7 @@
               htmx.ajax('POST', '/setup/step', {
                 target: '#wizard-step', swap: 'innerHTML',
                 values: {
-                  step: 'done',
+                  step: 'secrets',
                   'values[admin.api_key]': key,
                   'values[admin.enabled]': 'true'
                 }

--- a/api/templates/wizard/secrets.html
+++ b/api/templates/wizard/secrets.html
@@ -1,0 +1,58 @@
+{# Wizard step: master key + import existing .env secrets into the vault. #}
+<div class="card">
+  <h2 class="text-base mb-3">Secrets vault <span class="text-muted font-normal text-xs">(optional)</span></h2>
+  <p class="text-muted text-sm mb-3">
+    Consolidate your API keys and tokens into one encrypted store. Infrastructure secrets are
+    sealed with a machine key so the agent can boot unattended; persona/login secrets are
+    sealed with your admin password.
+  </p>
+
+  {% if step_ctx.env_seed_present %}
+  <div class="alert-error text-xs mb-3">
+    Your admin password seed (<code>ADMIN_PASSWORD</code>/<code>ADMIN_API_KEY</code>) is still in
+    the environment/<code>.env</code>. Remove it after setup — it is no longer needed and a
+    leftover plaintext password weakens the persona vault.
+  </div>
+  {% endif %}
+
+  <div class="mb-4">
+    <h3 class="text-sm text-accent mb-1">1. Encryption key</h3>
+    {% if step_ctx.machine_key_present %}
+    <p class="text-xs text-success">Machine key present — the infra vault is ready.</p>
+    {% else %}
+    <p class="text-muted text-xs mb-2">
+      No machine key yet. Generate one (saved to <code>data/master.key</code>), or set
+      <code>MPA_MASTER_KEY</code> in your environment.
+    </p>
+    <button class="btn btn-sm"
+            hx-post="/setup/step/secrets" hx-target="#wizard-step" hx-swap="innerHTML"
+            hx-vals='{"action": "generate"}'>Generate &amp; save key</button>
+    {% endif %}
+  </div>
+
+  <div class="mb-4">
+    <h3 class="text-sm text-accent mb-1">2. Import from .env</h3>
+    {% if step_ctx.detected_secrets %}
+    <p class="text-muted text-xs mb-2">
+      Detected {{ step_ctx.detected_secrets|length }} secret(s) currently stored as plain values.
+      Move them into the encrypted vault (config will reference them as
+      <code>${% raw %}{vault:NAME}{% endraw %}</code>, with <code>.env</code> fallback).
+    </p>
+    <button class="btn btn-sm"
+            {% if not step_ctx.machine_key_present %}disabled title="Generate a key first"{% endif %}
+            hx-post="/setup/step/secrets" hx-target="#wizard-step" hx-swap="innerHTML"
+            hx-vals='{"action": "import"}'>Move {{ step_ctx.detected_secrets|length }} secret(s) into the vault</button>
+    {% else %}
+    <p class="text-xs text-success">No plaintext infra secrets detected (or already migrated).</p>
+    {% endif %}
+  </div>
+
+  <div class="flex justify-between mt-4">
+    <button class="btn"
+            hx-post="/setup/step" hx-target="#wizard-step" hx-swap="innerHTML"
+            hx-vals='{"step": "admin", "values": {}}'>Back</button>
+    <button class="btn-primary"
+            hx-post="/setup/step" hx-target="#wizard-step" hx-swap="innerHTML"
+            hx-vals='{"step": "done", "values": {}}'>Finish</button>
+  </div>
+</div>

--- a/core/agent.py
+++ b/core/agent.py
@@ -1660,17 +1660,6 @@ class AgentCore:
         skills_index = await self.skills.get_index_block(allow=persona.skills if persona else None)
         memories = await self.memory.format_for_prompt(query=query)
 
-        # Secret discoverability (issue #19): the NAMES in scope, never values.
-        secret_names: list[tuple[str, str]] = []
-        if self.secret_store is not None:
-            try:
-                allowed = set(persona.secrets) if persona else set()
-                allowed |= await self.secret_store.shared_names()
-                meta = await self.secret_store.list_secret_meta(allowed=allowed)
-                secret_names = [(m["name"], m["description"]) for m in meta]
-            except Exception:
-                log.exception("Failed to load secret names for prompt")
-
         # Task reflections — lessons learned from past tasks
         reflections = ""
         if self.config.task_reflection.enabled:
@@ -1687,7 +1676,7 @@ class AgentCore:
             reflections=reflections,
             decomposed_goal=decomposed_goal,
             persona=persona,
-            secrets=secret_names,
+            secrets_available=self.secret_store is not None,
         )
         return sections.full_prompt
 

--- a/core/agent.py
+++ b/core/agent.py
@@ -30,6 +30,7 @@ from core.permissions import PermissionEngine, PermissionLevel, format_approval_
 from core.personae import Persona, PersonaStore
 from core.prompt_builder import build_prompt_sections
 from core.scheduler import AgentScheduler
+from core.secret_store import SecretStore
 from core.skills import SkillsEngine
 from core.task_reflection import ReflectionStore
 from core.tools import tool_env
@@ -244,6 +245,42 @@ TOOLS = [
             "required": ["action"],
         },
     },
+    # Secrets vault (issue #19) — discover + request secrets by NAME only.
+    {
+        "name": "list_secrets",
+        "description": (
+            "List the names of stored secrets you may use (with descriptions). "
+            "Returns NAMES ONLY — never values. Use a listed name by reference as "
+            "{{secret:NAME}} inside run_command."
+        ),
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "request_secret",
+        "description": (
+            "Ask the owner to provide a secret you need but don't have (e.g. a website "
+            "login). Sends the owner a secure web link to enter the value; you never "
+            "handle the value yourself. Use when a needed {{secret:NAME}} is not listed."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name for the secret (letters, digits, _ - : only)",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Why you need it / what you'll do with it",
+                },
+                "suggested_scope": {
+                    "type": "string",
+                    "description": "Optional hint: which persona(s) should be able to use it",
+                },
+            },
+            "required": ["name", "reason"],
+        },
+    },
 ]
 
 
@@ -255,12 +292,18 @@ def scoped_tools(persona: Persona | None) -> list[dict]:
     """
     if persona is None or not persona.tools:
         return TOOLS
-    return [t for t in TOOLS if persona.allows_tool(t["name"]) or t["name"] == "load_skill"]
+    # ``load_skill`` and the vault discovery/request tools are always retained:
+    # they are the mechanics personae rely on to read skills and obtain secrets.
+    _always = {"load_skill", "list_secrets", "request_secret"}
+    return [t for t in TOOLS if persona.allows_tool(t["name"]) or t["name"] in _always]
 
 
 class AgentCore:
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, secret_store: SecretStore | None = None):
         self.config = config
+        # Secrets vault (issue #19). Shared, process-wide so the persona DEK
+        # unsealed by an admin login is visible to the agent at runtime.
+        self.secret_store = secret_store
         self.llm: LLMClient = LLMClient.from_agent_config(config.agent)
         self.skills = SkillsEngine(
             db_path=config.agent.skills_db_path,
@@ -357,6 +400,8 @@ class AgentCore:
         # make this per-chat; for now it is the globally selected persona.
         persona = await self._resolve_persona(channel, user_id, chat_id)
         tools = scoped_tools(persona)
+        if self.secret_store is None:
+            tools = [t for t in tools if t["name"] not in ("list_secrets", "request_secret")]
 
         # Static system prompt. In session mode it is snapshotted once at the
         # start of the session and reused for every turn (so the static content
@@ -905,7 +950,18 @@ class AgentCore:
         # --- Dispatch ---
         if name == "run_command":
             log.info("Tool call: run_command — %s", params.get("purpose", ""))
-            return await self.executor.run_command(params["command"])
+            command = params["command"]
+            # Secret substitution boundary (issue #19): {{secret:NAME}} is resolved
+            # ONLY here, for the model's generic command tool, after an ACL check.
+            # Structured tools (send_email/send_message/…) build their commands
+            # elsewhere and never pass through this path, so a secret cannot be
+            # exfiltrated through a message/email body.
+            if self.secret_store is not None:
+                allowed = set(request_state.get("persona_secrets") or [])
+                command, serr = await self.secret_store.resolve_command_secrets(command, allowed)
+                if serr:
+                    return {"error": serr}
+            return await self.executor.run_command(command)
 
         if name == "send_email":
             result = await self._tool_send_email(params)
@@ -954,6 +1010,28 @@ class AgentCore:
                 executed_writes.add(write_sig)
             return result
 
+        if name == "list_secrets":
+            if self.secret_store is None:
+                return {"error": "Secrets vault is not configured."}
+            allowed = set(request_state.get("persona_secrets") or [])
+            allowed |= await self.secret_store.shared_names()
+            meta = await self.secret_store.list_secret_meta(allowed=allowed)
+            return {
+                "secrets": [
+                    {
+                        "name": m["name"],
+                        "description": m["description"],
+                        "shared": m["shared"],
+                        "structured": m["structured"],
+                        "last_used_at": m["last_used_at"],
+                    }
+                    for m in meta
+                ]
+            }
+
+        if name == "request_secret":
+            return await self._tool_request_secret(params, channel, user_id, request_state)
+
         return {"error": f"Unknown tool: {name}"}
 
     @staticmethod
@@ -969,6 +1047,9 @@ class AgentCore:
             "write_decisions": {},
             "approvals": {},
             "allowed_skills": persona.skills if persona else None,
+            # Secret scope for {{secret:}} ACL in run_command (issue #19).
+            "persona_secrets": list(persona.secrets) if persona else [],
+            "persona_name": persona.name if persona else "",
         }
 
     @staticmethod
@@ -1062,6 +1143,61 @@ class AgentCore:
             return {"ok": True, "channel": channel_name, "to": to}
         except Exception as exc:
             return {"error": str(exc)}
+
+    def _vault_base_url(self) -> str:
+        import os
+
+        return os.getenv("MPA_BASE_URL", f"http://localhost:{self.config.admin.port}")
+
+    async def _notify_secret_request(
+        self, channel: str, user_id: str, name: str, reason: str, link: str
+    ) -> None:
+        """Best-effort: push the owner a secure link to provide a requested secret.
+
+        Link only — the value is NEVER entered or shown over the chat channel.
+        """
+        text = (
+            f"🔑 I need the secret '{name}' to continue"
+            + (f" ({reason})" if reason else "")
+            + ".\nAdd it securely via this link (no value over chat):\n"
+            + link
+        )
+        ch = self.channels.get(channel)
+        if ch is None:
+            return
+        try:
+            await ch.send(user_id, text)
+        except Exception:
+            log.exception("Failed to send secret-request link via %s", channel)
+
+    async def _tool_request_secret(
+        self, params: dict, channel: str, user_id: str, request_state: dict | None
+    ) -> dict:
+        """Create a pending secret request and send the owner a secure fill link."""
+        if self.secret_store is None:
+            return {"error": "Secrets vault is not configured."}
+        from core.secret_store import valid_name
+
+        sname = str(params.get("name", "")).strip()
+        if not valid_name(sname):
+            return {"error": "Invalid secret name (use letters, digits, _ - : only)."}
+        reason = str(params.get("reason", "")).strip()
+        scope = str(params.get("suggested_scope", "")).strip()
+        persona_name = (request_state or {}).get("persona_name", "")
+        log.info("Tool call: request_secret — %s (persona=%s)", sname, persona_name)
+        token = await self.secret_store.create_request(
+            sname, persona=persona_name, reason=reason, suggested_scope=scope
+        )
+        link = f"{self._vault_base_url()}/vault/fill/{token}"
+        await self._notify_secret_request(channel, user_id, sname, reason, link)
+        return {
+            "status": "requested",
+            "secure_link": link,
+            "message": (
+                f"Sent the owner a secure link to provide '{sname}'. It is not available "
+                "yet — let the user know, then continue once they confirm it's added."
+            ),
+        }
 
     async def _tool_create_calendar_event(self, params: dict) -> dict:
         """Create a calendar event via the CalDAV helper script."""
@@ -1524,6 +1660,17 @@ class AgentCore:
         skills_index = await self.skills.get_index_block(allow=persona.skills if persona else None)
         memories = await self.memory.format_for_prompt(query=query)
 
+        # Secret discoverability (issue #19): the NAMES in scope, never values.
+        secret_names: list[tuple[str, str]] = []
+        if self.secret_store is not None:
+            try:
+                allowed = set(persona.secrets) if persona else set()
+                allowed |= await self.secret_store.shared_names()
+                meta = await self.secret_store.list_secret_meta(allowed=allowed)
+                secret_names = [(m["name"], m["description"]) for m in meta]
+            except Exception:
+                log.exception("Failed to load secret names for prompt")
+
         # Task reflections — lessons learned from past tasks
         reflections = ""
         if self.config.task_reflection.enabled:
@@ -1540,6 +1687,7 @@ class AgentCore:
             reflections=reflections,
             decomposed_goal=decomposed_goal,
             persona=persona,
+            secrets=secret_names,
         )
         return sections.full_prompt
 

--- a/core/config.py
+++ b/core/config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Callable
 from pathlib import Path
 
 import yaml
@@ -17,7 +18,12 @@ from pydantic import BaseModel, Field, field_validator
 
 
 def _resolve_env_vars(obj: object) -> object:
-    """Recursively resolve ${ENV_VAR} references in strings."""
+    """Recursively resolve ${ENV_VAR} references in strings.
+
+    ``${vault:NAME}`` references contain a ``:`` and so do not match ``\\w+`` —
+    they pass through here untouched and are resolved later against the encrypted
+    infra vault (see :func:`resolve_vault_vars`).
+    """
     if isinstance(obj, str):
         return re.sub(
             r"\$\{(\w+)\}",
@@ -28,6 +34,25 @@ def _resolve_env_vars(obj: object) -> object:
         return {k: _resolve_env_vars(v) for k, v in obj.items()}
     if isinstance(obj, list):
         return [_resolve_env_vars(v) for v in obj]
+    return obj
+
+
+_VAULT_RE = re.compile(r"\$\{vault:([A-Za-z0-9_:-]+)\}")
+
+
+def resolve_vault_vars(obj: object, resolve: Callable[[str], str | None]) -> object:
+    """Recursively resolve ``${vault:NAME}`` references via ``resolve``.
+
+    ``resolve(name)`` returns the decrypted infra-vault value, falling back to
+    the environment (so ``.env`` stays a fallback). A miss leaves the reference
+    literally in place rather than blanking the field.
+    """
+    if isinstance(obj, str):
+        return _VAULT_RE.sub(lambda m: resolve(m.group(1)) or m.group(0), obj)
+    if isinstance(obj, dict):
+        return {k: resolve_vault_vars(v, resolve) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [resolve_vault_vars(v, resolve) for v in obj]
     return obj
 
 

--- a/core/config_store.py
+++ b/core/config_store.py
@@ -84,6 +84,7 @@ SETUP_STEPS = [
     "search",
     "browser",
     "admin",
+    "secrets",
     "done",
 ]
 
@@ -300,10 +301,19 @@ class ConfigStore:
         config = load_config(yaml_path)
         return await self.import_from_config(config)
 
-    async def export_to_config(self) -> Config:
-        """Reconstruct a Config object from the store."""
+    async def export_to_config(self, vault_resolve=None) -> Config:
+        """Reconstruct a Config object from the store.
+
+        When ``vault_resolve`` (a ``name -> str | None`` callable) is supplied,
+        ``${vault:NAME}`` references are resolved against the encrypted infra
+        vault, with ``.env`` fallback handled by the resolver itself.
+        """
         flat = await self.get_many()
         nested = _unflatten(flat)
+        if vault_resolve is not None:
+            from core.config import resolve_vault_vars
+
+            nested = resolve_vault_vars(nested, vault_resolve)
         return Config.model_validate(nested)
 
     # -- Redacted views (for API responses) ----------------------------------

--- a/core/main.py
+++ b/core/main.py
@@ -140,6 +140,12 @@ _agent_state = AgentState()
 async def _lifespan(application):  # noqa: ANN001
     """FastAPI lifespan: seed config, start agent, yield, then tear down."""
     # -- startup --
+    # Load .env so MPA_MASTER_KEY / ADMIN_PASSWORD etc. are in the environment even
+    # for existing installs where the config store is already seeded (Docker injects
+    # env_file directly; this covers `make run` / bare-process deployments).
+    from dotenv import load_dotenv
+
+    load_dotenv()
     await _config_store.seed_if_empty()
     await _config_store.ensure_admin_password()
     # Initialise the persona vault's wrapped DEK when an admin password is set via

--- a/core/main.py
+++ b/core/main.py
@@ -25,6 +25,7 @@ from fastapi.responses import HTMLResponse
 from api.admin import AgentState, create_admin_app, install_log_buffer
 from core.config_store import ConfigStore
 from core.email_config import materialize_himalaya_config
+from core.secret_store import SecretStore
 
 logging.basicConfig(
     level=logging.INFO,
@@ -46,9 +47,13 @@ async def _start_agent(config_store: ConfigStore):
     from core.agent import AgentCore
     from voice.pipeline import VoicePipeline
 
-    config = await config_store.export_to_config()
+    # Decrypt infra secrets into memory so ${vault:NAME} resolves at config load
+    # (with .env fallback). Then build the config and hand the shared secret store
+    # to the agent so the executor can resolve {{secret:NAME}} at runtime.
+    await _secret_store.load_infra_cache()
+    config = await config_store.export_to_config(vault_resolve=_secret_store.infra_resolve)
 
-    agent = AgentCore(config)
+    agent = AgentCore(config, secret_store=_secret_store)
 
     # Ensure scheduler jobs can resolve the current agent instance
     from core.scheduler import set_agent_context
@@ -127,6 +132,7 @@ async def _stop_agent(agent) -> None:
 # ---------------------------------------------------------------------------
 
 _config_store = ConfigStore()
+_secret_store = SecretStore()
 _agent_state = AgentState()
 
 
@@ -136,6 +142,12 @@ async def _lifespan(application):  # noqa: ANN001
     # -- startup --
     await _config_store.seed_if_empty()
     await _config_store.ensure_admin_password()
+    # Initialise the persona vault's wrapped DEK when an admin password is set via
+    # the environment (the only point at boot where plaintext is available). When
+    # the password is set through the wizard/UI instead, the admin routes mint it.
+    seed_pw = environ.get("ADMIN_PASSWORD") or environ.get("ADMIN_API_KEY")
+    if seed_pw:
+        await _secret_store.ensure_wrapped_dek(seed_pw)
     await materialize_himalaya_config(_config_store)
 
     setup_complete = await _config_store.is_setup_complete()
@@ -168,7 +180,9 @@ async def _lifespan(application):  # noqa: ANN001
 # Build the FastAPI app at module level so ``uvicorn core.main:app`` works.
 # ---------------------------------------------------------------------------
 
-app, _auth = create_admin_app(_agent_state, _config_store, lifespan=_lifespan)
+app, _auth = create_admin_app(
+    _agent_state, _config_store, lifespan=_lifespan, secret_store=_secret_store
+)
 
 
 def _attach_lifecycle_routes(

--- a/core/prompt_builder.py
+++ b/core/prompt_builder.py
@@ -113,7 +113,7 @@ def build_prompt_sections(
     reflections: str,
     decomposed_goal: DecomposedGoal | None,
     persona: Persona | None = None,
-    secrets: list[tuple[str, str]] | None = None,
+    secrets_available: bool = False,
     include_memories: bool = True,
     include_reflections: bool = True,
 ) -> PromptSections:
@@ -161,19 +161,21 @@ def build_prompt_sections(
     if tool_blocks:
         tools_section = "<tools>\n" + "\n\n".join(tool_blocks) + "\n</tools>"
 
-    # Secret discoverability: list the NAMES the active scope may use (never values).
+    # Secret discoverability: a short, static pointer to the `list_secrets` tool —
+    # NOT the secret names themselves, to keep the cacheable prompt small and avoid
+    # polluting context with the whole vault. The model discovers names on demand.
     secrets_section = ""
-    if secrets:
-        lines = "\n".join(f"- {name}" + (f" — {desc}" if desc else "") for name, desc in secrets)
+    if secrets_available:
         secrets_section = (
             "<secrets>\n"
-            "You may use these stored secrets BY REFERENCE inside `run_command` only, "
-            "as {{secret:NAME}} (or {{secret:NAME.field}} for a structured secret). "
-            "NEVER print, echo, or place a secret value or a {{secret:...}} placeholder "
-            "in a message, email, calendar event, or any other output — substitution "
-            "happens only inside `run_command`. If you need a secret that is not listed, "
-            "call `request_secret` to ask the owner for it.\n"
-            f"{lines}\n"
+            "An encrypted secrets vault is available. Before logging into a site or calling "
+            "an authenticated API, call the `list_secrets` tool to see which secrets you may "
+            "use (it returns names + descriptions only, never values). Use a secret BY "
+            "REFERENCE inside `run_command` as {{secret:NAME}} (or {{secret:NAME.field}} for a "
+            "structured login). If the secret you need isn't listed, call `request_secret` to "
+            "ask the owner for it. NEVER print, echo, or place a secret value or a "
+            "{{secret:...}} placeholder in a message, email, calendar event, or any other "
+            "output — substitution happens only inside `run_command`.\n"
             "</secrets>"
         )
     memory_instruction = (

--- a/core/prompt_builder.py
+++ b/core/prompt_builder.py
@@ -52,6 +52,7 @@ class PromptSections:
     about_user: str
     tool_usage: str
     tools: str
+    secrets: str
     memory_instruction: str
     history_handling: str
     memories: str
@@ -70,6 +71,8 @@ class PromptSections:
         ]
         if self.tools:
             parts.append(self.tools)
+        if self.secrets:
+            parts.append(self.secrets)
         parts.append(self.memory_instruction)
         if self.history_handling:
             parts.append(self.history_handling)
@@ -91,6 +94,7 @@ class PromptSections:
             "about_user": self.about_user,
             "tool_usage": self.tool_usage,
             "tools": self.tools,
+            "secrets": self.secrets,
             "memory_instruction": self.memory_instruction,
             "history_handling": self.history_handling,
             "memories": self.memories,
@@ -109,6 +113,7 @@ def build_prompt_sections(
     reflections: str,
     decomposed_goal: DecomposedGoal | None,
     persona: Persona | None = None,
+    secrets: list[tuple[str, str]] | None = None,
     include_memories: bool = True,
     include_reflections: bool = True,
 ) -> PromptSections:
@@ -155,6 +160,22 @@ def build_prompt_sections(
     tools_section = ""
     if tool_blocks:
         tools_section = "<tools>\n" + "\n\n".join(tool_blocks) + "\n</tools>"
+
+    # Secret discoverability: list the NAMES the active scope may use (never values).
+    secrets_section = ""
+    if secrets:
+        lines = "\n".join(f"- {name}" + (f" — {desc}" if desc else "") for name, desc in secrets)
+        secrets_section = (
+            "<secrets>\n"
+            "You may use these stored secrets BY REFERENCE inside `run_command` only, "
+            "as {{secret:NAME}} (or {{secret:NAME.field}} for a structured secret). "
+            "NEVER print, echo, or place a secret value or a {{secret:...}} placeholder "
+            "in a message, email, calendar event, or any other output — substitution "
+            "happens only inside `run_command`. If you need a secret that is not listed, "
+            "call `request_secret` to ask the owner for it.\n"
+            f"{lines}\n"
+            "</secrets>"
+        )
     memory_instruction = (
         "You can store and recall memories using the sqlite3 CLI (see the memory skill).\n"
         "Proactively remember important facts about the user and their contacts.\n"
@@ -195,6 +216,7 @@ def build_prompt_sections(
         about_user=about_user,
         tool_usage=tool_usage,
         tools=tools_section,
+        secrets=secrets_section,
         memory_instruction=memory_instruction,
         history_handling=history_handling,
         memories=memory_section,

--- a/core/repl.py
+++ b/core/repl.py
@@ -314,13 +314,27 @@ async def main() -> None:
     )
     args = parser.parse_args()
 
+    from dotenv import load_dotenv
+
+    load_dotenv()  # MPA_MASTER_KEY / ADMIN_PASSWORD from .env, as main.py does at boot
+
     spinner = Spinner()
     _setup_logging(spinner)
 
     store = ConfigStore()
     await store.seed_if_empty()
     await store.ensure_admin_password()
-    config = await store.export_to_config()
+
+    # Wire the secrets vault the same way main.py does, so {{secret:}} / ${vault:}
+    # and list_secrets/request_secret work in the repl. ponytail: mirror boot, no abstraction.
+    from core.secret_store import SecretStore
+
+    secret_store = SecretStore()
+    await secret_store.load_infra_cache()
+    seed_pw = os.environ.get("ADMIN_PASSWORD") or os.environ.get("ADMIN_API_KEY")
+    if seed_pw:  # unseals persona vault in-process (created on first set)
+        await secret_store.ensure_wrapped_dek(seed_pw)
+    config = await store.export_to_config(vault_resolve=secret_store.infra_resolve)
 
     if args.persona is not None:
         # Validate against the persona store so a typo fails loudly with options.
@@ -333,7 +347,7 @@ async def main() -> None:
             return
         config.agent.active_persona = args.persona
 
-    agent = AgentCore(config)
+    agent = AgentCore(config, secret_store=secret_store)
     agent.channels["repl"] = ReplChannel(agent, spinner, yolo=args.yolo)
     if args.yolo:
         print(f"{_DIM}⚠ --yolo: auto-approving all tool permissions this session.{_RESET}")

--- a/core/secret_store.py
+++ b/core/secret_store.py
@@ -559,6 +559,11 @@ class SecretStore:
         """
         await self._ensure_schema()
         self._infra_cache = {}
+        # Re-resolve the machine key: SecretStore() is constructed at import time,
+        # which can be before .env is loaded. By boot (this call) the key may now be
+        # present in the environment, so pick it up.
+        if not self.infra.available:
+            self.infra = InfraVault(load_machine_key())
         if not self.infra.available:
             return self._infra_cache
         async with aiosqlite.connect(self.db_path) as db:

--- a/core/secret_store.py
+++ b/core/secret_store.py
@@ -1,0 +1,668 @@
+"""SQLite-backed secrets vault — storage, ACL, resolution (issue #19).
+
+Sits on the same database file as :class:`core.config_store.ConfigStore` but owns
+its own tables. Wraps the two vaults from :mod:`core.vault`:
+
+* **infra_secrets** — encrypted with the :class:`~core.vault.InfraVault` machine
+  key; resolved into config at load time via ``${vault:NAME}`` (with ``.env``
+  fallback). Read by app code, not persona-scoped.
+* **secrets** — encrypted with the :class:`~core.vault.PersonaVault` (envelope,
+  password-derived). Used *by reference* from ``run_command`` as
+  ``{{secret:NAME}}`` / ``{{secret:NAME.field}}`` after an ACL check. Values
+  never enter the model's context.
+* **secret_requests** — pending "agent needs a secret" requests, redeemed via a
+  one-time secure web link.
+* **vault_meta** — the wrapped DEK + salt for the persona vault.
+
+Security boundary: placeholder substitution happens **only** where
+:meth:`resolve_command_secrets` is called — the model-facing ``run_command``
+dispatch — never in message/email tool bodies. See ``core/agent.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import secrets as _secrets
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiosqlite
+
+from core.vault import InfraVault, PersonaVault, VaultLocked, load_machine_key
+
+log = logging.getLogger(__name__)
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS infra_secrets (
+    name        TEXT PRIMARY KEY,
+    value       BLOB NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS secrets (
+    name         TEXT PRIMARY KEY,
+    value        BLOB NOT NULL,
+    structured   INTEGER NOT NULL DEFAULT 0,
+    shared       INTEGER NOT NULL DEFAULT 0,
+    owner        TEXT NOT NULL DEFAULT '',
+    description  TEXT NOT NULL DEFAULT '',
+    expires_at   TEXT,
+    max_uses     INTEGER,
+    use_count    INTEGER NOT NULL DEFAULT 0,
+    last_used_at TEXT,
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE IF NOT EXISTS secret_requests (
+    token_hash      TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    persona         TEXT NOT NULL DEFAULT '',
+    reason          TEXT NOT NULL DEFAULT '',
+    suggested_scope TEXT NOT NULL DEFAULT '',
+    status          TEXT NOT NULL DEFAULT 'pending',
+    created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    expires_at      TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS vault_meta (
+    id          INTEGER PRIMARY KEY CHECK (id = 1),
+    wrapped_dek TEXT,
+    salt        TEXT
+);
+"""
+
+# A secret name: letters/digits/_/-/: (the ':' allows persona:<name>:* namespaces).
+# No '.' — that is reserved as the field separator in {{secret:NAME.field}}.
+_NAME_RE = re.compile(r"^[A-Za-z0-9_:-]+$")
+_PLACEHOLDER_RE = re.compile(r"\{\{secret:([A-Za-z0-9_:-]+)(?:\.([A-Za-z0-9_-]+))?\}\}")
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def valid_name(name: str) -> bool:
+    return bool(_NAME_RE.match(name or ""))
+
+
+def slugify_name(raw: str) -> str:
+    """Turn an arbitrary label (e.g. a Bitwarden item name) into a valid name."""
+    s = re.sub(r"[^A-Za-z0-9_:-]+", "_", (raw or "").strip()).strip("_")
+    return s or "secret"
+
+
+def parse_bitwarden_export(data: dict) -> list[dict]:
+    """Extract login items from a Bitwarden JSON export (pure, testable).
+
+    Returns one dict per login: ``{name, username, password, url, totp, notes}``.
+    Only ``type == 1`` (login) items with a password are included.
+    """
+    out: list[dict] = []
+    for item in data.get("items", []):
+        if item.get("type") != 1:
+            continue
+        login = item.get("login") or {}
+        password = login.get("password") or ""
+        if not password:
+            continue
+        uris = login.get("uris") or []
+        url = (uris[0].get("uri") if uris and isinstance(uris[0], dict) else "") or ""
+        out.append(
+            {
+                "name": slugify_name(item.get("name", "")),
+                "username": login.get("username") or "",
+                "password": password,
+                "url": url,
+                "totp": login.get("totp") or "",
+                "notes": item.get("notes") or "",
+            }
+        )
+    return out
+
+
+class SecretStore:
+    """Vault storage + ACL + resolution on top of the config database."""
+
+    def __init__(
+        self,
+        db_path: str = "data/config.db",
+        infra_vault: InfraVault | None = None,
+        persona_vault: PersonaVault | None = None,
+    ) -> None:
+        self.db_path = db_path
+        self.infra = infra_vault if infra_vault is not None else InfraVault(load_machine_key())
+        self.persona = persona_vault if persona_vault is not None else PersonaVault()
+        self._ready = False
+        self._infra_cache: dict[str, str] = {}
+
+    async def _ensure_schema(self) -> None:
+        if self._ready:
+            return
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.executescript(_SCHEMA)
+        self._ready = True
+
+    # -- Persona vault lifecycle --------------------------------------------
+
+    async def ensure_wrapped_dek(self, password: str) -> bool:
+        """Create the wrapped DEK if none exists (first admin-password set).
+
+        Returns True if a DEK was created. Also unseals the vault in-process.
+        """
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("SELECT wrapped_dek, salt FROM vault_meta WHERE id = 1")
+            row = await cur.fetchone()
+            if row and row[0] and row[1]:
+                # Already initialised — just unseal in memory.
+                self.persona.unseal(password, row[0], row[1])
+                return False
+            wrapped, salt = PersonaVault.create_wrapped_dek(password)
+            await db.execute(
+                "INSERT INTO vault_meta (id, wrapped_dek, salt) VALUES (1, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET wrapped_dek = excluded.wrapped_dek, "
+                "salt = excluded.salt",
+                (wrapped, salt),
+            )
+            await db.commit()
+        self.persona.unseal(password, wrapped, salt)
+        return True
+
+    async def unseal_persona(self, password: str) -> bool:
+        """Unwrap + cache the DEK using the admin password. Idempotent."""
+        await self._ensure_schema()
+        if self.persona.unsealed:
+            return True
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("SELECT wrapped_dek, salt FROM vault_meta WHERE id = 1")
+            row = await cur.fetchone()
+        if not row or not row[0] or not row[1]:
+            return False
+        return self.persona.unseal(password, row[0], row[1])
+
+    async def rotate_password(self, old_password: str, new_password: str) -> None:
+        """Re-wrap the DEK under a new admin password (or create it if missing)."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("SELECT wrapped_dek, salt FROM vault_meta WHERE id = 1")
+            row = await cur.fetchone()
+            if row and row[0] and row[1]:
+                from cryptography.fernet import InvalidToken
+
+                try:
+                    wrapped, salt = PersonaVault.rewrap(old_password, new_password, row[0], row[1])
+                except InvalidToken, ValueError, TypeError:
+                    # Old password wrong (or meta corrupt): cannot preserve the DEK.
+                    # Leave existing secrets intact under the old wrapping rather than
+                    # silently orphaning them.
+                    log.warning("Vault rewrap skipped: could not unwrap DEK with old password")
+                    return
+            else:
+                wrapped, salt = PersonaVault.create_wrapped_dek(new_password)
+            await db.execute(
+                "INSERT INTO vault_meta (id, wrapped_dek, salt) VALUES (1, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET wrapped_dek = excluded.wrapped_dek, "
+                "salt = excluded.salt",
+                (wrapped, salt),
+            )
+            await db.commit()
+        self.persona.unseal(new_password, wrapped, salt)
+
+    def persona_unsealed(self) -> bool:
+        return self.persona.unsealed
+
+    def lock_persona(self) -> None:
+        self.persona.lock()
+
+    # -- Persona secret CRUD -------------------------------------------------
+
+    async def set_secret(
+        self,
+        name: str,
+        value: str | dict,
+        *,
+        shared: bool = False,
+        owner: str = "",
+        description: str = "",
+        expires_at: str | None = None,
+        max_uses: int | None = None,
+    ) -> None:
+        """Encrypt and upsert a persona secret. ``value`` may be a scalar or dict."""
+        await self._ensure_schema()
+        if not valid_name(name):
+            raise ValueError(f"invalid secret name: {name!r}")
+        structured = isinstance(value, dict)
+        plaintext = json.dumps(value) if structured else str(value)
+        token = self.persona.encrypt(plaintext)  # raises VaultLocked if sealed
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "INSERT INTO secrets "
+                "(name, value, structured, shared, owner, description, expires_at, max_uses, "
+                " use_count, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, datetime('now'), datetime('now')) "
+                "ON CONFLICT(name) DO UPDATE SET value = excluded.value, "
+                "structured = excluded.structured, shared = excluded.shared, "
+                "owner = excluded.owner, description = excluded.description, "
+                "expires_at = excluded.expires_at, max_uses = excluded.max_uses, "
+                "use_count = 0, updated_at = datetime('now')",
+                (
+                    name,
+                    token,
+                    1 if structured else 0,
+                    1 if shared else 0,
+                    owner,
+                    description,
+                    expires_at,
+                    max_uses,
+                ),
+            )
+            await db.commit()
+
+    async def get_secret(self, name: str) -> str | dict | None:
+        """Decrypt and return a secret value (scalar or dict), or None if absent."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("SELECT value, structured FROM secrets WHERE name = ?", (name,))
+            row = await cur.fetchone()
+        if not row:
+            return None
+        plaintext = self.persona.decrypt(row[0])  # raises VaultLocked if sealed
+        return json.loads(plaintext) if row[1] else plaintext
+
+    async def delete_secret(self, name: str) -> bool:
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("DELETE FROM secrets WHERE name = ?", (name,))
+            await db.commit()
+            return cur.rowcount > 0
+
+    async def shared_names(self) -> set[str]:
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("SELECT name FROM secrets WHERE shared = 1")
+            return {r[0] for r in await cur.fetchall()}
+
+    async def list_secret_meta(self, allowed: set[str] | None = None) -> list[dict]:
+        """List secret metadata — NEVER values. Optionally filter to ``allowed``."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cur = await db.execute(
+                "SELECT name, structured, shared, owner, description, expires_at, "
+                "max_uses, use_count, last_used_at FROM secrets ORDER BY name"
+            )
+            rows = await cur.fetchall()
+        out = []
+        for r in rows:
+            if allowed is not None and r["name"] not in allowed and not r["shared"]:
+                continue
+            out.append(
+                {
+                    "name": r["name"],
+                    "structured": bool(r["structured"]),
+                    "shared": bool(r["shared"]),
+                    "owner": r["owner"],
+                    "description": r["description"],
+                    "expires_at": r["expires_at"],
+                    "max_uses": r["max_uses"],
+                    "use_count": r["use_count"],
+                    "last_used_at": r["last_used_at"],
+                }
+            )
+        return out
+
+    # -- Resolution (the run_command substitution boundary) ------------------
+
+    async def resolve_command_secrets(
+        self, command: str, allowed: set[str] | None
+    ) -> tuple[str, str | None]:
+        """Substitute ``{{secret:NAME[.field]}}`` in ``command`` after an ACL check.
+
+        ``allowed`` is the set of names the active persona may use; shared
+        secrets are always permitted. ``allowed=None`` bypasses the ACL (used
+        only for trusted, agent-constructed commands — never for model input).
+
+        Returns ``(resolved_command, error)``. On any error the original command
+        is returned unchanged and ``error`` is a message for the model. Single-use
+        and audit accounting is applied only after every placeholder resolves.
+        """
+        matches = list(_PLACEHOLDER_RE.finditer(command))
+        if not matches:
+            return command, None
+
+        if not self.persona.unsealed:
+            return command, (
+                "Secrets vault is locked. Ask the owner to open the admin UI to unlock it."
+            )
+
+        acl = None if allowed is None else (set(allowed) | await self.shared_names())
+
+        # Validate + decrypt every referenced secret before substituting any.
+        resolved_values: dict[tuple[str, str | None], str] = {}
+        used_names: set[str] = set()
+        for m in matches:
+            name, field = m.group(1), m.group(2)
+            if acl is not None and name not in acl:
+                return command, (
+                    f"Secret '{name}' is not in this persona's scope. "
+                    "Request access or use a permitted secret."
+                )
+            value, err = await self._materialize(name)
+            if err:
+                return command, err
+            if field is not None:
+                if not isinstance(value, dict):
+                    return command, f"Secret '{name}' is not structured; '.{field}' is invalid."
+                if field not in value:
+                    return command, f"Secret '{name}' has no field '{field}'."
+                resolved_values[(name, field)] = str(value[field])
+            else:
+                if isinstance(value, dict):
+                    return command, (
+                        f"Secret '{name}' is structured; reference a field as "
+                        f"{{{{secret:{name}.<field>}}}}."
+                    )
+                resolved_values[(name, field)] = str(value)
+            used_names.add(name)
+
+        def _sub(m: re.Match) -> str:
+            return resolved_values[(m.group(1), m.group(2))]
+
+        resolved = _PLACEHOLDER_RE.sub(_sub, command)
+        await self._record_use(used_names)
+        return resolved, None
+
+    async def _materialize(self, name: str) -> tuple[str | dict | None, str | None]:
+        """Fetch + decrypt a secret, honouring expiry. Returns (value, error)."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                "SELECT value, structured, expires_at FROM secrets WHERE name = ?", (name,)
+            )
+            row = await cur.fetchone()
+        if not row:
+            return None, (
+                f"Secret '{name}' is not available. Use request_secret to ask the owner for it."
+            )
+        expires = _parse_iso(row[2])
+        if expires and _now() > expires:
+            return None, f"Secret '{name}' has expired."
+        try:
+            plaintext = self.persona.decrypt(row[0])
+        except VaultLocked:
+            return None, "Secrets vault is locked."
+        value = json.loads(plaintext) if row[1] else plaintext
+        return value, None
+
+    async def _record_use(self, names: set[str]) -> None:
+        """Audit a successful resolution; delete single-use secrets once consumed."""
+        if not names:
+            return
+        async with aiosqlite.connect(self.db_path) as db:
+            for name in names:
+                await db.execute(
+                    "UPDATE secrets SET use_count = use_count + 1, "
+                    "last_used_at = datetime('now') WHERE name = ?",
+                    (name,),
+                )
+                # Single-use ("once"): drop the row once its budget is spent.
+                await db.execute(
+                    "DELETE FROM secrets WHERE name = ? AND max_uses IS NOT NULL "
+                    "AND use_count >= max_uses",
+                    (name,),
+                )
+            await db.commit()
+
+    # -- Secret requests (secure-link flow) ----------------------------------
+
+    async def create_request(
+        self,
+        name: str,
+        persona: str = "",
+        reason: str = "",
+        suggested_scope: str = "",
+        ttl_sec: int = 86_400,
+    ) -> str:
+        """Create a pending secret request and return the one-time token (plaintext).
+
+        Only the SHA-256 of the token is stored; the plaintext goes into the
+        secure link and is never persisted.
+        """
+        await self._ensure_schema()
+        token = _secrets.token_urlsafe(32)
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        expires = datetime.fromtimestamp(_now().timestamp() + ttl_sec, tz=UTC).isoformat()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "INSERT INTO secret_requests "
+                "(token_hash, name, persona, reason, suggested_scope, status, expires_at) "
+                "VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+                (token_hash, name, persona, reason, suggested_scope, expires),
+            )
+            await db.commit()
+        return token
+
+    async def get_request(self, token: str) -> dict | None:
+        """Return a pending, unexpired request by token, or None."""
+        await self._ensure_schema()
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cur = await db.execute(
+                "SELECT * FROM secret_requests WHERE token_hash = ? AND status = 'pending'",
+                (token_hash,),
+            )
+            row = await cur.fetchone()
+        if not row:
+            return None
+        expires = _parse_iso(row["expires_at"])
+        if expires and _now() > expires:
+            return None
+        return dict(row)
+
+    async def resolve_request(self, token: str) -> bool:
+        await self._ensure_schema()
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                "UPDATE secret_requests SET status = 'done' "
+                "WHERE token_hash = ? AND status = 'pending'",
+                (token_hash,),
+            )
+            await db.commit()
+            return cur.rowcount > 0
+
+    # -- Infra secrets (machine-key vault) -----------------------------------
+
+    async def set_infra_secret(self, name: str, value: str, description: str = "") -> None:
+        await self._ensure_schema()
+        if not self.infra.available:
+            raise RuntimeError("infra vault has no machine key configured")
+        if not valid_name(name):
+            raise ValueError(f"invalid infra secret name: {name!r}")
+        token = self.infra.encrypt(value)
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "INSERT INTO infra_secrets (name, value, description, updated_at) "
+                "VALUES (?, ?, ?, datetime('now')) "
+                "ON CONFLICT(name) DO UPDATE SET value = excluded.value, "
+                "description = excluded.description, updated_at = datetime('now')",
+                (name, token, description),
+            )
+            await db.commit()
+        self._infra_cache[name] = value
+
+    async def get_infra_secret(self, name: str) -> str | None:
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("SELECT value FROM infra_secrets WHERE name = ?", (name,))
+            row = await cur.fetchone()
+        if not row:
+            return None
+        return self.infra.decrypt(row[0])
+
+    async def delete_infra_secret(self, name: str) -> bool:
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("DELETE FROM infra_secrets WHERE name = ?", (name,))
+            await db.commit()
+        self._infra_cache.pop(name, None)
+        return cur.rowcount > 0
+
+    async def list_infra_names(self) -> list[dict]:
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            cur = await db.execute(
+                "SELECT name, description, updated_at FROM infra_secrets ORDER BY name"
+            )
+            return [dict(r) for r in await cur.fetchall()]
+
+    async def load_infra_cache(self) -> dict[str, str]:
+        """Decrypt every infra secret into memory for the sync ``${vault:}`` resolver.
+
+        Called at boot (the infra vault is available headlessly). If the machine
+        key is missing, the cache stays empty and ``${vault:}`` falls back to env.
+        """
+        await self._ensure_schema()
+        self._infra_cache = {}
+        if not self.infra.available:
+            return self._infra_cache
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute("SELECT name, value FROM infra_secrets")
+            rows = await cur.fetchall()
+        for name, token in rows:
+            try:
+                self._infra_cache[name] = self.infra.decrypt(token)
+            except Exception:
+                log.warning("Failed to decrypt infra secret %r (wrong machine key?)", name)
+        return self._infra_cache
+
+    def infra_resolve(self, name: str) -> str | None:
+        """Sync resolver for ``${vault:NAME}`` — cache, then ``.env`` fallback."""
+        import os
+
+        if name in self._infra_cache:
+            return self._infra_cache[name]
+        return os.environ.get(name)
+
+
+if __name__ == "__main__":
+    # ponytail: one runnable check exercising the full lifecycle on a temp db.
+    import asyncio
+    import tempfile
+
+    def _check_bitwarden() -> None:
+        export = {
+            "items": [
+                {
+                    "type": 1,
+                    "name": "ACME Portal",
+                    "login": {
+                        "username": "me@x.com",
+                        "password": "p@ss",
+                        "uris": [{"uri": "https://acme.test"}],
+                        "totp": "JBSWY3DPEHPK3PXP",
+                    },
+                    "notes": "n",
+                },
+                {"type": 2, "name": "a secure note"},  # not a login -> skipped
+                {"type": 1, "name": "no password", "login": {"username": "x"}},  # skipped
+            ]
+        }
+        items = parse_bitwarden_export(export)
+        assert len(items) == 1, items
+        assert items[0]["name"] == "ACME_Portal"
+        assert items[0]["password"] == "p@ss"
+        assert items[0]["url"] == "https://acme.test"
+
+    async def _check_store() -> None:
+        with tempfile.TemporaryDirectory() as d:
+            store = SecretStore(db_path=str(Path(d) / "config.db"))
+            # Persona vault must be initialised + unsealed before writes.
+            await store.ensure_wrapped_dek("admin-pw")
+            assert store.persona_unsealed()
+
+            # Scalar secret + ACL resolution.
+            await store.set_secret("STRIPE", "sk_live_abc", owner="persona:finance")
+            cmd = "curl -H 'Authorization: Bearer {{secret:STRIPE}}' https://api"
+            resolved, err = await store.resolve_command_secrets(cmd, allowed={"STRIPE"})
+            assert err is None and "sk_live_abc" in resolved and "{{secret" not in resolved
+
+            # ACL denial: not in scope, not shared.
+            _, err = await store.resolve_command_secrets(cmd, allowed=set())
+            assert err and "scope" in err
+
+            # Shared secret is allowed regardless of persona scope.
+            await store.set_secret("GLOBAL", "g", shared=True)
+            _, err = await store.resolve_command_secrets("x {{secret:GLOBAL}}", allowed=set())
+            assert err is None
+
+            # Structured secret + field reference.
+            await store.set_secret("ACME", {"username": "u", "password": "pw"}, owner="persona:x")
+            r, err = await store.resolve_command_secrets(
+                "login {{secret:ACME.username}}:{{secret:ACME.password}}", allowed={"ACME"}
+            )
+            assert err is None and r == "login u:pw", r
+            # Scalar referenced with a field, or struct referenced bare -> errors.
+            _, err = await store.resolve_command_secrets("{{secret:STRIPE.x}}", allowed={"STRIPE"})
+            assert err and "not structured" in err
+            _, err = await store.resolve_command_secrets("{{secret:ACME}}", allowed={"ACME"})
+            assert err and "structured" in err
+
+            # Single-use ("once"): resolves once, then gone.
+            await store.set_secret("ONCE", "one-shot", max_uses=1)
+            r, err = await store.resolve_command_secrets("use {{secret:ONCE}}", allowed={"ONCE"})
+            assert err is None and "one-shot" in r
+            assert await store.get_secret("ONCE") is None  # consumed + deleted
+            _, err = await store.resolve_command_secrets("use {{secret:ONCE}}", allowed={"ONCE"})
+            assert err and "not available" in err
+
+            # Expiry.
+            past = "2000-01-01T00:00:00+00:00"
+            await store.set_secret("OLD", "v", expires_at=past)
+            _, err = await store.resolve_command_secrets("{{secret:OLD}}", allowed={"OLD"})
+            assert err and "expired" in err
+
+            # Audit recorded.
+            meta = {m["name"]: m for m in await store.list_secret_meta()}
+            assert meta["STRIPE"]["use_count"] == 1 and meta["STRIPE"]["last_used_at"]
+            # list_secret_meta never leaks values.
+            assert "value" not in meta["STRIPE"]
+
+            # Requests: one-time token, hash-stored, redeemable once.
+            tok = await store.create_request("NEWKEY", persona="finance", reason="need it")
+            req = await store.get_request(tok)
+            assert req and req["name"] == "NEWKEY" and req["status"] == "pending"
+            assert await store.resolve_request(tok)
+            assert await store.get_request(tok) is None  # no longer pending
+
+            # Locked vault refuses resolution.
+            store.lock_persona()
+            _, err = await store.resolve_command_secrets("{{secret:GLOBAL}}", allowed={"GLOBAL"})
+            assert err and "locked" in err
+
+            # Infra vault round-trip (machine key supplied directly).
+            store2 = SecretStore(
+                db_path=str(Path(d) / "config2.db"), infra_vault=InfraVault("machine-key")
+            )
+            await store2.set_infra_secret("ANTHROPIC_API_KEY", "sk-ant-xyz")
+            await store2.load_infra_cache()
+            assert store2.infra_resolve("ANTHROPIC_API_KEY") == "sk-ant-xyz"
+            assert store2.infra_resolve("MISSING") is None
+
+    _check_bitwarden()
+    asyncio.run(_check_store())
+    print("secret_store.py self-check OK")

--- a/core/secret_store.py
+++ b/core/secret_store.py
@@ -21,6 +21,7 @@ dispatch — never in message/email tool bodies. See ``core/agent.py``.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -30,6 +31,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import aiosqlite
+from cryptography.fernet import InvalidToken
 
 from core.vault import InfraVault, PersonaVault, VaultLocked, load_machine_key
 
@@ -146,6 +148,11 @@ class SecretStore:
         self.persona = persona_vault if persona_vault is not None else PersonaVault()
         self._ready = False
         self._infra_cache: dict[str, str] = {}
+        # Serializes secret resolution so single-use ("once") secrets cannot be
+        # consumed twice by concurrent run_command calls (TOCTOU).
+        # ponytail: global lock; fine for a single-user agent — revisit if
+        # secret resolution ever becomes a throughput bottleneck.
+        self._resolve_lock = asyncio.Lock()
 
     async def _ensure_schema(self) -> None:
         if self._ready:
@@ -168,7 +175,11 @@ class SecretStore:
             row = await cur.fetchone()
             if row and row[0] and row[1]:
                 # Already initialised — just unseal in memory.
-                self.persona.unseal(password, row[0], row[1])
+                if not self.persona.unseal(password, row[0], row[1]):
+                    log.warning(
+                        "Persona vault already initialised but could not be unsealed with "
+                        "this password (password may differ from the one that wrapped the DEK)"
+                    )
                 return False
             wrapped, salt = PersonaVault.create_wrapped_dek(password)
             await db.execute(
@@ -200,16 +211,10 @@ class SecretStore:
             cur = await db.execute("SELECT wrapped_dek, salt FROM vault_meta WHERE id = 1")
             row = await cur.fetchone()
             if row and row[0] and row[1]:
-                from cryptography.fernet import InvalidToken
-
-                try:
-                    wrapped, salt = PersonaVault.rewrap(old_password, new_password, row[0], row[1])
-                except InvalidToken, ValueError, TypeError:
-                    # Old password wrong (or meta corrupt): cannot preserve the DEK.
-                    # Leave existing secrets intact under the old wrapping rather than
-                    # silently orphaning them.
-                    log.warning("Vault rewrap skipped: could not unwrap DEK with old password")
-                    return
+                # Raises InvalidToken if old_password can't unwrap the DEK — the
+                # caller (change_admin_password) must abort the password change so
+                # we never advance the auth hash while orphaning the vault.
+                wrapped, salt = PersonaVault.rewrap(old_password, new_password, row[0], row[1])
             else:
                 wrapped, salt = PersonaVault.create_wrapped_dek(new_password)
             await db.execute(
@@ -338,52 +343,63 @@ class SecretStore:
         Returns ``(resolved_command, error)``. On any error the original command
         is returned unchanged and ``error`` is a message for the model. Single-use
         and audit accounting is applied only after every placeholder resolves.
+        Resolution is serialized (a lock) so a single-use secret cannot be
+        consumed twice by concurrent calls.
         """
-        matches = list(_PLACEHOLDER_RE.finditer(command))
-        if not matches:
+        if "{{secret:" not in command:
             return command, None
 
-        if not self.persona.unsealed:
-            return command, (
-                "Secrets vault is locked. Ask the owner to open the admin UI to unlock it."
-            )
-
-        acl = None if allowed is None else (set(allowed) | await self.shared_names())
-
-        # Validate + decrypt every referenced secret before substituting any.
-        resolved_values: dict[tuple[str, str | None], str] = {}
-        used_names: set[str] = set()
-        for m in matches:
-            name, field = m.group(1), m.group(2)
-            if acl is not None and name not in acl:
+        async with self._resolve_lock:
+            if not self.persona.unsealed:
                 return command, (
-                    f"Secret '{name}' is not in this persona's scope. "
-                    "Request access or use a permitted secret."
+                    "Secrets vault is locked. Ask the owner to open the admin UI to unlock it."
                 )
-            value, err = await self._materialize(name)
-            if err:
-                return command, err
-            if field is not None:
-                if not isinstance(value, dict):
-                    return command, f"Secret '{name}' is not structured; '.{field}' is invalid."
-                if field not in value:
-                    return command, f"Secret '{name}' has no field '{field}'."
-                resolved_values[(name, field)] = str(value[field])
-            else:
-                if isinstance(value, dict):
+
+            acl = None if allowed is None else (set(allowed) | await self.shared_names())
+
+            # Validate + decrypt every referenced secret before substituting any.
+            matches = list(_PLACEHOLDER_RE.finditer(command))
+            resolved_values: dict[tuple[str, str | None], str] = {}
+            used_names: set[str] = set()
+            for m in matches:
+                name, field = m.group(1), m.group(2)
+                if acl is not None and name not in acl:
                     return command, (
-                        f"Secret '{name}' is structured; reference a field as "
-                        f"{{{{secret:{name}.<field>}}}}."
+                        f"Secret '{name}' is not in this persona's scope. "
+                        "Request access or use a permitted secret."
                     )
-                resolved_values[(name, field)] = str(value)
-            used_names.add(name)
+                value, err = await self._materialize(name)
+                if err:
+                    return command, err
+                if field is not None:
+                    if not isinstance(value, dict):
+                        return command, f"Secret '{name}' is not structured; '.{field}' is invalid."
+                    if field not in value:
+                        return command, f"Secret '{name}' has no field '{field}'."
+                    resolved_values[(name, field)] = str(value[field])
+                else:
+                    if isinstance(value, dict):
+                        return command, (
+                            f"Secret '{name}' is structured; reference a field as "
+                            f"{{{{secret:{name}.<field>}}}}."
+                        )
+                    resolved_values[(name, field)] = str(value)
+                used_names.add(name)
 
-        def _sub(m: re.Match) -> str:
-            return resolved_values[(m.group(1), m.group(2))]
+            def _sub(m: re.Match) -> str:
+                return resolved_values[(m.group(1), m.group(2))]
 
-        resolved = _PLACEHOLDER_RE.sub(_sub, command)
-        await self._record_use(used_names)
-        return resolved, None
+            resolved = _PLACEHOLDER_RE.sub(_sub, command)
+            # A leftover ``{{secret:`` means a malformed reference (e.g. multi-dot
+            # or empty name) that matched nothing. Refuse rather than execute a
+            # command with an unresolved placeholder.
+            if "{{secret:" in resolved:
+                return command, (
+                    "Malformed secret reference — use {{secret:NAME}} or {{secret:NAME.field}} "
+                    "(names allow letters, digits, _ - : and at most one .field)."
+                )
+            await self._record_use(used_names)
+            return resolved, None
 
     async def _materialize(self, name: str) -> tuple[str | dict | None, str | None]:
         """Fetch + decrypt a secret, honouring expiry. Returns (value, error)."""
@@ -403,6 +419,11 @@ class SecretStore:
             plaintext = self.persona.decrypt(row[0])
         except VaultLocked:
             return None, "Secrets vault is locked."
+        except InvalidToken:
+            # Ciphertext was written under a different DEK (e.g. a restored DB or
+            # a vault re-init). Surface a model-safe error instead of crashing.
+            log.warning("Secret %r could not be decrypted (DEK mismatch)", name)
+            return None, f"Secret '{name}' could not be decrypted (vault key mismatch)."
         value = json.loads(plaintext) if row[1] else plaintext
         return value, None
 

--- a/core/vault.py
+++ b/core/vault.py
@@ -94,9 +94,14 @@ def generate_and_save_machine_key(keyfile: str = DEFAULT_KEYFILE) -> str:
         return path.read_text().strip()
     path.parent.mkdir(parents=True, exist_ok=True)
     key = Fernet.generate_key().decode()
-    path.write_text(key)
+    # Create with 0600 atomically (no world-readable window between write + chmod).
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
-        path.chmod(0o600)
+        os.write(fd, key.encode())
+    finally:
+        os.close(fd)
+    try:
+        path.chmod(0o600)  # tighten if the file pre-existed with looser perms
     except OSError:
         pass  # best-effort on filesystems without POSIX perms
     return key

--- a/core/vault.py
+++ b/core/vault.py
@@ -1,0 +1,239 @@
+"""Encryption primitives + key management for the secrets vault (issue #19).
+
+Two vaults, two keys — because the two kinds of secret have different unseal
+requirements:
+
+* :class:`InfraVault` — encrypts *infrastructure* secrets (provider keys, bot
+  token, …). Its key is a **machine key** read from the environment / a keyfile,
+  so the vault unseals at boot, headless, with no human present. Same on-disk
+  posture as the existing ``.env`` (a key sitting on the data volume), just
+  consolidated and editable in the UI.
+
+* :class:`PersonaVault` — encrypts *persona / login* secrets (website logins,
+  payment keys, …). It uses **envelope encryption**: a random Data-Encryption
+  Key (DEK) encrypts the secrets, and the DEK is stored *wrapped* by a
+  Key-Encryption Key ``KEK = PBKDF2(admin_password, salt)``. The KEK is derived
+  live at login (never stored), so a stolen disk alone cannot open the vault.
+  Changing the admin password re-wraps the DEK only — the secrets are never
+  re-encrypted. The vault stays locked until :meth:`PersonaVault.unseal`.
+
+This module is pure crypto + key handling: no database, no async. Storage,
+ACL, and resolution live in :mod:`core.secret_store`.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+
+# PBKDF2 work factor for deriving the persona KEK from the admin password.
+# Matches the admin-auth hash cost (core/config_store.py); a *different* salt is
+# used so the stored auth hash can never double as the encryption key.
+KDF_ITERATIONS = 200_000
+
+# Default on-disk location for the machine key when neither env var is set.
+# Lives on the data volume (gitignored), so the infra vault unseals at boot
+# without forcing the user to edit their environment.
+DEFAULT_KEYFILE = "data/master.key"
+
+
+def _coerce_fernet_key(value: str | bytes) -> bytes:
+    """Turn any string into a valid Fernet key.
+
+    A real 32-byte url-safe base64 Fernet key is used as-is; anything else
+    (e.g. a human passphrase) is hashed to 32 bytes and base64-encoded. This
+    lets the user set ``MPA_MASTER_KEY`` to either a generated key or a memorable
+    passphrase.
+    """
+    raw = value.encode() if isinstance(value, str) else value
+    try:
+        Fernet(raw)  # validates length + base64 alphabet
+        return raw
+    except ValueError, TypeError:
+        digest = hashlib.sha256(raw).digest()
+        return base64.urlsafe_b64encode(digest)
+
+
+def derive_kek(password: str, salt: bytes) -> bytes:
+    """Derive a Fernet-compatible key-encryption key from a password + salt."""
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode(), salt, KDF_ITERATIONS)
+    return base64.urlsafe_b64encode(dk)
+
+
+def load_machine_key() -> str | None:
+    """Locate the infra-vault machine key.
+
+    Order: ``MPA_MASTER_KEY`` env → ``MPA_MASTER_KEY_FILE`` path → the default
+    keyfile on the data volume. Returns ``None`` when no key is configured (the
+    infra vault is then unavailable and ``${vault:...}`` falls back to env).
+    """
+    env = os.getenv("MPA_MASTER_KEY")
+    if env:
+        return env
+    keyfile = os.getenv("MPA_MASTER_KEY_FILE") or DEFAULT_KEYFILE
+    path = Path(keyfile)
+    if path.exists():
+        text = path.read_text().strip()
+        if text:
+            return text
+    return None
+
+
+def generate_and_save_machine_key(keyfile: str = DEFAULT_KEYFILE) -> str:
+    """Generate a fresh machine key and persist it to ``keyfile`` (0600).
+
+    Used by the setup wizard so a user can enable the infra vault without
+    hand-editing their environment. Never overwrites an existing keyfile.
+    """
+    path = Path(keyfile)
+    if path.exists() and path.read_text().strip():
+        return path.read_text().strip()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = Fernet.generate_key().decode()
+    path.write_text(key)
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass  # best-effort on filesystems without POSIX perms
+    return key
+
+
+class InfraVault:
+    """Symmetric encryption with a machine key (boot-time, headless)."""
+
+    def __init__(self, key: str | bytes | None) -> None:
+        self._fernet = Fernet(_coerce_fernet_key(key)) if key else None
+
+    @property
+    def available(self) -> bool:
+        return self._fernet is not None
+
+    def encrypt(self, plaintext: str) -> bytes:
+        if self._fernet is None:
+            raise RuntimeError("InfraVault has no key configured")
+        return self._fernet.encrypt(plaintext.encode())
+
+    def decrypt(self, token: bytes) -> str:
+        if self._fernet is None:
+            raise RuntimeError("InfraVault has no key configured")
+        return self._fernet.decrypt(token).decode()
+
+
+class PersonaVault:
+    """Envelope encryption: DEK encrypts data, KEK (from password) wraps the DEK.
+
+    Locked until :meth:`unseal`. The DEK lives only in process memory once
+    unsealed; it is never written to disk in usable form.
+    """
+
+    def __init__(self) -> None:
+        self._fernet: Fernet | None = None
+
+    @property
+    def unsealed(self) -> bool:
+        return self._fernet is not None
+
+    @staticmethod
+    def create_wrapped_dek(password: str) -> tuple[str, str]:
+        """Mint a new random DEK wrapped by ``password``.
+
+        Returns ``(wrapped_dek_b64, salt_b64)`` for persistence. Call once when
+        the admin password is first set.
+        """
+        dek = Fernet.generate_key()  # this is itself a valid Fernet key
+        salt = os.urandom(16)
+        wrapped = Fernet(derive_kek(password, salt)).encrypt(dek)
+        return base64.b64encode(wrapped).decode(), base64.b64encode(salt).decode()
+
+    def unseal(self, password: str, wrapped_dek_b64: str, salt_b64: str) -> bool:
+        """Unwrap the DEK with ``password`` and cache it. Returns success."""
+        try:
+            salt = base64.b64decode(salt_b64)
+            wrapped = base64.b64decode(wrapped_dek_b64)
+            dek = Fernet(derive_kek(password, salt)).decrypt(wrapped)
+        except InvalidToken, ValueError, TypeError:
+            return False
+        self._fernet = Fernet(dek)
+        return True
+
+    @staticmethod
+    def rewrap(
+        old_password: str, new_password: str, wrapped_dek_b64: str, salt_b64: str
+    ) -> tuple[str, str]:
+        """Re-wrap the existing DEK under a new password (password rotation).
+
+        Preserves the DEK so every stored secret stays decryptable; only the
+        wrapping changes. Raises :class:`InvalidToken` if ``old_password`` is wrong.
+        """
+        salt = base64.b64decode(salt_b64)
+        wrapped = base64.b64decode(wrapped_dek_b64)
+        dek = Fernet(derive_kek(old_password, salt)).decrypt(wrapped)
+        new_salt = os.urandom(16)
+        new_wrapped = Fernet(derive_kek(new_password, new_salt)).encrypt(dek)
+        return base64.b64encode(new_wrapped).decode(), base64.b64encode(new_salt).decode()
+
+    def lock(self) -> None:
+        self._fernet = None
+
+    def encrypt(self, plaintext: str) -> bytes:
+        if self._fernet is None:
+            raise VaultLocked("persona vault is locked")
+        return self._fernet.encrypt(plaintext.encode())
+
+    def decrypt(self, token: bytes) -> str:
+        if self._fernet is None:
+            raise VaultLocked("persona vault is locked")
+        return self._fernet.decrypt(token).decode()
+
+
+class VaultLocked(RuntimeError):
+    """Raised when a persona-vault operation is attempted while sealed."""
+
+
+if __name__ == "__main__":
+    # ponytail: one runnable check covering both vaults + the envelope invariants.
+    # Infra vault round-trip.
+    iv = InfraVault("a-memorable-passphrase")
+    assert iv.available
+    tok = iv.encrypt("sk-infra-123")
+    assert iv.decrypt(tok) == "sk-infra-123"
+    # A different key cannot read it.
+    try:
+        InfraVault("other").decrypt(tok)
+        raise AssertionError("cross-key decrypt should fail")
+    except InvalidToken:
+        pass
+    # No key configured -> unavailable.
+    assert not InfraVault(None).available
+
+    # Persona vault: locked until unsealed.
+    pv = PersonaVault()
+    assert not pv.unsealed
+    try:
+        pv.encrypt("nope")
+        raise AssertionError("locked vault must refuse encrypt")
+    except VaultLocked:
+        pass
+
+    wrapped, salt = PersonaVault.create_wrapped_dek("hunter2")
+    assert pv.unseal("hunter2", wrapped, salt)
+    assert pv.unsealed
+    ct = pv.encrypt("stripe-key-xyz")
+    assert pv.decrypt(ct) == "stripe-key-xyz"
+
+    # Wrong password fails to unseal a fresh vault.
+    assert not PersonaVault().unseal("wrong", wrapped, salt)
+
+    # Password rotation re-wraps the DEK but preserves stored data.
+    new_wrapped, new_salt = PersonaVault.rewrap("hunter2", "hunter3", wrapped, salt)
+    pv2 = PersonaVault()
+    assert pv2.unseal("hunter3", new_wrapped, new_salt)
+    assert pv2.decrypt(ct) == "stripe-key-xyz"  # same DEK -> old ciphertext still readable
+    # Old password no longer unseals the rewrapped DEK.
+    assert not PersonaVault().unseal("hunter2", new_wrapped, new_salt)
+
+    print("vault.py self-check OK")

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -85,6 +85,14 @@ Configure conversation history and browse stored turns:
 - **Mode** — `injection` (replay the last N user/assistant pairs each request) or `session` (sticky per-chat session, full context, cache-friendly). Reset a conversation any time by sending `/new` (or its alias `/clear`).
 - **Context compaction** (session mode) — when the conversation nears the model's context window, the oldest turns are summarized by a small model while recent turns are kept verbatim, and the user gets a system message saying it happened. Set the trigger threshold here as either a **percent of the context window** or an **absolute token count** (e.g. 200k), plus how many recent turns to keep. The compaction model is configured in the **LLM** tab (under *History Compaction*). Has no effect in injection mode (which is already windowed).
 
+### Secrets
+
+Manage the [secrets vault](/docs/secrets). Lists secret **names** + descriptions + recent-use
+audit only — values are write-only and never shown. Includes a **persona × secret access
+matrix** (tick to grant a persona use of a secret), add/rotate/revoke, **Bitwarden JSON
+import**, and the infra-secrets section. Responsive at phone width. Sensitive value entry is
+web-only; over Telegram you can see names and access but never values.
+
 ### Logs
 
 Real-time log viewer for debugging and monitoring agent behavior.
@@ -102,7 +110,8 @@ On first boot, the admin UI presents a step-by-step setup wizard:
 7. **Calendar** — set up CalDAV providers
 8. **Search** — configure web search
 9. **Admin** — set admin API key
-10. **Done** — save and start
+10. **Secrets** — generate the vault machine key and migrate existing `.env` secrets into the vault (optional)
+11. **Done** — save and start
 
 The wizard writes to the SQLite config store, which becomes the source of truth after setup.
 

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -10,6 +10,10 @@ MPA uses a dual-layer configuration system:
 1. **File-based** (`config.yml` + `.env`) — seed config loaded on first boot, supports `${ENV_VAR}` interpolation
 2. **SQLite config store** (`data/config.db`) — becomes the source of truth after setup, managed through the admin UI
 
+Config values may also reference the encrypted infra vault with `${vault:NAME}`, which
+resolves at load time and falls back to the environment variable of the same name. See the
+[secrets vault](/docs/secrets).
+
 ## Environment variables (`.env`)
 
 Secrets and API keys live in `.env`. Copy the example to get started:
@@ -33,10 +37,13 @@ Key variables:
 | `TAVILY_API_KEY` | Tavily web search API key |
 | `GOOGLE_EMAIL` | Google account for calendar |
 | `GOOGLE_APP_PASSWORD` | Google app-specific password |
+| `MPA_MASTER_KEY` | Infra [secrets vault](/docs/secrets) machine key (optional; a `data/master.key` keyfile is used if unset) |
+| `MPA_BASE_URL` | Base URL for secure "provide a secret" links (defaults to `http://localhost:<admin port>`) |
 
 ## Agent config (`config.yml`)
 
-The main configuration file. Supports `${ENV_VAR}` interpolation for secrets.
+The main configuration file. Supports `${ENV_VAR}` interpolation for secrets, and
+`${vault:NAME}` references to the encrypted [secrets vault](/docs/secrets) (with `.env` fallback).
 
 ### Full example
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -12,6 +12,7 @@
     "personae",
     "memory",
     "permissions",
+    "secrets",
     "scheduler",
     "voice",
     "admin-ui",

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -16,7 +16,7 @@ A persona is exactly these things:
 - a **skill allowlist** — which skills it may load (empty = all);
 - a **tool scope** — which function-tools are advertised (empty = all; `load_skill` is always available);
 - a **voice** — a TTS voice override (empty = the configured default);
-- a **secret scope** — vault namespaces it may use (stored now; enforced once the [secrets vault](https://github.com/mattmezza/mpa/issues/19) lands).
+- a **secret scope** — which [vault](/docs/secrets) secrets it may use, enforced as a reference-only ACL (a persona may use a secret only if it is shared or named in this scope).
 
 When **no** persona is active, the agent uses the configured `character` / `personalia` from
 the **Assistant** tab — so first-run behaviour is unchanged. The default identity *is* the
@@ -111,5 +111,7 @@ Persona resolution is deliberately funnelled through one seam,
 - **Per-chat personae** ([#14](https://github.com/mattmezza/mpa/issues/14)) — bind a persona
   per Telegram forum topic (history is already keyed by `chat_id`), so several personae run
   concurrently, each with its own isolated context, identity, scope, and voice.
-- **Secrets vault** ([#19](https://github.com/mattmezza/mpa/issues/19)) — turns the stored
-  secret scope into an enforced, reference-only ACL.
+
+The **secret scope** facet is now enforced by the [secrets vault](/docs/secrets) — a persona
+uses a secret by reference (`{{secret:NAME}}`) only if it is shared or in scope, and values
+never enter the model's context.

--- a/docs/content/docs/secrets.mdx
+++ b/docs/content/docs/secrets.mdx
@@ -77,8 +77,10 @@ refused before the command runs. Subagents inherit-never-widen.
 
 ### Discovery and requests
 
-- The persona's system prompt lists the **names** of secrets in scope (never values), and
-  the agent has a `list_secrets` tool that returns names + descriptions only.
+- The system prompt carries only a short, static pointer telling the agent a vault exists
+  and to call the **`list_secrets`** tool before logging in — it returns names +
+  descriptions only (never values). Names are discovered on demand, so the full vault is
+  never dumped into the model's context.
 - If the agent needs a secret it doesn't have, it calls `request_secret`. You receive a
   **secure one-time link** (over Telegram, link only — never a value) to a web form where
   you enter the value and choose its scope (this persona / specific personas / all) and

--- a/docs/content/docs/secrets.mdx
+++ b/docs/content/docs/secrets.mdx
@@ -1,0 +1,126 @@
+---
+title: Secrets vault
+description: Encrypted, two-tier secrets store — infra keys and per-persona login secrets, used by reference so values never reach the model.
+---
+
+# Secrets vault
+
+MPA stores secrets encrypted at rest and lets personas use them **by reference** — a
+secret's value is never placed in the model's context, history, logs, or messages. There
+are **two vaults** with **two different keys**, because the two kinds of secret have
+different unseal requirements.
+
+| | **Infra vault** | **Persona / login vault** |
+|---|---|---|
+| Holds | provider keys, bot token, Tavily, CalDAV/email/contacts creds, `gh` token | website logins, payment keys, agent session tokens |
+| Key | **machine key** (env `MPA_MASTER_KEY` or a keyfile) | derived from your **admin password** (envelope) |
+| Unseals | at boot, headless | when you log into the admin UI |
+| Used as | `${vault:NAME}` in config (with `.env` fallback) | `{{secret:NAME}}` inside `run_command` |
+| Access control | none (app code reads it) | per-persona **secret scope** (ACL) |
+
+Encryption uses [Fernet](https://cryptography.io/en/latest/fernet/) (AES-128-CBC + HMAC).
+
+## Infra vault — `${vault:NAME}`
+
+Infrastructure secrets are read at boot, before anyone logs in, so they are sealed with a
+**machine key** that is available headlessly:
+
+- `MPA_MASTER_KEY` environment variable (a generated key or any passphrase), or
+- a keyfile (default `data/master.key`, auto-generated from the setup wizard).
+
+Any config value can then reference a vault entry: `anthropic_api_key: "${vault:ANTHROPIC_API_KEY}"`.
+At load time `${vault:NAME}` resolves from the infra vault, **falling back to the
+environment variable of the same name** — so you can migrate one secret at a time and
+`.env` keeps working. If no machine key is configured, the vault is simply unavailable and
+every `${vault:NAME}` falls back to env.
+
+The setup wizard's **Secrets** step can generate the machine key and migrate the API keys
+already in your config into the vault in one pass.
+
+## Persona vault — `{{secret:NAME}}`
+
+Login and agent secrets are more sensitive, so the persona vault is sealed with a key
+**derived from your admin password** using envelope encryption: a random Data-Encryption
+Key (DEK) encrypts the secrets, and the DEK is stored *wrapped* by `PBKDF2(admin password)`.
+The password-derived key is computed live at login and never written to disk, so a stolen
+disk alone cannot open this vault. Changing your admin password re-wraps the DEK only — the
+secrets are never re-encrypted.
+
+The vault unseals automatically the first time you open the admin UI after a restart, and
+the DEK is cached in memory so scheduled/autonomous persona jobs can use secrets without you
+present.
+
+### Using a secret
+
+An agent references a secret by name inside the `run_command` tool only:
+
+```
+run_command("curl -H 'Authorization: Bearer {{secret:STRIPE_KEY}}' https://api.stripe.com/...")
+```
+
+Structured (login) secrets expose fields:
+
+```
+{{secret:ACME.username}}  {{secret:ACME.password}}  {{secret:ACME.totp}}
+```
+
+Substitution happens **only** at the `run_command` boundary, after an ACL check —
+**never** in an email, message, or calendar body. This is the core anti-exfiltration
+guarantee: a prompt-injected agent cannot smuggle a secret out through a messaging tool,
+because those tools never resolve `{{secret:...}}`.
+
+### Access control (the persona's secret scope)
+
+A persona may use a secret if it is **shared** (global) or its name is in the persona's
+**secret scope** (the fourth [persona](/docs/personae) facet). A secret outside scope is
+refused before the command runs. Subagents inherit-never-widen.
+
+### Discovery and requests
+
+- The persona's system prompt lists the **names** of secrets in scope (never values), and
+  the agent has a `list_secrets` tool that returns names + descriptions only.
+- If the agent needs a secret it doesn't have, it calls `request_secret`. You receive a
+  **secure one-time link** (over Telegram, link only — never a value) to a web form where
+  you enter the value and choose its scope (this persona / specific personas / all) and
+  duration (once / until a date / forever).
+
+## Admin UI
+
+The **Secrets** tab lists secret **names** + descriptions + recent-use audit (values are
+write-only and never shown), a **persona × secret access matrix**, add/rotate/revoke, the
+Bitwarden import, and the infra-secrets section. It is responsive at phone width.
+
+Over Telegram you can ask the agent to list secret names and who holds them, but **values
+are never entered or shown over chat** — sensitive entry is deep-linked to the web UI.
+
+### Import from Bitwarden
+
+Export your Bitwarden vault as JSON (`bw export --format json`, or the web vault → Export),
+then upload it on the Secrets tab. Login items become secrets you can scope. MPA never sees
+your Bitwarden master password.
+
+## Duration
+
+- **forever** — the default.
+- **until `<date>`** — the secret stops resolving after the date.
+- **once** — single use; the secret is deleted after its first successful resolution.
+
+## Configuration
+
+| Variable | Purpose |
+|----------|---------|
+| `MPA_MASTER_KEY` | Infra-vault machine key. Optional; a keyfile (`data/master.key`) is used if unset. |
+| `MPA_MASTER_KEY_FILE` | Override the keyfile path. |
+| `MPA_BASE_URL` | Base URL used in secure "provide a secret" links (defaults to `http://localhost:<admin port>`). |
+
+> **Tip:** if you seeded the admin password via `ADMIN_PASSWORD` / `ADMIN_API_KEY` in
+> `.env`, remove it after setup. Once the persona vault is keyed by your admin password, a
+> leftover plaintext copy in `.env` weakens that protection. The wizard warns you when it
+> detects this.
+
+## Threat model
+
+Combining a secret store, outbound messaging, and untrusted web content reproduces the
+classic prompt-injection trifecta. Mitigations: reference-only reads; substitution confined
+to `run_command`; per-persona scoping; the persona key never written to disk; audit records
+names/personas/timestamps, never values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "fastembed",
     "numpy",
     "playwright",
+    "cryptography",
 ]
 
 [dependency-groups]

--- a/tests/test_personae.py
+++ b/tests/test_personae.py
@@ -77,11 +77,13 @@ def test_scoped_tools_filters_but_keeps_load_skill() -> None:
 
 def test_gateable_tools_in_sync_with_tools() -> None:
     # The admin UI lists GATEABLE_TOOLS for the scope checkboxes; it must stay
-    # in sync with the real tool set (every tool except always-on load_skill).
+    # in sync with the real tool set (every tool except the always-on ones:
+    # load_skill plus the vault discovery/request tools — issue #19).
     from api.admin import GATEABLE_TOOLS
     from core.agent import TOOLS
 
-    assert set(GATEABLE_TOOLS) | {"load_skill"} == {t["name"] for t in TOOLS}
+    always_on = {"load_skill", "list_secrets", "request_secret"}
+    assert set(GATEABLE_TOOLS) | always_on == {t["name"] for t in TOOLS}
 
 
 def test_prompt_uses_persona_identity() -> None:

--- a/tests/test_secrets_vault.py
+++ b/tests/test_secrets_vault.py
@@ -305,11 +305,20 @@ async def test_request_secret_creates_request_and_link(agent: AgentCore) -> None
     assert req and req["name"] == "ACME_LOGIN" and req["persona"] == "finance"
 
 
-async def test_prompt_lists_secret_names_not_values(agent: AgentCore) -> None:
+async def test_prompt_points_to_tool_not_secret_names(agent: AgentCore) -> None:
+    # Discovery is via the list_secrets tool — the prompt must NOT dump secret
+    # names (context pollution) or values, just a static pointer + usage rule.
     prompt = await agent._build_system_prompt(persona=None)
-    assert "TOKEN" in prompt  # discoverable name
-    assert "SUPERSECRET" not in prompt  # value never injected
+    assert "list_secrets" in prompt  # tells the model how to discover on demand
     assert "{{secret:NAME}}" in prompt  # usage instruction present
+    assert "TOKEN" not in prompt  # the specific secret NAME is not injected
+    assert "SUPERSECRET" not in prompt  # value never injected
+
+
+async def test_no_secrets_block_without_vault() -> None:
+    agent = AgentCore(Config(), secret_store=None)
+    prompt = await agent._build_system_prompt(persona=None)
+    assert "list_secrets" not in prompt  # no vault configured -> no secrets block
 
 
 # ── Admin UI ───────────────────────────────────────────────────────────────

--- a/tests/test_secrets_vault.py
+++ b/tests/test_secrets_vault.py
@@ -126,6 +126,38 @@ async def test_unknown_secret_suggests_request(store: SecretStore) -> None:
     assert err and "request_secret" in err
 
 
+async def test_malformed_placeholder_errors_not_silent(store: SecretStore) -> None:
+    # Multi-dot and empty references match nothing — must error, never pass the
+    # literal placeholder through to execution.
+    await store.set_secret("DB", {"host": "h"})
+    _, err = await store.resolve_command_secrets("{{secret:DB.host.port}}", allowed={"DB"})
+    assert err and "Malformed" in err
+    _, err = await store.resolve_command_secrets("echo {{secret:}}", allowed=set())
+    assert err and "Malformed" in err
+
+
+async def test_decrypt_mismatch_returns_error_not_crash(tmp_path) -> None:
+    db = str(tmp_path / "c.db")
+    s = SecretStore(db_path=db)
+    await s.ensure_wrapped_dek("pw")
+    await s.set_secret("K", "v", shared=True)
+    # Swap in a *different* unsealed DEK so the stored ciphertext can't decrypt.
+    other = PersonaVault()
+    w, salt = PersonaVault.create_wrapped_dek("pw")
+    other.unseal("pw", w, salt)
+    s.persona = other
+    _, err = await s.resolve_command_secrets("{{secret:K}}", allowed=set())
+    assert err and "key mismatch" in err
+
+
+async def test_rotate_password_preserves_secrets_and_rejects_wrong_old(store: SecretStore) -> None:
+    await store.set_secret("K", "v", shared=True)
+    await store.rotate_password("admin-pw", "new-pw")
+    assert await store.get_secret("K") == "v"  # DEK preserved, vault re-unsealed
+    with pytest.raises(InvalidToken):
+        await store.rotate_password("wrong-old", "x")
+
+
 async def test_requests_are_one_time(store: SecretStore) -> None:
     tok = await store.create_request("NEW", persona="finance", reason="r")
     req = await store.get_request(tok)
@@ -356,6 +388,24 @@ async def test_bitwarden_import_parse_and_commit(admin_client) -> None:
     )
     assert commit.status_code == 200
     assert await s.get_secret("Site") == {"username": "u", "password": "pw"}
+
+
+async def test_change_password_rotates_and_keeps_secrets(admin_client) -> None:
+    client, s, _cs = admin_client
+    await s.set_secret("K", "v", shared=True)
+    resp = client.post(
+        "/admin/password",
+        json={"current_password": "testpw", "new_password": "newpw"},
+        headers=_auth("testpw"),
+    )
+    assert resp.json()["ok"] is True
+    assert await s.get_secret("K") == "v"  # secret survives the rotation
+
+
+async def test_wizard_secrets_blocked_after_setup(admin_client) -> None:
+    client, _s, _cs = admin_client  # fixture marks setup complete
+    r = client.post("/setup/step/secrets", data={"action": "generate"})
+    assert r.status_code == 403
 
 
 async def test_wizard_secrets_step_generates_key_and_imports(tmp_path, monkeypatch) -> None:

--- a/tests/test_secrets_vault.py
+++ b/tests/test_secrets_vault.py
@@ -1,0 +1,378 @@
+"""Tests for the secrets vault (issue #19).
+
+Covers: crypto/envelope, ACL-gated resolution, once/expiry, requests, infra
+resolution, Bitwarden import, the prompt-injection exfil boundary (substitution
+happens only in run_command, never in email/message bodies), and the admin UI.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from cryptography.fernet import InvalidToken
+from fastapi.testclient import TestClient
+
+from api.admin import AgentState, create_admin_app
+from core.agent import AgentCore
+from core.config import Config, resolve_vault_vars
+from core.config_store import ConfigStore
+from core.llm import LLMToolCall
+from core.permissions import PermissionLevel
+from core.personae import Persona
+from core.secret_store import SecretStore, parse_bitwarden_export
+from core.vault import InfraVault, PersonaVault, VaultLocked
+
+# ── Crypto / envelope ──────────────────────────────────────────────────────
+
+
+def test_infra_vault_roundtrip_and_isolation() -> None:
+    iv = InfraVault("machine-key")
+    tok = iv.encrypt("sk-123")
+    assert iv.decrypt(tok) == "sk-123"
+    with pytest.raises(InvalidToken):
+        InfraVault("other").decrypt(tok)
+    assert not InfraVault(None).available
+
+
+def test_persona_vault_envelope_and_rotation() -> None:
+    pv = PersonaVault()
+    with pytest.raises(VaultLocked):
+        pv.encrypt("x")
+    wrapped, salt = PersonaVault.create_wrapped_dek("pw1")
+    assert pv.unseal("pw1", wrapped, salt)
+    ct = pv.encrypt("secret")
+    assert pv.decrypt(ct) == "secret"
+    # Wrong password cannot unseal.
+    assert not PersonaVault().unseal("nope", wrapped, salt)
+    # Rotation preserves the DEK -> old ciphertext still decrypts.
+    nw, ns = PersonaVault.rewrap("pw1", "pw2", wrapped, salt)
+    pv2 = PersonaVault()
+    assert pv2.unseal("pw2", nw, ns)
+    assert pv2.decrypt(ct) == "secret"
+    assert not PersonaVault().unseal("pw1", nw, ns)
+
+
+# ── Secret store: ACL, resolution, lifecycle ───────────────────────────────
+
+
+@pytest.fixture
+async def store(tmp_path) -> SecretStore:
+    s = SecretStore(db_path=str(tmp_path / "config.db"))
+    await s.ensure_wrapped_dek("admin-pw")
+    return s
+
+
+async def test_acl_allows_scoped_and_shared(store: SecretStore) -> None:
+    await store.set_secret("PRIV", "p", owner="persona:x")
+    await store.set_secret("SHARED", "s", shared=True)
+    cmd = "curl {{secret:PRIV}} {{secret:SHARED}}"
+    # In scope: both resolve.
+    out, err = await store.resolve_command_secrets(cmd, allowed={"PRIV"})
+    assert err is None and "p" in out and "s" in out
+    # Out of scope: PRIV denied even though SHARED is allowed.
+    _, err = await store.resolve_command_secrets(cmd, allowed=set())
+    assert err and "scope" in err
+    # Shared alone resolves with empty persona scope.
+    out, err = await store.resolve_command_secrets("{{secret:SHARED}}", allowed=set())
+    assert err is None and out == "s"
+
+
+async def test_structured_field_reference(store: SecretStore) -> None:
+    await store.set_secret("ACME", {"username": "u", "password": "pw"})
+    out, err = await store.resolve_command_secrets(
+        "login {{secret:ACME.username}}:{{secret:ACME.password}}", allowed={"ACME"}
+    )
+    assert err is None and out == "login u:pw"
+    _, err = await store.resolve_command_secrets("{{secret:ACME}}", allowed={"ACME"})
+    assert err and "structured" in err
+    await store.set_secret("FLAT", "v")
+    _, err = await store.resolve_command_secrets("{{secret:FLAT.x}}", allowed={"FLAT"})
+    assert err and "not structured" in err
+
+
+async def test_once_is_single_use(store: SecretStore) -> None:
+    await store.set_secret("ONCE", "boom", max_uses=1)
+    out, err = await store.resolve_command_secrets("{{secret:ONCE}}", allowed={"ONCE"})
+    assert err is None and "boom" in out
+    assert await store.get_secret("ONCE") is None
+    _, err = await store.resolve_command_secrets("{{secret:ONCE}}", allowed={"ONCE"})
+    assert err and "not available" in err
+
+
+async def test_expiry_blocks_resolution(store: SecretStore) -> None:
+    await store.set_secret("OLD", "v", expires_at="2000-01-01T00:00:00+00:00")
+    _, err = await store.resolve_command_secrets("{{secret:OLD}}", allowed={"OLD"})
+    assert err and "expired" in err
+
+
+async def test_audit_records_use_never_value(store: SecretStore) -> None:
+    await store.set_secret("K", "v", shared=True)
+    await store.resolve_command_secrets("{{secret:K}}", allowed=set())
+    meta = {m["name"]: m for m in await store.list_secret_meta()}
+    assert meta["K"]["use_count"] == 1 and meta["K"]["last_used_at"]
+    assert "value" not in meta["K"]  # metadata never carries the value
+
+
+async def test_locked_vault_refuses_resolution(store: SecretStore) -> None:
+    await store.set_secret("K", "v", shared=True)
+    store.lock_persona()
+    _, err = await store.resolve_command_secrets("{{secret:K}}", allowed=set())
+    assert err and "locked" in err
+
+
+async def test_unknown_secret_suggests_request(store: SecretStore) -> None:
+    _, err = await store.resolve_command_secrets("{{secret:MISSING}}", allowed={"MISSING"})
+    assert err and "request_secret" in err
+
+
+async def test_requests_are_one_time(store: SecretStore) -> None:
+    tok = await store.create_request("NEW", persona="finance", reason="r")
+    req = await store.get_request(tok)
+    assert req and req["name"] == "NEW"
+    assert await store.resolve_request(tok)
+    assert await store.get_request(tok) is None
+    # A bogus token never resolves.
+    assert await store.get_request("garbage") is None
+
+
+async def test_infra_resolution_with_env_fallback(tmp_path, monkeypatch) -> None:
+    s = SecretStore(db_path=str(tmp_path / "c.db"), infra_vault=InfraVault("mk"))
+    await s.set_infra_secret("ANTHROPIC_API_KEY", "sk-vault")
+    await s.load_infra_cache()
+    assert s.infra_resolve("ANTHROPIC_API_KEY") == "sk-vault"
+    monkeypatch.setenv("FALLBACK_KEY", "from-env")
+    assert s.infra_resolve("FALLBACK_KEY") == "from-env"
+    assert s.infra_resolve("NOPE") is None
+
+
+def test_bitwarden_parse_only_logins() -> None:
+    export = {
+        "items": [
+            {
+                "type": 1,
+                "name": "ACME / Portal",
+                "login": {
+                    "username": "u",
+                    "password": "p",
+                    "uris": [{"uri": "https://acme.test"}],
+                    "totp": "SEED",
+                },
+            },
+            {"type": 2, "name": "note"},
+            {"type": 1, "name": "no pw", "login": {"username": "x"}},
+        ]
+    }
+    items = parse_bitwarden_export(export)
+    assert len(items) == 1
+    assert items[0]["name"] == "ACME_Portal" and items[0]["url"] == "https://acme.test"
+
+
+# ── Config ${vault:NAME} resolution ────────────────────────────────────────
+
+
+def test_resolve_vault_vars() -> None:
+    data = {"a": "${vault:X}", "b": ["${vault:Y}", "plain"], "c": "${vault:MISS}"}
+    out = resolve_vault_vars(data, {"X": "xv", "Y": "yv"}.get)
+    assert out["a"] == "xv" and out["b"][0] == "yv" and out["b"][1] == "plain"
+    assert out["c"] == "${vault:MISS}"  # miss left literal
+
+
+async def test_export_to_config_resolves_vault(tmp_path) -> None:
+    cs = ConfigStore(db_path=str(tmp_path / "config.db"))
+    s = SecretStore(db_path=str(tmp_path / "config.db"), infra_vault=InfraVault("mk"))
+    await cs.set("agent.anthropic_api_key", "${vault:ANTHROPIC_API_KEY}")
+    await s.set_infra_secret("ANTHROPIC_API_KEY", "sk-from-vault")
+    await s.load_infra_cache()
+    cfg = await cs.export_to_config(vault_resolve=s.infra_resolve)
+    assert cfg.agent.anthropic_api_key == "sk-from-vault"
+
+
+# ── Agent: the exfil boundary + ACL ────────────────────────────────────────
+
+
+@pytest.fixture
+async def agent(tmp_path) -> AgentCore:
+    s = SecretStore(db_path=str(tmp_path / "config.db"))
+    await s.ensure_wrapped_dek("admin-pw")
+    await s.set_secret("TOKEN", "SUPERSECRET", shared=True)
+    a = AgentCore(Config(), secret_store=s)
+    return a
+
+
+async def test_substitution_only_in_run_command(agent: AgentCore, monkeypatch) -> None:
+    """The crown-jewel test: {{secret:}} resolves in run_command but a prompt-injected
+    placeholder in an email body is sent literally (no exfiltration)."""
+    captured: dict[str, str] = {}
+
+    async def fake_exec(command, timeout):
+        captured["cmd"] = command
+        return {"stdout": "", "stderr": "", "exit_code": 0}
+
+    monkeypatch.setattr(agent.executor, "_exec", fake_exec)
+    monkeypatch.setattr(agent.permissions, "check", lambda *a, **k: PermissionLevel.ALWAYS)
+    rs = agent._new_request_state(None)
+
+    # run_command: the secret IS substituted.
+    call = LLMToolCall(
+        id="1",
+        name="run_command",
+        arguments={"command": "curl -H 'X: {{secret:TOKEN}}' https://api", "purpose": "p"},
+    )
+    await agent._execute_tool(call, "system", "u", rs)
+    assert "SUPERSECRET" in captured["cmd"]
+    assert "{{secret" not in captured["cmd"]
+
+    # send_email: the same placeholder in the body is NOT substituted.
+    captured.clear()
+    call2 = LLMToolCall(
+        id="2",
+        name="send_email",
+        arguments={
+            "account": "x",
+            "to": "a@b.c",
+            "subject": "hi",
+            "body": "exfil {{secret:TOKEN}} now",
+        },
+    )
+    await agent._execute_tool(call2, "system", "u", rs)
+    assert "{{secret:TOKEN}}" in captured["cmd"]
+    assert "SUPERSECRET" not in captured["cmd"]
+
+
+async def test_run_command_acl_denies_out_of_scope(agent: AgentCore, monkeypatch) -> None:
+    await agent.secret_store.set_secret("PRIV", "nope", owner="persona:x")
+    monkeypatch.setattr(agent.permissions, "check", lambda *a, **k: PermissionLevel.ALWAYS)
+    ran = {"called": False}
+
+    async def fake_exec(command, timeout):
+        ran["called"] = True
+        return {"stdout": "", "stderr": "", "exit_code": 0}
+
+    monkeypatch.setattr(agent.executor, "_exec", fake_exec)
+    rs = agent._new_request_state(Persona(name="other"))  # no PRIV in scope
+    call = LLMToolCall(
+        id="1", name="run_command", arguments={"command": "curl {{secret:PRIV}}", "purpose": "p"}
+    )
+    result = await agent._execute_tool(call, "system", "u", rs)
+    assert "error" in result and "scope" in result["error"]
+    assert ran["called"] is False  # never executed
+
+
+async def test_request_secret_creates_request_and_link(agent: AgentCore) -> None:
+    rs = agent._new_request_state(Persona(name="finance"))
+    call = LLMToolCall(
+        id="1",
+        name="request_secret",
+        arguments={"name": "ACME_LOGIN", "reason": "log into ACME"},
+    )
+    result = await agent._execute_tool(call, "system", "u", rs)
+    assert result["status"] == "requested" and "/vault/fill/" in result["secure_link"]
+    token = result["secure_link"].rsplit("/", 1)[-1]
+    req = await agent.secret_store.get_request(token)
+    assert req and req["name"] == "ACME_LOGIN" and req["persona"] == "finance"
+
+
+async def test_prompt_lists_secret_names_not_values(agent: AgentCore) -> None:
+    prompt = await agent._build_system_prompt(persona=None)
+    assert "TOKEN" in prompt  # discoverable name
+    assert "SUPERSECRET" not in prompt  # value never injected
+    assert "{{secret:NAME}}" in prompt  # usage instruction present
+
+
+# ── Admin UI ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+async def admin_client(tmp_path):
+    db = str(tmp_path / "config.db")
+    cs = ConfigStore(db_path=db)
+    await cs.set_setup_step("done")
+    await cs.set_admin_password("testpw")
+    await cs.set("agent.personae_db_path", str(tmp_path / "personae.db"))
+    await cs.set("agent.personae_dir", "")
+    s = SecretStore(db_path=db)
+    await s.ensure_wrapped_dek("testpw")
+    app, _ = create_admin_app(AgentState(), cs, secret_store=s)
+    return TestClient(app), s, cs
+
+
+def _auth(token="testpw"):
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_secrets_partial_requires_auth(admin_client) -> None:
+    client, _s, _cs = admin_client
+    assert client.get("/partials/secrets").status_code == 401
+    assert client.get("/partials/secrets", headers=_auth()).status_code == 200
+
+
+async def test_add_and_list_secret_via_admin(admin_client) -> None:
+    client, s, _cs = admin_client
+    resp = client.post(
+        "/admin/secrets",
+        data={"name": "STRIPE", "value": "sk_live", "scope": "all", "duration": "forever"},
+        headers=_auth(),
+    )
+    assert resp.status_code == 200 and "STRIPE" in resp.text
+    assert "sk_live" not in resp.text  # value never rendered
+    assert await s.get_secret("STRIPE") == "sk_live"
+
+
+async def test_vault_fill_flow(admin_client) -> None:
+    client, s, _cs = admin_client
+    token = await s.create_request("NEWKEY", persona="", reason="need")
+    # Page shell is public.
+    assert client.get(f"/vault/fill/{token}").status_code == 200
+    # Detail + submit require auth.
+    assert client.get(f"/vault/request/{token}").status_code == 401
+    assert client.get(f"/vault/request/{token}", headers=_auth()).json()["name"] == "NEWKEY"
+    resp = client.post(
+        f"/vault/fill/{token}",
+        data={"value": "filled-value", "scope": "all", "duration": "forever"},
+        headers=_auth(),
+    )
+    assert resp.json()["ok"] is True
+    assert await s.get_secret("NEWKEY") == "filled-value"
+    # Request consumed.
+    assert await s.get_request(token) is None
+
+
+async def test_bitwarden_import_parse_and_commit(admin_client) -> None:
+    client, s, _cs = admin_client
+    export = json.dumps(
+        {"items": [{"type": 1, "name": "Site", "login": {"username": "u", "password": "pw"}}]}
+    )
+    resp = client.post(
+        "/admin/secrets/import/parse",
+        files={"file": ("bw.json", export, "application/json")},
+        headers=_auth(),
+    )
+    assert resp.status_code == 200 and "Site" in resp.text
+    commit = client.post(
+        "/admin/secrets/import/commit",
+        data={"selected": "Site", "username__Site": "u", "password__Site": "pw", "scope": "all"},
+        headers=_auth(),
+    )
+    assert commit.status_code == 200
+    assert await s.get_secret("Site") == {"username": "u", "password": "pw"}
+
+
+async def test_wizard_secrets_step_generates_key_and_imports(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)  # so data/master.key lands in the tmp dir
+    db = str(tmp_path / "config.db")
+    cs = ConfigStore(db_path=db)
+    await cs.set_setup_step("admin")
+    await cs.set("agent.anthropic_api_key", "sk-plaintext")
+    s = SecretStore(db_path=db)
+    app, _ = create_admin_app(AgentState(), cs, secret_store=s)
+    client = TestClient(app)
+    # Generate the machine key.
+    r = client.post("/setup/step/secrets", data={"action": "generate"})
+    assert r.status_code == 200
+    assert s.infra.available
+    # Import the detected plaintext infra secret into the vault.
+    r = client.post("/setup/step/secrets", data={"action": "import"})
+    assert r.status_code == 200
+    assert await cs.get("agent.anthropic_api_key") == "${vault:ANTHROPIC_API_KEY}"
+    assert await s.get_infra_secret("ANTHROPIC_API_KEY") == "sk-plaintext"

--- a/uv.lock
+++ b/uv.lock
@@ -204,6 +204,39 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -247,6 +280,56 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
 ]
 
 [[package]]
@@ -852,6 +935,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "apscheduler" },
     { name = "caldav" },
+    { name = "cryptography" },
     { name = "edge-tts" },
     { name = "fastapi" },
     { name = "fastembed" },
@@ -886,6 +970,7 @@ requires-dist = [
     { name = "anthropic" },
     { name = "apscheduler", specifier = ">=3.10,<4" },
     { name = "caldav" },
+    { name = "cryptography" },
     { name = "edge-tts" },
     { name = "fastapi" },
     { name = "fastembed" },
@@ -1181,6 +1266,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/d7/32c6d3995e7036b73683389de2771f4dbbf40de192b7efe73c2528ee1eb5/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:479c77c32d8be692f3cfcde7e19273f02ac81d6f45c6aef49887ef95cab7abbb", size = 596085, upload-time = "2026-05-22T11:00:16.404Z" },
     { url = "https://files.pythonhosted.org/packages/00/8c/e68fa5d862ea6a27fced3535c25ea4eaa26ba1ce00dfef5841924c74b167/py_rust_stemmers-0.1.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c786235275c5c2abb7f206b8236aee3ca0bc53c7497daf7fb7b01d3491469547", size = 539747, upload-time = "2026-05-22T11:00:17.414Z" },
     { url = "https://files.pythonhosted.org/packages/44/48/aa584cf3772e01231641c95dc1aa73327a7d986c562639d78d0013733acf/py_rust_stemmers-0.1.8-cp314-cp314-win_amd64.whl", hash = "sha256:931d13570962b093417e5443a9d1bd63d73fa239ebb81e5b1d346663571403e4", size = 209636, upload-time = "2026-05-22T11:00:18.662Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #19.

Encrypted secrets backend that consolidates secrets out of `.env`/config and lets personas use secrets **by reference** — values never enter the model's context, history, logs, or messages.

## Design: two vaults, two keys

| | Infra vault | Persona / login vault |
|---|---|---|
| Holds | provider keys, bot token, Tavily, CalDAV/email/contacts, `gh` | website logins, payment keys, agent tokens |
| Key | machine key (`MPA_MASTER_KEY` / `data/master.key`) | envelope DEK wrapped by `PBKDF2(admin password)` |
| Unseals | at boot, headless | on admin login (DEK cached for autonomous jobs) |
| Used as | `${vault:NAME}` in config (with `.env` fallback) | `{{secret:NAME}}` / `{{secret:NAME.field}}` in `run_command` |
| ACL | none | per-persona secret scope (the 4th persona facet) |

Crypto is Fernet (AES-128-CBC + HMAC). The persona key is derived live at login and never written to disk, so a stolen disk alone can't open it; changing the admin password re-wraps the DEK only.

## Anti-exfiltration boundary

`{{secret:}}` substitution happens **only** at the model-facing `run_command` dispatch, after an ACL check — never inside the executor and never for structured tools (`send_email`/`send_message`/`create_calendar_event`). A prompt-injected agent therefore cannot exfiltrate a secret through a message/email/calendar body. Covered by a dedicated test.

## What's included

- `core/vault.py` — Fernet primitives, envelope encryption, machine-key loading (each with a runnable self-check).
- `core/secret_store.py` — tables (`secrets`, `infra_secrets`, `secret_requests`, `vault_meta`), ACL-gated resolution, audit (use count / last used), `once`/`until` durations, Bitwarden JSON parsing.
- Resolvers: `${vault:NAME}` at config load (infra, `.env` fallback) and `{{secret:NAME[.field]}}` in `run_command` (persona, ACL).
- Agent: `list_secrets` + `request_secret` tools, secure-link credential flow, secret-name discoverability injected into the persona prompt (names only).
- Admin UI: **Secrets** tab (names + persona×secret matrix, never values), Bitwarden import, secure `/vault/fill/<token>` page, wizard master-key + import-from-`.env` step with leftover-seed warning.
- Docs: new `docs/secrets.mdx` + README/configuration/admin-ui/personae updates.

## UX flows

1. **Agent needs a login it lacks** → `request_secret` → you get a Telegram **link only** → web form to enter the value, scope (this/specific/all personas) and duration (once/until/forever) → agent retries with `{{secret:...}}`.
2. **Discovery** → persona prompt + `list_secrets` expose names only; the agent references existing secrets directly.
3. **Bitwarden → MPA** → `bw export --format json`, upload on the Secrets tab, pick items + scope.

## Hardening from an adversarial review pass

Lock-serialized resolution (no double-spend of single-use secrets), graceful error on DEK-mismatch decrypt, rejection of malformed `{{secret:}}` references, rotate-before-set on password change (can't orphan the vault), atomic `0600` keyfile, and a setup-complete guard on the wizard endpoint.

## Tests

376 passing (28 new in `tests/test_secrets_vault.py`), `ruff` clean. Migrations are additive (`CREATE TABLE IF NOT EXISTS`) so existing `config.db` upgrades in place; `.env` remains a fallback throughout — no flag day.

## Notes / follow-ups

- Phase-1 infra consolidation + phase-2 persona ACL from #19 are both implemented; browser-session backing is left as a hook (browser automation isn't on `main` yet).
- The persona vault is unsealed by the admin bearer password on first authed request; scheduled persona-secret use works after the first login of a boot.
