### PR TITLE
Per-chat persona binding + isolated contexts (channel-agnostic) (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Email** — Read, compose, and manage emails via [Himalaya](https://github.com/pimalaya/himalaya) CLI
 - **Calendar** — CalDAV integration (Google Calendar, iCloud, etc.)
 - **Contacts** — CardDAV providers via the built-in contacts CLI
+- **Personae** — Swappable agent identities (own character, skill/tool scope, voice). Bind one per chat — and, on Telegram, per forum topic — so several run concurrently, each with its own isolated context
 - **Memory** — Two-tier system: permanent long-term facts and expiring short-term context, both extracted automatically from conversations
 - **Scheduled tasks** — Cron-based jobs for morning briefings, email checks, contact sync, and custom tasks
 - **Voice** — Speech-to-text (faster-whisper) and text-to-speech (edge-tts)
@@ -15,7 +16,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Browser automation** — Optional headless browser (Playwright) to read JS-heavy pages and act on sites, with persistent logged-in profiles and per-domain approval (off by default)
 - **Secrets vault** — Encrypted, two-tier secrets store: infrastructure keys (machine-key sealed, served into config via `${vault:NAME}`) and per-persona login/agent secrets (admin-password sealed, used by reference as `{{secret:NAME}}` in commands — values never enter the model's context). Bitwarden import + secure-link credential requests
 - **Permissions** — Glob-pattern rules (ALWAYS/ASK/NEVER) with interactive Telegram approval for write actions
-- **Admin UI** — Web dashboard for configuration, skills editing, memory inspection, job management, and agent lifecycle control
+- **Admin UI** — Web dashboard for configuration, persona & per-chat binding, skills editing, memory inspection, job management, and agent lifecycle control
 - **Skills** — Teach the agent new capabilities by writing markdown files instead of code
 - **Setup wizard** — Step-by-step first-boot configuration via the admin UI
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -1495,6 +1495,10 @@ def create_admin_app(
 
     @app.patch("/config", dependencies=[Depends(auth)])
     async def patch_config(body: ConfigPatchIn) -> dict:
+        # Which keys actually changed — so restart_required only fires when a
+        # restart-bound value really moved. A form may re-send unchanged keys
+        # (e.g. History saves both mode (hot-applied) and max_turns every time).
+        changed = {k: v for k, v in body.values.items() if str(await config_store.get(k)) != str(v)}
         await config_store.set_many(body.values)
         agent = agent_state.agent
         if agent:
@@ -1527,7 +1531,7 @@ def create_admin_app(
                 log.exception("Failed to apply updated config to running agent")
         return {
             "updated": list(body.values.keys()),
-            "restart_required": _config_requires_restart(body.values),
+            "restart_required": _config_requires_restart(changed),
         }
 
     @app.post("/debug/system-prompt/preview", dependencies=[Depends(auth)])

--- a/api/admin.py
+++ b/api/admin.py
@@ -2265,6 +2265,51 @@ def create_admin_app(
         await _set_active_persona(name)
         return await _personae_partial()
 
+    # ── Chats API (per-chat persona bindings) ──────────────────────────
+
+    async def _chats_partial() -> HTMLResponse:
+        history = await _history_from_config(config_store)
+        chats = await history.list_chats()
+        store = await _persona_store_from_config(config_store)
+        personae = await store.list_personae()
+        return _render_partial("partials/chats.html", chats=chats, personae=personae)
+
+    @app.get("/partials/chats", dependencies=[Depends(auth)])
+    async def partial_chats() -> HTMLResponse:
+        """Chats tab partial — active contexts and their bound persona."""
+        return await _chats_partial()
+
+    @app.post("/chats/bind", dependencies=[Depends(auth)])
+    async def bind_chat(request: Request) -> HTMLResponse:
+        content_type = request.headers.get("content-type", "")
+        if "application/x-www-form-urlencoded" in content_type:
+            body = await request.form()
+        else:
+            body = await request.json()
+        channel = str(body.get("channel", "")).strip()
+        user_id = str(body.get("user_id", "")).strip()
+        chat_id = str(body.get("chat_id", "")).strip()
+        persona = str(body.get("persona", "")).strip()  # "" = unbind (default identity)
+        if not channel or not user_id:
+            raise HTTPException(400, "Missing 'channel' or 'user_id' in request body")
+        if persona:
+            store = await _persona_store_from_config(config_store)
+            if not await store.get(persona):
+                raise HTTPException(404, f"Persona not found: {persona}")
+        # Prefer the running agent so its in-memory caches stay coherent; fall
+        # back to a config-built store when the agent is not running.
+        agent = agent_state.agent
+        if agent:
+            await agent.bind_chat_persona(channel, user_id, chat_id, persona)
+        else:
+            history = await _history_from_config(config_store)
+            if persona:
+                await history.set_chat_persona(channel, user_id, persona, chat_id)
+            else:
+                await history.clear_chat_persona(channel, user_id, chat_id)
+            await history.clear_session_system(channel, user_id, chat_id)
+        return await _chats_partial()
+
     # ── Memory API ─────────────────────────────────────────────────────
 
     @app.get("/memory/long-term", dependencies=[Depends(auth)])
@@ -3080,6 +3125,13 @@ async def _persona_store_from_config(config_store: ConfigStore):
     db_path = await config_store.get("agent.personae_db_path") or "data/personae.db"
     seed_dir = await config_store.get("agent.personae_dir") or "personae/"
     return PersonaStore(db_path=db_path, seed_dir=seed_dir)
+
+
+async def _history_from_config(config_store: ConfigStore):
+    from core.history import ConversationHistory
+
+    db_path = await config_store.get("history.db_path") or "data/history.db"
+    return ConversationHistory(db_path=db_path)
 
 
 # Function-tools that a persona may scope. ``load_skill`` is intentionally

--- a/api/admin.py
+++ b/api/admin.py
@@ -162,9 +162,6 @@ async def _wizard_step_context(step: str, config_store: ConfigStore) -> dict[str
             val = await config_store.get(key)
             if val:
                 ctx[var] = val
-        ctx["topics_enabled"] = (
-            str(await config_store.get("channels.telegram.topics_enabled")).lower() == "true"
-        )
     elif step == "whatsapp":
         for key, var in (("channels.whatsapp.allowed_numbers", "allowed_numbers"),):
             val = await config_store.get(key)
@@ -301,6 +298,9 @@ async def _channel_wizard_context(
             ctx["bot_token"] = bot_token
         if user_ids:
             ctx["user_ids"] = user_ids
+        ctx["topics_enabled"] = (
+            str(await config_store.get("channels.telegram.topics_enabled")).lower() == "true"
+        )
     if channel == "whatsapp":
         enabled_raw = await config_store.get("channels.whatsapp.enabled")
         enabled = str(enabled_raw).lower() != "false"

--- a/api/admin.py
+++ b/api/admin.py
@@ -1525,7 +1525,10 @@ def create_admin_app(
                     agent.search_client = None
             except Exception:
                 log.exception("Failed to apply updated config to running agent")
-        return {"updated": list(body.values.keys())}
+        return {
+            "updated": list(body.values.keys()),
+            "restart_required": _config_requires_restart(body.values),
+        }
 
     @app.post("/debug/system-prompt/preview", dependencies=[Depends(auth)])
     async def system_prompt_preview(body: PromptPreviewIn) -> dict:
@@ -3130,6 +3133,17 @@ async def _history_from_config(config_store: ConfigStore):
 
     db_path = await config_store.get("history.db_path") or "data/history.db"
     return ConversationHistory(db_path=db_path)
+
+
+# Config keys the running agent only reads at startup, so a change to them via
+# PATCH /config takes effect only after an agent restart. Everything else is
+# hot-applied in patch_config (agent.config swap + llm/memory/search rebuild).
+# Channels are saved through their own routes (always restart-bound) and handled
+# client-side, so they are not listed here.
+def _config_requires_restart(values: dict) -> bool:
+    """True if any saved key is consumed only at agent startup (voice pipeline,
+    history window) and so needs a restart to take effect."""
+    return any(key == "history.max_turns" or key.startswith("voice.") for key in values)
 
 
 # Function-tools that a persona may scope. ``load_skill`` is intentionally

--- a/api/admin.py
+++ b/api/admin.py
@@ -162,6 +162,9 @@ async def _wizard_step_context(step: str, config_store: ConfigStore) -> dict[str
             val = await config_store.get(key)
             if val:
                 ctx[var] = val
+        ctx["topics_enabled"] = (
+            str(await config_store.get("channels.telegram.topics_enabled")).lower() == "true"
+        )
     elif step == "whatsapp":
         for key, var in (("channels.whatsapp.allowed_numbers", "allowed_numbers"),):
             val = await config_store.get(key)
@@ -1994,12 +1997,14 @@ def create_admin_app(
         bot_token = str(body.get("bot_token", "")).strip()
         user_ids = str(body.get("user_ids", "")).strip()
         enabled = str(body.get("enabled", "true")).lower() == "true"
+        topics_enabled = bool(body.get("topics_enabled", False))
         if not bot_token:
             raise HTTPException(400, "Bot token is required")
         values = {
             "channels.telegram.enabled": str(enabled).lower(),
             "channels.telegram.bot_token": bot_token,
             "channels.telegram.allowed_user_ids": user_ids,
+            "channels.telegram.topics_enabled": str(topics_enabled).lower(),
         }
         await config_store.set_many(values)
         channel_data = await _channel_list_context(config_store, wacli)
@@ -2296,18 +2301,11 @@ def create_admin_app(
             store = await _persona_store_from_config(config_store)
             if not await store.get(persona):
                 raise HTTPException(404, f"Persona not found: {persona}")
-        # Prefer the running agent so its in-memory caches stay coherent; fall
-        # back to a config-built store when the agent is not running.
+        # Use the running agent's history instance so its in-memory session cache
+        # is the one cleared; fall back to a config-built store when not running.
         agent = agent_state.agent
-        if agent:
-            await agent.bind_chat_persona(channel, user_id, chat_id, persona)
-        else:
-            history = await _history_from_config(config_store)
-            if persona:
-                await history.set_chat_persona(channel, user_id, persona, chat_id)
-            else:
-                await history.clear_chat_persona(channel, user_id, chat_id)
-            await history.clear_session_system(channel, user_id, chat_id)
+        history = agent.history if agent else await _history_from_config(config_store)
+        await history.bind_chat_persona(channel, user_id, chat_id, persona)
         return await _chats_partial()
 
     # ── Memory API ─────────────────────────────────────────────────────

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -71,7 +71,7 @@
         .then(r => r.json().catch(() => ({})))
         .then(data => {
           const ok = data.status === 'restarted';
-          if (window.showToast) showToast(ok ? 'Agent restarted' : (data.error || 'Restart failed'), ok);
+          if (window.showToast) showToast(ok ? 'Agent restarted' : (data.error || data.detail || 'Restart failed'), ok);
           if (ok) dismissRestartBanner();
         })
         .catch(() => { if (window.showToast) showToast('Restart failed', false); })

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -42,6 +42,46 @@
     }
     window.showToast = showToast;
 
+    // Restart-required affordance. Some settings (channels, voice, history length)
+    // are read once when the agent starts, so a save only takes effect after a
+    // restart. notifyRestartRequired() surfaces the banner; restartAgentNow()
+    // restarts and refreshes the top-left status badge via the refresh-status event.
+    function notifyRestartRequired() {
+      const b = document.getElementById('restart-banner');
+      if (b) b.style.display = 'block';
+    }
+    window.notifyRestartRequired = notifyRestartRequired;
+
+    function dismissRestartBanner() {
+      const b = document.getElementById('restart-banner');
+      if (b) b.style.display = 'none';
+    }
+    window.dismissRestartBanner = dismissRestartBanner;
+
+    function restartAgentNow(btn) {
+      const key = localStorage.getItem('admin_api_key') || '';
+      const original = btn ? btn.textContent : '';
+      if (btn) { btn.disabled = true; btn.textContent = 'Restarting…'; }
+      // Flip the badge to RESTARTING immediately, then settle on the final state.
+      document.body.dispatchEvent(new CustomEvent('refresh-status'));
+      fetch('/agent/restart', {
+        method: 'POST',
+        headers: { 'Authorization': 'Bearer ' + key }
+      })
+        .then(r => r.json().catch(() => ({})))
+        .then(data => {
+          const ok = data.status === 'restarted';
+          if (window.showToast) showToast(ok ? 'Agent restarted' : (data.error || 'Restart failed'), ok);
+          if (ok) dismissRestartBanner();
+        })
+        .catch(() => { if (window.showToast) showToast('Restart failed', false); })
+        .finally(() => {
+          document.body.dispatchEvent(new CustomEvent('refresh-status'));
+          if (btn) { btn.disabled = false; btn.textContent = original || 'Restart now'; }
+        });
+    }
+    window.restartAgentNow = restartAgentNow;
+
     function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel) {
       const currentProvider = provider || 'anthropic';
       return {

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -64,6 +64,10 @@
             @click="select('personae')">
       Personae
     </button>
+    <button class="tab-link" :class="tab === 'chats' && 'tab-link-active'"
+            @click="select('chats')">
+      Chats
+    </button>
     <button class="tab-link" :class="tab === 'llm' && 'tab-link-active'"
             @click="select('llm')">
       LLM
@@ -687,6 +691,7 @@
       identity: '/partials/identity',
       you: '/partials/you',
       personae: '/partials/personae',
+      chats: '/partials/chats',
       llm: '/partials/llm',
       memory: '/partials/memory',
       history: '/partials/history',

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -15,6 +15,18 @@
     <span class="text-muted text-xs">Loading...</span>
   </div>
 
+  {# Restart-required banner — shown after saving a setting the agent only reads at
+     startup. Sibling of #tab-content so it survives tab swaps. #}
+  <div id="restart-banner" class="card mb-4" style="display:none;" role="status">
+    <div class="flex items-center justify-between gap-3 flex-wrap">
+      <span class="text-xs">⟳ A saved change needs an agent restart to take effect.</span>
+      <span class="flex items-center gap-2">
+        <button class="btn-primary btn-sm" type="button" onclick="restartAgentNow(this)">Restart now</button>
+        <button class="btn btn-sm" type="button" onclick="dismissRestartBanner()">Dismiss</button>
+      </span>
+    </div>
+  </div>
+
   <div id="agent-modal" class="fixed" style="inset: 0; background: rgba(0,0,0,0.65); display: none; align-items: center; justify-content: center; z-index: 50;">
     <div class="card" style="max-width: 520px; width: 100%;"
          x-data="agentControl()" x-init="init()">
@@ -349,6 +361,7 @@
         document.getElementById('tab-content').innerHTML = html;
         closeChannelWizard();
         if (window.showToast) { window.showToast('Telegram channel saved'); }
+        if (window.notifyRestartRequired) { notifyRestartRequired(); }
       })
       .catch(e => {
         result.textContent = e.message;
@@ -377,6 +390,7 @@
         document.getElementById('tab-content').innerHTML = html;
         closeChannelWizard();
         if (window.showToast) { window.showToast('WhatsApp channel saved'); }
+        if (window.notifyRestartRequired) { notifyRestartRequired(); }
       })
       .catch(e => {
         result.textContent = e.message;

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -329,6 +329,8 @@
     if (!result || !tokenInput || !usersInput) return;
     const token = tokenInput.value.trim();
     const users = usersInput.value.trim();
+    const topicsInput = document.getElementById('ch-tg-topics');
+    const topics = topicsInput ? topicsInput.checked : false;
     if (!token) {
       result.textContent = 'Bot token is required.';
       result.className = 'alert-error';
@@ -340,7 +342,7 @@
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
       },
-      body: JSON.stringify({bot_token: token, user_ids: users, enabled: true})
+      body: JSON.stringify({bot_token: token, user_ids: users, enabled: true, topics_enabled: topics})
     })
       .then(r => r.text())
       .then(html => {

--- a/api/templates/partials/channel_wizard_telegram.html
+++ b/api/templates/partials/channel_wizard_telegram.html
@@ -16,6 +16,15 @@
          value="{{ user_ids|default('') }}">
   <div class="hint">Comma-separated IDs. Leave empty to allow any user.</div>
 
+  <label class="flex items-center gap-2 mt-3 text-sm">
+    <input type="checkbox" id="ch-tg-topics" {% if topics_enabled %}checked{% endif %}>
+    Separate persona per forum topic
+  </label>
+  <div class="hint">
+    Each topic in a group with Topics enabled becomes its own context. Name a
+    topic after a persona to auto-bind it; rebind any chat on the Chats tab.
+  </div>
+
   <div class="flex items-center gap-2 mt-3">
     <button class="btn btn-sm" type="button" onclick="testTelegram()">Test connection</button>
     <button class="btn-primary btn-sm" type="button" onclick="saveTelegram()">Save</button>

--- a/api/templates/partials/channel_wizard_telegram.html
+++ b/api/templates/partials/channel_wizard_telegram.html
@@ -25,6 +25,8 @@
     topic after a persona to auto-bind it; rebind any chat on the Chats tab.
   </div>
 
+  {% include "partials/restart_note.html" %}
+
   <div class="flex items-center gap-2 mt-3">
     <button class="btn btn-sm" type="button" onclick="testTelegram()">Test connection</button>
     <button class="btn-primary btn-sm" type="button" onclick="saveTelegram()">Save</button>

--- a/api/templates/partials/channel_wizard_whatsapp.html
+++ b/api/templates/partials/channel_wizard_whatsapp.html
@@ -28,6 +28,8 @@
     </div>
   </div>
 
+  {% include "partials/restart_note.html" %}
+
   <div class="flex items-center gap-2 mt-4">
     <button class="btn btn-sm" type="button" onclick="testWhatsApp()">Test wacli</button>
     <button class="btn btn-sm" type="button" onclick="syncWhatsApp()">Sync</button>

--- a/api/templates/partials/chats.html
+++ b/api/templates/partials/chats.html
@@ -1,0 +1,65 @@
+{# Chats tab partial — active contexts and the persona bound to each #}
+<div x-data="{ filter: '' }">
+  {# Intro #}
+  <div class="card mb-4">
+    <h2 class="text-base mb-0.5">Chats</h2>
+    <p class="text-muted text-xs">
+      Every active conversation, by <code>channel · user · chat</code>. Bind a
+      persona to a single chat — it overrides the global active persona there.
+      Telegram topics show as <code>chat:topic</code> when topic mode is on.
+    </p>
+    <p class="text-muted text-xs mt-2">
+      A change applies on the next turn; the open chat keeps its current identity
+      until then (its messages are preserved).
+    </p>
+  </div>
+
+  {# Toolbar #}
+  <div class="flex items-center gap-2 mb-4 flex-wrap">
+    <input type="text" class="input-sm flex-1" style="max-width:280px"
+           placeholder="Filter chats..." x-model="filter">
+    <span class="text-muted text-xs">{{ chats|length }} chat{{ '' if chats|length == 1 else 's' }}</span>
+  </div>
+
+  {# Card grid — 1 col on phone, 2 on large #}
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+    {% for c in chats %}
+    <div class="card flex flex-col gap-2 {% if c.persona %}border-accent{% endif %}"
+         x-show="!filter
+                 || {{ c.channel|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                 || {{ c.user_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                 || {{ c.chat_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())">
+      <div class="flex items-start gap-2 min-w-0">
+        <span class="badge-ok whitespace-nowrap">{{ c.channel }}</span>
+        <div class="min-w-0 flex-1">
+          <div class="text-sm font-semibold break-all">{{ c.chat_id or '(default)' }}</div>
+          <div class="text-muted text-xs break-all">user {{ c.user_id }}</div>
+        </div>
+      </div>
+
+      <form class="flex items-center gap-1.5 mt-auto pt-1">
+        <input type="hidden" name="channel" value="{{ c.channel }}">
+        <input type="hidden" name="user_id" value="{{ c.user_id }}">
+        <input type="hidden" name="chat_id" value="{{ c.chat_id }}">
+        <label class="text-muted text-xs whitespace-nowrap">Persona</label>
+        <select name="persona" class="input-sm flex-1"
+                hx-post="/chats/bind" hx-trigger="change"
+                hx-include="closest form"
+                hx-target="#tab-content" hx-swap="innerHTML">
+          <option value="" {% if not c.persona %}selected{% endif %}>Default</option>
+          {% for p in personae %}
+          <option value="{{ p.name }}" {% if p.name == c.persona %}selected{% endif %}>
+            {{ p.emoji or '🧩' }} {{ p.role or p.name }}
+          </option>
+          {% endfor %}
+        </select>
+      </form>
+    </div>
+    {% endfor %}
+    {% if not chats %}
+    <div class="text-muted text-xs text-center py-6 col-span-full">
+      No chats yet. They appear here once a conversation has started.
+    </div>
+    {% endif %}
+  </div>
+</div>

--- a/api/templates/partials/chats.html
+++ b/api/templates/partials/chats.html
@@ -18,7 +18,7 @@
   <div class="flex items-center gap-2 mb-4 flex-wrap">
     <input type="text" class="input-sm flex-1" style="max-width:280px"
            placeholder="Filter chats..." x-model="filter">
-    <span class="text-muted text-xs">{{ chats|length }} chat{{ '' if chats|length == 1 else 's' }}</span>
+    <span class="text-muted text-xs">{{ chats|length }} total</span>
   </div>
 
   {# Card grid — 1 col on phone, 2 on large #}

--- a/api/templates/partials/history.html
+++ b/api/templates/partials/history.html
@@ -41,6 +41,7 @@
         <input type="number" class="input-sm" style="max-width:120px"
                x-model="maxTurns" min="1" max="50">
         <p class="text-muted text-xs mt-1">Number of recent user-assistant pairs included as context. Lower values reduce noise from old conversations; higher values give more continuity.</p>
+        {% include "partials/restart_note.html" %}
       </div>
     </div>
 
@@ -63,6 +64,7 @@
                 .then(d => {
                   result = resultOk ? 'History settings saved' : (d.detail || 'Error');
                   if (resultOk && window.showToast) { window.showToast('History settings saved'); }
+                  if (resultOk && d.restart_required && window.notifyRestartRequired) { notifyRestartRequired(); }
                 })
                 .catch(e => { resultOk = false; result = e.message; })
               ">

--- a/api/templates/partials/identity.html
+++ b/api/templates/partials/identity.html
@@ -148,6 +148,7 @@
         <input type="text" class="input-sm" style="max-width:260px" x-model="ttsVoice" placeholder="en-US-AvaNeural">
         <p class="text-muted text-xs mt-1">Use Edge TTS voice names. Example: en-US-AvaNeural.</p>
       </div>
+      {% include "partials/restart_note.html" %}
     </div>
 
     <div class="flex justify-end mt-3">
@@ -170,6 +171,7 @@
                 .then(d => {
                   voiceResult = voiceOk ? 'Voice settings saved' : (d.detail || 'Error');
                   if (voiceOk && window.showToast) { window.showToast('Voice settings saved'); }
+                  if (voiceOk && d.restart_required && window.notifyRestartRequired) { notifyRestartRequired(); }
                 })
                 .catch(e => { voiceOk = false; voiceResult = e.message; })
               ">

--- a/api/templates/partials/restart_note.html
+++ b/api/templates/partials/restart_note.html
@@ -1,0 +1,2 @@
+{# Reusable inline note for a setting the agent only reads at startup. #}
+<p class="hint">⟳ Takes effect after an agent restart (use the status badge above, top-left).</p>

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -49,7 +49,7 @@ class TelegramChannel:
         self.app.add_handler(MessageHandler(filters.TEXT, self._on_text))
         self.app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, self._on_voice))
         self.app.add_handler(MessageHandler(filters.PHOTO | filters.Document.IMAGE, self._on_photo))
-        if getattr(config, "topics_enabled", False):
+        if config.topics_enabled:
             self.app.add_handler(
                 MessageHandler(
                     filters.StatusUpdate.FORUM_TOPIC_CREATED
@@ -72,10 +72,14 @@ class TelegramChannel:
         """
         if not chat:
             return None
-        if not getattr(self.config, "topics_enabled", False):
+        if not self.config.topics_enabled:
             return chat.id
+        # message_thread_id is also set on reply-chains in non-forum groups and on
+        # linked-discussion comments (there it is just the root message id), so it
+        # alone would fragment an ordinary chat. is_topic_message marks a genuine
+        # forum topic and is False for the General topic — gate on it.
         thread = getattr(message, "message_thread_id", None)
-        if thread:
+        if thread and getattr(message, "is_topic_message", False):
             return f"{chat.id}:{thread}"
         return chat.id
 
@@ -162,11 +166,8 @@ class TelegramChannel:
 
         chat_id = folded if folded is not None else user_id
         if not self.voice:
-            cid, kw = self._route(chat_id)
-            await self.app.bot.send_message(
-                cid,
-                "Voice messages are not supported (voice pipeline not configured).",
-                **kw,
+            await self.send(
+                chat_id, "Voice messages are not supported (voice pipeline not configured)."
             )
             return
 
@@ -274,8 +275,7 @@ class TelegramChannel:
         chat_id = f"{chat.id}:{thread}"
         bound = await self.agent.bind_chat_persona_by_label("telegram", str(user_id), chat_id, name)
         if bound:
-            cid, kw = self._route(chat_id)
-            await self.app.bot.send_message(cid, f"Bound this topic to {bound}.", **kw)
+            await self.send(chat_id, f"Bound this topic to {bound}.")
 
     # -- Outgoing ------------------------------------------------------------
 
@@ -449,8 +449,7 @@ class TelegramChannel:
             transcript = await voice.transcribe(bytes(audio_bytes))
 
             if not transcript.strip():
-                cid, kw = self._route(chat_id)
-                await self.app.bot.send_message(cid, "(could not transcribe voice)", **kw)
+                await self.send(chat_id, "(could not transcribe voice)")
                 return
 
             log.info("Transcript: %s", transcript[:200])
@@ -495,11 +494,8 @@ class TelegramChannel:
                 )
 
             if not attachments:
-                cid, kw = self._route(chat_id)
-                await self.app.bot.send_message(
-                    cid,
-                    "Sorry, I can only process image files (JPEG, PNG, GIF, WebP) for now.",
-                    **kw,
+                await self.send(
+                    chat_id, "Sorry, I can only process image files (JPEG, PNG, GIF, WebP) for now."
                 )
                 return
 

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -42,12 +42,55 @@ class TelegramChannel:
         self.config = config
         self.agent = agent
         self.voice = voice
-        self._last_chat_for_user: dict[int, int] = {}
+        # Last chat a user wrote from, used to route approval prompts. Holds a
+        # folded "<chat>:<thread>" string when the message came from a topic.
+        self._last_chat_for_user: dict[int, int | str] = {}
         self.app = Application.builder().token(config.bot_token).concurrent_updates(8).build()
         self.app.add_handler(MessageHandler(filters.TEXT, self._on_text))
         self.app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, self._on_voice))
         self.app.add_handler(MessageHandler(filters.PHOTO | filters.Document.IMAGE, self._on_photo))
+        if getattr(config, "topics_enabled", False):
+            self.app.add_handler(
+                MessageHandler(
+                    filters.StatusUpdate.FORUM_TOPIC_CREATED
+                    | filters.StatusUpdate.FORUM_TOPIC_EDITED,
+                    self._on_forum_topic,
+                )
+            )
         self.app.add_handler(CallbackQueryHandler(self._on_approval_callback))
+
+    # -- Topic folding helpers -----------------------------------------------
+
+    def _fold(self, chat, message) -> int | str | None:
+        """Derive the context id for a message.
+
+        With ``topics_enabled``, a forum-topic message folds its
+        ``message_thread_id`` into the chat id as ``"<chat>:<thread>"`` so each
+        topic is a separate context. The forum's General topic carries no thread
+        id, so it maps to the bare chat (the default context). Returns ``None``
+        when there is no chat (caller falls back to the user id).
+        """
+        if not chat:
+            return None
+        if not getattr(self.config, "topics_enabled", False):
+            return chat.id
+        thread = getattr(message, "message_thread_id", None)
+        if thread:
+            return f"{chat.id}:{thread}"
+        return chat.id
+
+    @staticmethod
+    def _route(chat_id: int | str) -> tuple[int | str, dict]:
+        """Split a folded ``"<chat>:<thread>"`` id for the Bot API.
+
+        Returns ``(chat_id, kwargs)`` where kwargs carries ``message_thread_id``
+        when a topic is encoded, and is empty otherwise — so non-topic calls are
+        unchanged.
+        """
+        base, sep, thread = str(chat_id).partition(":")
+        if sep and thread.isdigit() and base.lstrip("-").isdigit():
+            return int(base), {"message_thread_id": int(thread)}
+        return chat_id, {}
 
     # -- Incoming handlers ---------------------------------------------------
 
@@ -88,12 +131,13 @@ class TelegramChannel:
         if not user or not message:
             return
         user_id = user.id
-        if chat:
-            self._last_chat_for_user[user_id] = chat.id
+        folded = self._fold(chat, message)
+        if folded is not None:
+            self._last_chat_for_user[user_id] = folded
         if not self._is_allowed(user_id):
             return
 
-        chat_id = chat.id if chat else user_id
+        chat_id = folded if folded is not None else user_id
         reply_context = self._reply_context(message)
         text = (message.text or "").strip()
         payload = f"{reply_context}{text}" if reply_context else text
@@ -110,16 +154,19 @@ class TelegramChannel:
         if not user or not message:
             return
         user_id = user.id
-        if chat:
-            self._last_chat_for_user[user_id] = chat.id
+        folded = self._fold(chat, message)
+        if folded is not None:
+            self._last_chat_for_user[user_id] = folded
         if not self._is_allowed(user_id):
             return
 
-        chat_id = chat.id if chat else user_id
+        chat_id = folded if folded is not None else user_id
         if not self.voice:
+            cid, kw = self._route(chat_id)
             await self.app.bot.send_message(
-                chat_id,
+                cid,
                 "Voice messages are not supported (voice pipeline not configured).",
+                **kw,
             )
             return
 
@@ -141,12 +188,13 @@ class TelegramChannel:
         if not user or not message:
             return
         user_id = user.id
-        if chat:
-            self._last_chat_for_user[user_id] = chat.id
+        folded = self._fold(chat, message)
+        if folded is not None:
+            self._last_chat_for_user[user_id] = folded
         if not self._is_allowed(user_id):
             return
 
-        chat_id = chat.id if chat else user_id
+        chat_id = folded if folded is not None else user_id
         caption = message.caption or ""
 
         # Collect file IDs to download.
@@ -178,8 +226,9 @@ class TelegramChannel:
         await query.answer()  # Acknowledge the button press
 
         user_id = user.id
-        if chat:
-            self._last_chat_for_user[user_id] = chat.id
+        folded = self._fold(chat, getattr(query, "message", None))
+        if folded is not None:
+            self._last_chat_for_user[user_id] = folded
         if not self._is_allowed(user_id):
             return
 
@@ -200,6 +249,34 @@ class TelegramChannel:
             resolved = self.agent.permissions.resolve_approval(request_id, True, always_allow=True)
             await self._finalize_approval_response(query, resolved, "Always allowed")
 
+    async def _on_forum_topic(self, update: Update, context) -> None:
+        """Auto-bind a freshly created/renamed forum topic to a matching persona.
+
+        The topic name is only carried on these service messages (not on ordinary
+        messages), so this is the one place a topic→persona name match can happen
+        without a web round-trip. Binding is skipped when the topic is already
+        bound, so a manual rebind is never clobbered.
+        """
+        message = update.message
+        chat = update.effective_chat
+        user = update.effective_user
+        if not message or not chat:
+            return
+        created = getattr(message, "forum_topic_created", None)
+        edited = getattr(message, "forum_topic_edited", None)
+        name = getattr(created or edited, "name", None)
+        thread = getattr(message, "message_thread_id", None)
+        if not name or not thread:
+            return
+        user_id = user.id if user else None
+        if user_id is None or not self._is_allowed(user_id):
+            return
+        chat_id = f"{chat.id}:{thread}"
+        bound = await self.agent.bind_chat_persona_by_label("telegram", str(user_id), chat_id, name)
+        if bound:
+            cid, kw = self._route(chat_id)
+            await self.app.bot.send_message(cid, f"Bound this topic to {bound}.", **kw)
+
     # -- Outgoing ------------------------------------------------------------
 
     async def send(self, chat_id: int | str, text: str) -> None:
@@ -209,12 +286,13 @@ class TelegramChannel:
             html = text
         else:
             html = to_telegram_html(text)
+        cid, kw = self._route(chat_id)
         try:
-            await self.app.bot.send_message(chat_id, html, parse_mode="HTML")
+            await self.app.bot.send_message(cid, html, parse_mode="HTML", **kw)
         except BadRequest as exc:
             if "parse entities" in str(exc).lower():
                 log.warning("Telegram HTML parse failed; sending as plain text: %s", exc)
-                await self.app.bot.send_message(chat_id, text)
+                await self.app.bot.send_message(cid, text, **kw)
                 return
             raise
 
@@ -240,32 +318,34 @@ class TelegramChannel:
             ]
         )
         text = f"Permission request:\n\n{description}"
+        cid, kw = self._route(chat_id)
         if image_path:
             try:
                 with open(image_path, "rb") as photo:
                     # Telegram caption hard limit is 1024 chars.
                     await self.app.bot.send_photo(
-                        chat_id, photo, caption=text[:1024], reply_markup=keyboard
+                        cid, photo, caption=text[:1024], reply_markup=keyboard, **kw
                     )
                 return
             except Exception:
                 log.exception("Failed to send approval screenshot; falling back to text")
-        await self.app.bot.send_message(chat_id, text, reply_markup=keyboard)
+        await self.app.bot.send_message(cid, text, reply_markup=keyboard, **kw)
 
     # -- Helpers -------------------------------------------------------------
 
     @asynccontextmanager
-    async def _typing(self, chat_id: int):
+    async def _typing(self, chat_id: int | str):
         """Send 'typing' chat action continuously until the wrapped block completes.
 
         Telegram's typing indicator expires after ~5 seconds, so we resend it
         every 4 seconds to keep it visible for the duration of agent processing.
         """
+        cid, kw = self._route(chat_id)
 
         async def _send_typing():
             try:
                 while True:
-                    await self.app.bot.send_chat_action(chat_id, action=ChatAction.TYPING)
+                    await self.app.bot.send_chat_action(cid, action=ChatAction.TYPING, **kw)
                     await asyncio.sleep(4)
             except asyncio.CancelledError:
                 pass
@@ -281,7 +361,7 @@ class TelegramChannel:
                 pass
 
     @asynccontextmanager
-    async def _progress(self, chat_id: int):
+    async def _progress(self, chat_id: int | str):
         """Mirror an in-flight `browser.py explore` run into ONE edited message.
 
         explore writes a per-step line to data/browser/last/explore.status; we
@@ -290,6 +370,7 @@ class TelegramChannel:
         """
         status = Path("/app/data" if Path("/app/data").exists() else "data")
         status = status / "browser" / "last" / "explore.status"
+        cid, kw = self._route(chat_id)  # split a folded "<chat>:<thread>" topic id
         message_id: int | None = None
         last = None
 
@@ -308,11 +389,11 @@ class TelegramChannel:
                 last = text
                 try:
                     if message_id is None:
-                        msg = await self.app.bot.send_message(chat_id, text)
+                        msg = await self.app.bot.send_message(cid, text, **kw)
                         message_id = msg.message_id
                     else:
                         await self.app.bot.edit_message_text(
-                            text, chat_id=chat_id, message_id=message_id
+                            text, chat_id=cid, message_id=message_id
                         )
                 except Exception:
                     pass  # transient edit/rate-limit error — keep polling
@@ -328,7 +409,7 @@ class TelegramChannel:
                 pass
             if message_id is not None:  # tidy the progress message away
                 try:
-                    await self.app.bot.delete_message(chat_id, message_id)
+                    await self.app.bot.delete_message(cid, message_id)
                 except Exception:
                     pass
 
@@ -338,7 +419,7 @@ class TelegramChannel:
             return False
         return True
 
-    async def _handle_text(self, text: str, user_id: int, chat_id: int) -> None:
+    async def _handle_text(self, text: str, user_id: int, chat_id: int | str) -> None:
         async with self._typing(chat_id), self._progress(chat_id):
             response = await self.agent.process(
                 message=text,
@@ -349,7 +430,7 @@ class TelegramChannel:
         await self._send_response(chat_id, response)
 
     async def _handle_voice(
-        self, file_id: str, user_id: int, chat_id: int, reply_context: str
+        self, file_id: str, user_id: int, chat_id: int | str, reply_context: str
     ) -> None:
         async with self._typing(chat_id), self._progress(chat_id):
             file = await self.app.bot.get_file(file_id)
@@ -368,7 +449,8 @@ class TelegramChannel:
             transcript = await voice.transcribe(bytes(audio_bytes))
 
             if not transcript.strip():
-                await self.app.bot.send_message(chat_id, "(could not transcribe voice)")
+                cid, kw = self._route(chat_id)
+                await self.app.bot.send_message(cid, "(could not transcribe voice)", **kw)
                 return
 
             log.info("Transcript: %s", transcript[:200])
@@ -390,7 +472,7 @@ class TelegramChannel:
         caption: str,
         reply_context: str,
         user_id: int,
-        chat_id: int,
+        chat_id: int | str,
     ) -> None:
         from core.models import IMAGE_MIME_TYPES, Attachment
 
@@ -413,9 +495,11 @@ class TelegramChannel:
                 )
 
             if not attachments:
+                cid, kw = self._route(chat_id)
                 await self.app.bot.send_message(
-                    chat_id,
+                    cid,
                     "Sorry, I can only process image files (JPEG, PNG, GIF, WebP) for now.",
+                    **kw,
                 )
                 return
 
@@ -431,10 +515,11 @@ class TelegramChannel:
             )
         await self._send_response(chat_id, response)
 
-    async def _send_response(self, chat_id: int, response) -> None:
+    async def _send_response(self, chat_id: int | str, response) -> None:
         """Send an AgentResponse back — voice if present, otherwise text."""
         if response.voice:
-            await self.app.bot.send_voice(chat_id, response.voice)
+            cid, kw = self._route(chat_id)
+            await self.app.bot.send_voice(cid, response.voice, **kw)
         elif response.text:
             await self.send(chat_id, response.text)
         else:

--- a/config.yml.example
+++ b/config.yml.example
@@ -22,6 +22,8 @@ channels:
     enabled: true
     bot_token: "${TELEGRAM_BOT_TOKEN}"
     allowed_user_ids: "${TELEGRAM_ALLOWED_USER_IDS}"
+    # Opt-in: treat each forum topic as its own persona-bound context (#14).
+    topics_enabled: false
   whatsapp:
     enabled: false
     bridge_url: "local-wacli"

--- a/core/agent.py
+++ b/core/agent.py
@@ -396,8 +396,8 @@ class AgentCore:
         # Per-turn preamble: live date/time + (optional) execution plan.
         preamble = self._turn_preamble(decomposed_goal)
 
-        # Resolve the active persona (its identity, skills + tool scope). #14 will
-        # make this per-chat; for now it is the globally selected persona.
+        # Resolve the active persona (its identity, skills + tool scope) — a
+        # per-chat binding wins over the globally selected persona (#14).
         persona = await self._resolve_persona(channel, user_id, chat_id)
         tools = scoped_tools(persona)
         if self.secret_store is None:
@@ -431,21 +431,81 @@ class AgentCore:
         )
 
     async def _resolve_persona(self, channel: str, user_id: str, chat_id: str) -> Persona | None:
-        """Resolve the active persona for this request.
+        """Resolve the active persona for this request, in precedence order:
 
-        For issue #13 this is the single globally-selected persona
-        (``agent.active_persona``); #14 will extend this to a per-chat binding
-        keyed on ``chat_id``. Returns ``None`` (default identity) when unset or
-        the named persona no longer exists.
+        1. the per-chat binding for ``(channel, user_id, chat_id)`` (#14),
+        2. the globally-selected persona (``config.agent.active_persona``, #13),
+        3. the default identity (``None``).
+
+        A future per-persona bot (#29) will add a rung above (1): a
+        ``"telegram:<name>"`` channel would resolve straight to that persona.
+        Not wired here — no such channel exists yet.
         """
+        # 1. Per-chat binding.
+        bound = await self.history.get_chat_persona(channel, user_id, chat_id)
+        if bound:
+            persona = await self._load_persona(bound)
+            if persona:
+                return persona
+
+        # 2. Globally-selected persona.
         name = (self.config.agent.active_persona or "").strip()
-        if not name:
-            return None
+        if name:
+            return await self._load_persona(name)
+
+        # 3. Default identity.
+        return None
+
+    async def _load_persona(self, name: str) -> Persona | None:
+        """Load a persona by name, returning ``None`` if it is missing/broken."""
         try:
             return await self.personae.get(name)
         except Exception:
-            log.exception("Failed to load active persona %r", name)
+            log.exception("Failed to load persona %r", name)
             return None
+
+    async def bind_chat_persona(
+        self, channel: str, user_id: str, chat_id: str, persona_name: str
+    ) -> None:
+        """Bind (or, with an empty name, unbind) a chat to a persona.
+
+        Drops the snapshotted session system prompt so the new identity takes
+        effect on the next turn without wiping the conversation (in injection
+        mode the prompt is rebuilt per turn, so this is a harmless no-op).
+        """
+        name = (persona_name or "").strip()
+        if name:
+            await self.history.set_chat_persona(channel, user_id, name, chat_id)
+        else:
+            await self.history.clear_chat_persona(channel, user_id, chat_id)
+        await self.history.clear_session_system(channel, user_id, chat_id)
+
+    async def bind_chat_persona_by_label(
+        self, channel: str, user_id: str, chat_id: str, label: str
+    ) -> str | None:
+        """Auto-bind a chat to the persona matching ``label`` (case-insensitive).
+
+        Matches the label against each persona's ``name``, ``agent_name`` and
+        ``role``. Only binds when the chat is not already bound, so a manual
+        rebind is never clobbered. Returns the bound persona name, or ``None``.
+        """
+        label = (label or "").strip()
+        if not label:
+            return None
+        if await self.history.get_chat_persona(channel, user_id, chat_id):
+            return None  # already bound — don't override a manual choice
+        target = label.lower()
+        try:
+            personae = await self.personae.list_personae()
+        except Exception:
+            log.exception("Failed to list personae for topic auto-bind")
+            return None
+        for p in personae:
+            labels = {p.name.lower(), (p.agent_name or "").lower(), (p.role or "").lower()}
+            if target in labels - {""}:
+                await self.bind_chat_persona(channel, user_id, chat_id, p.name)
+                return p.name
+        return None
 
     def _turn_preamble(self, decomposed_goal: DecomposedGoal | None) -> str:
         """Build the per-turn preamble prepended to the current user message.

--- a/core/agent.py
+++ b/core/agent.py
@@ -469,16 +469,10 @@ class AgentCore:
     ) -> None:
         """Bind (or, with an empty name, unbind) a chat to a persona.
 
-        Drops the snapshotted session system prompt so the new identity takes
-        effect on the next turn without wiping the conversation (in injection
-        mode the prompt is rebuilt per turn, so this is a harmless no-op).
+        Thin pass-through to the history store, which also drops the snapshotted
+        session system prompt so the new identity takes effect on the next turn.
         """
-        name = (persona_name or "").strip()
-        if name:
-            await self.history.set_chat_persona(channel, user_id, name, chat_id)
-        else:
-            await self.history.clear_chat_persona(channel, user_id, chat_id)
-        await self.history.clear_session_system(channel, user_id, chat_id)
+        await self.history.bind_chat_persona(channel, user_id, chat_id, persona_name)
 
     async def bind_chat_persona_by_label(
         self, channel: str, user_id: str, chat_id: str, label: str

--- a/core/config.py
+++ b/core/config.py
@@ -88,6 +88,9 @@ class TelegramConfig(BaseModel):
     enabled: bool = False
     bot_token: str = ""
     allowed_user_ids: list[int] = Field(default_factory=list)
+    # Opt-in: fold forum topics into separate contexts (one persona per topic).
+    # Off by default so the plain 1:1 DM flow is unchanged.
+    topics_enabled: bool = False
 
     @field_validator("allowed_user_ids", mode="before")
     @classmethod

--- a/core/history.py
+++ b/core/history.py
@@ -50,6 +50,15 @@ CREATE TABLE IF NOT EXISTS session_system (
     created_at DATETIME DEFAULT (datetime('now')),
     PRIMARY KEY (channel, user_id, chat_id)
 );
+CREATE TABLE IF NOT EXISTS chat_persona (
+    channel TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    chat_id TEXT NOT NULL DEFAULT '',
+    persona TEXT NOT NULL,
+    created_at DATETIME DEFAULT (datetime('now')),
+    updated_at DATETIME DEFAULT (datetime('now')),
+    PRIMARY KEY (channel, user_id, chat_id)
+);
 """
 
 # Migrations applied after initial schema creation.
@@ -329,3 +338,96 @@ class ConversationHistory:
                 (channel, user_id, chat_id, system),
             )
             await db.commit()
+
+    async def clear_session_system(self, channel: str, user_id: str, chat_id: str = "") -> None:
+        """Drop just the snapshotted system prompt for a session (keep messages).
+
+        Used when the bound persona changes mid-session so the next turn rebuilds
+        the static prompt with the new identity without wiping the conversation.
+        """
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "DELETE FROM session_system WHERE channel = ? AND user_id = ? AND chat_id = ?",
+                (channel, user_id, chat_id),
+            )
+            await db.commit()
+        self._session_system.pop((channel, user_id, chat_id), None)
+
+    # -------------------------------------------------------------------
+    # Per-chat persona binding — (channel, user_id, chat_id) -> persona name
+    # -------------------------------------------------------------------
+
+    async def get_chat_persona(self, channel: str, user_id: str, chat_id: str = "") -> str | None:
+        """Return the persona name bound to this triple, or None if unbound.
+
+        Not cached: a primary-key lookup per turn is cheap, and skipping the
+        cache avoids staleness when the binding is changed from the admin UI on
+        a different store instance.
+        """
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT persona FROM chat_persona "
+                "WHERE channel = ? AND user_id = ? AND chat_id = ?",
+                (channel, user_id, chat_id),
+            )
+            row = await cursor.fetchone()
+        return row[0] if row else None
+
+    async def set_chat_persona(
+        self, channel: str, user_id: str, persona: str, chat_id: str = ""
+    ) -> None:
+        """Bind a (channel, user_id, chat_id) triple to a persona name (upsert)."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "INSERT INTO chat_persona (channel, user_id, chat_id, persona) "
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(channel, user_id, chat_id) DO UPDATE SET "
+                "persona = excluded.persona, updated_at = datetime('now')",
+                (channel, user_id, chat_id, persona),
+            )
+            await db.commit()
+
+    async def clear_chat_persona(self, channel: str, user_id: str, chat_id: str = "") -> None:
+        """Remove a per-chat persona binding (revert to global/default identity)."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "DELETE FROM chat_persona WHERE channel = ? AND user_id = ? AND chat_id = ?",
+                (channel, user_id, chat_id),
+            )
+            await db.commit()
+
+    async def list_chats(self) -> list[dict[str, str]]:
+        """List every known (channel, user_id, chat_id) with its bound persona.
+
+        Drives the admin Chats page. Unions the turn/session/binding tables so a
+        chat appears whichever history mode produced it (and even when it is only
+        bound, e.g. a topic auto-bound before its first message). LEFT JOIN
+        surfaces the binding; ``persona`` is "" when unbound.
+        """
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                """
+                SELECT c.channel, c.user_id, c.chat_id, p.persona
+                FROM (
+                    SELECT DISTINCT channel, user_id, chat_id FROM conversation_turns
+                    UNION
+                    SELECT DISTINCT channel, user_id, chat_id FROM session_messages
+                    UNION
+                    SELECT DISTINCT channel, user_id, chat_id FROM chat_persona
+                ) AS c
+                LEFT JOIN chat_persona AS p
+                  ON p.channel = c.channel AND p.user_id = c.user_id
+                  AND p.chat_id = c.chat_id
+                ORDER BY c.channel, c.user_id, c.chat_id
+                """
+            )
+            rows = await cursor.fetchall()
+        return [
+            {"channel": ch, "user_id": uid, "chat_id": cid, "persona": persona or ""}
+            for ch, uid, cid, persona in rows
+        ]

--- a/core/history.py
+++ b/core/history.py
@@ -400,6 +400,24 @@ class ConversationHistory:
             )
             await db.commit()
 
+    async def bind_chat_persona(
+        self, channel: str, user_id: str, chat_id: str, persona: str
+    ) -> None:
+        """Bind (or, with an empty name, unbind) a chat to a persona.
+
+        Drops the snapshotted session system prompt so a new identity takes effect
+        on the next turn without wiping the conversation (in injection mode there
+        is no snapshot, so the clear is a harmless no-op). Call this on the running
+        agent's history instance so its ``_session_system`` cache is the one that
+        gets cleared.
+        """
+        name = (persona or "").strip()
+        if name:
+            await self.set_chat_persona(channel, user_id, name, chat_id)
+        else:
+            await self.clear_chat_persona(channel, user_id, chat_id)
+        await self.clear_session_system(channel, user_id, chat_id)
+
     async def list_chats(self) -> list[dict[str, str]]:
         """List every known (channel, user_id, chat_id) with its bound persona.
 

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -29,6 +29,7 @@ Edit agent settings without touching config files:
 
 - **Assistant** — the default identity (agent name, character, personalia), used when no persona is active
 - **Personae** — create, edit, and switch swappable agent identities (see below)
+- **Chats** — list active conversations and bind a persona to each (see below)
 - **LLM** — provider, model, and API key configuration. The model field is free-text (enter any model id the provider supports); a **Fetch models** button on each provider card loads the live model list from the provider API into the field's autocomplete, and **Copy list** copies all available ids. Also configures the background models for memory, goal decomposition, task reflection, and **history compaction** (the model used to summarize old conversation turns — see the History tab for the trigger threshold)
 - **Channels** — enable/disable Telegram and WhatsApp
 - **Calendar** — manage CalDAV providers
@@ -51,6 +52,10 @@ Built-in skill editor for creating, editing, and deleting skill files. Changes t
 ### Personae
 
 Manage swappable agent identities — each with its own character, skill allowlist, tool scope, voice, and secret scope. Cards show every persona and the active one; **Use** activates one (applied live to new turns) or revert to **Default** (the Assistant-tab identity). The editor offers a **guided form** (identity, agent name, voice, skill + tool checkboxes, secret scope) and a **raw markdown** toggle for power users. Six starter personae ship seeded. The page is responsive at phone width. See [Personae](/docs/personae) for the full model.
+
+### Chats
+
+Lists every active conversation by `channel · user · chat` and lets you bind a persona to a single chat — it overrides the global active persona **there only** (the resolution ladder is per-chat binding → global persona → default identity). Works for any channel (Telegram, WhatsApp, REPL). Pick a persona from the per-chat dropdown to bind, or **Default** to unbind; the change applies on the next turn and the conversation is preserved. With Telegram `topics_enabled`, each forum topic appears as its own `chat:topic` context. The page is responsive at phone width. See [Per-chat personae](/docs/personae#per-chat-personae) for the model.
 
 ### Memory
 

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -21,7 +21,16 @@ Authentication uses a Bearer token (the `ADMIN_API_KEY` from your config).
 
 ### Dashboard
 
-Overview of agent status, active channels, and quick stats.
+Overview of agent status, active channels, and quick stats. The status badge (top-left)
+shows `RUNNING`/`STOPPED`/etc. and is clickable — it opens Agent Control to start, stop, or
+restart the agent.
+
+Most settings apply live. A few are read only when the agent starts — **channels** (Telegram/
+WhatsApp, including forum-topic mode), **voice** (STT/TTS), and **history → max turns** — so
+saving them shows a **"Restart required"** banner with a **Restart now** button (which also
+updates the status badge). Those sections also carry an inline ⟳ note. Everything else (LLM,
+vision, memory, compaction, search, personae, permissions, jobs, calendars/contacts/email,
+identity) takes effect immediately.
 
 ### Configuration
 

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -24,6 +24,7 @@ channels:
     enabled: true
     bot_token: "${TELEGRAM_BOT_TOKEN}"
     allowed_user_ids: "${TELEGRAM_ALLOWED_USER_IDS}"
+    topics_enabled: false   # opt-in: one persona-bound context per forum topic
 ```
 
 ### Features
@@ -32,6 +33,7 @@ channels:
 - **Voice messages** — automatically transcribed via Whisper, agent can respond with synthesized voice
 - **Inline keyboards** — used for permission approval flow (Approve / Edit / Deny)
 - **User ID whitelist** — only allowed users can interact with the bot
+- **Forum topics** (opt-in) — with `topics_enabled`, each topic in a group becomes its own context with its own bound persona; see [Per-chat personae](/docs/personae#per-chat-personae)
 
 ### Permission approvals
 

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -103,14 +103,37 @@ for skills outside it), filters the function-tool set to the tool scope, and use
 persona's voice for TTS. Switching applies to **new** turns; an open session keeps its
 snapshotted identity until you send `/new`.
 
+## Per-chat personae
+
+By default the active persona is global. You can instead bind a persona to a single
+conversation — it overrides the global one **only there**. Resolution runs a ladder in
+`AgentCore._resolve_persona(channel, user_id, chat_id)`:
+
+1. the per-chat binding for `(channel, user_id, chat_id)`,
+2. the global active persona,
+3. the default identity.
+
+Bindings live in the `chat_persona` table and work on **any** channel (Telegram, WhatsApp,
+REPL). Manage them on the **Chats** tab of the admin UI: it lists every active context and
+lets you pick a persona per chat. A change applies on the next turn; the open chat keeps its
+current identity until then (its messages are preserved).
+
+### Telegram forum topics (optional)
+
+Set `channels.telegram.topics_enabled: true` (or tick *Separate persona per forum topic* in
+the Telegram channel setup) to treat each forum topic in a group as its own context. The
+topic's `message_thread_id` is folded into the `chat_id`, so every topic gets isolated
+history and its own persona binding; the group's General topic maps to the default context.
+Name a topic after a persona (its name, agent name, or role) and it auto-binds when the topic
+is created or renamed; rebind any topic from the Chats tab.
+
 ## Roadmap
 
 Persona resolution is deliberately funnelled through one seam,
 `AgentCore._resolve_persona(channel, user_id, chat_id)`, so future work is additive:
 
-- **Per-chat personae** ([#14](https://github.com/mattmezza/mpa/issues/14)) — bind a persona
-  per Telegram forum topic (history is already keyed by `chat_id`), so several personae run
-  concurrently, each with its own isolated context, identity, scope, and voice.
+- **Bot-per-persona** ([#29](https://github.com/mattmezza/mpa/issues/29)) — run each persona
+  as its own Telegram bot, so agents become separate, independently-addressable contacts.
 
 The **secret scope** facet is now enforced by the [secrets vault](/docs/secrets) — a persona
 uses a secret by reference (`{{secret:NAME}}`) only if it is shared or in scope, and values

--- a/tests/test_chats_admin.py
+++ b/tests/test_chats_admin.py
@@ -107,3 +107,23 @@ def test_bind_unknown_persona_404(tmp_path) -> None:
     )
     assert r.status_code == 404
     assert _binding(tmp_path) is None
+
+
+def _wizard(tmp_path, **preset) -> str:
+    store = _Store(tmp_path)
+    store._data.update(preset)
+    app, _ = create_admin_app(AgentState(agent=None), cast(ConfigStore, store))
+    r = TestClient(app).get("/channels/wizard", params={"channel": "telegram"}, headers=AUTH)
+    assert r.status_code == 200
+    return r.text
+
+
+def test_topics_checkbox_reflects_stored_value(tmp_path) -> None:
+    # Regression: the Channels-tab Telegram editor must prefill topics_enabled from
+    # the stored value, else re-saving the channel silently disables topic mode.
+    on = _wizard(tmp_path, **{"channels.telegram.topics_enabled": "true"})
+    assert 'id="ch-tg-topics" checked' in on
+
+    off = _wizard(tmp_path)  # key absent → unchecked
+    assert 'id="ch-tg-topics" checked' not in off
+    assert "ch-tg-topics" in off  # the checkbox itself is present

--- a/tests/test_chats_admin.py
+++ b/tests/test_chats_admin.py
@@ -38,6 +38,9 @@ class _Store:
     async def set(self, key: str, value: str) -> None:
         self._data[key] = value
 
+    async def set_many(self, values: dict) -> None:
+        self._data.update(values)
+
     async def verify_admin_password(self, password: str) -> bool:
         return password == "secret"
 
@@ -140,3 +143,24 @@ def test_config_requires_restart_flags_startup_only_keys() -> None:
     assert _config_requires_restart({"memory.long_term_limit": "50"}) is False
     assert _config_requires_restart({"agent.model": "x", "agent.thinking_level": "high"}) is False
     assert _config_requires_restart({}) is False
+
+
+def test_patch_config_restart_required_only_on_real_change(tmp_path) -> None:
+    store = _Store(tmp_path)
+    store._data["history.max_turns"] = "10"
+    store._data["history.mode"] = "injection"
+    app, _ = create_admin_app(AgentState(agent=None), cast(ConfigStore, store))
+    client = TestClient(app)
+
+    def patch(values):
+        return client.patch("/config", json={"values": values}, headers=AUTH).json()
+
+    # Mode flips (hot-applied) but max_turns unchanged → no restart, even though the
+    # form re-sends max_turns.
+    res = patch({"history.mode": "session", "history.max_turns": "10"})
+    assert res["restart_required"] is False
+    # max_turns actually changes → restart.
+    assert patch({"history.max_turns": "20"})["restart_required"] is True
+    # voice change → restart; hot-applied key → no restart.
+    assert patch({"voice.tts_voice": "en-US-AvaNeural"})["restart_required"] is True
+    assert patch({"memory.long_term_limit": "99"})["restart_required"] is False

--- a/tests/test_chats_admin.py
+++ b/tests/test_chats_admin.py
@@ -123,7 +123,20 @@ def test_topics_checkbox_reflects_stored_value(tmp_path) -> None:
     # the stored value, else re-saving the channel silently disables topic mode.
     on = _wizard(tmp_path, **{"channels.telegram.topics_enabled": "true"})
     assert 'id="ch-tg-topics" checked' in on
+    assert "after an agent restart" in on  # restart note shown on the channel editor
 
     off = _wizard(tmp_path)  # key absent → unchecked
     assert 'id="ch-tg-topics" checked' not in off
     assert "ch-tg-topics" in off  # the checkbox itself is present
+
+
+def test_config_requires_restart_flags_startup_only_keys() -> None:
+    from api.admin import _config_requires_restart
+
+    # Read once at startup → restart required.
+    assert _config_requires_restart({"voice.tts_enabled": "true"}) is True
+    assert _config_requires_restart({"history.max_turns": "20"}) is True
+    # Hot-applied by patch_config (agent.config swap + llm/memory rebuild) → no restart.
+    assert _config_requires_restart({"memory.long_term_limit": "50"}) is False
+    assert _config_requires_restart({"agent.model": "x", "agent.thinking_level": "high"}) is False
+    assert _config_requires_restart({}) is False

--- a/tests/test_chats_admin.py
+++ b/tests/test_chats_admin.py
@@ -1,0 +1,109 @@
+"""Admin route tests for the Chats tab: list active contexts + per-chat bind."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+
+from fastapi.testclient import TestClient
+
+from api.admin import AgentState, create_admin_app
+from core.config_store import ConfigStore
+from core.history import ConversationHistory
+from core.personae import PersonaStore
+
+AUTH = {"Authorization": "Bearer secret"}
+
+
+class _Store:
+    """Config-store stub; personae + history live under tmp_path."""
+
+    def __init__(self, tmp_path):
+        self._data = {
+            "agent.personae_db_path": str(tmp_path / "personae.db"),
+            "agent.personae_dir": str(tmp_path / "seed"),
+            "history.db_path": str(tmp_path / "history.db"),
+        }
+
+    async def is_setup_complete(self) -> bool:
+        return True
+
+    async def get(self, key: str):
+        if key == "admin.password_hash":
+            return "hash"
+        if key == "admin.password_salt":
+            return "salt"
+        return self._data.get(key)
+
+    async def set(self, key: str, value: str) -> None:
+        self._data[key] = value
+
+    async def verify_admin_password(self, password: str) -> bool:
+        return password == "secret"
+
+    async def get_all_redacted(self) -> dict:
+        return {}
+
+
+def _client(tmp_path) -> TestClient:
+    # agent=None so /chats/bind exercises the config-store fallback write path.
+    app, _ = create_admin_app(AgentState(agent=None), cast(ConfigStore, _Store(tmp_path)))
+    return TestClient(app)
+
+
+async def _seed(tmp_path) -> None:
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "coach.md").write_text("---\nrole: Fitness coach\n---\n")
+    store = PersonaStore(db_path=str(tmp_path / "personae.db"), seed_dir=str(seed))
+    await store.ensure_seeded()
+    h = ConversationHistory(db_path=str(tmp_path / "history.db"))
+    await h.add_turn("telegram", "u1", "user", "hi", "c1")
+
+
+def _binding(tmp_path) -> str | None:
+    h = ConversationHistory(db_path=str(tmp_path / "history.db"))
+    return asyncio.run(h.get_chat_persona("telegram", "u1", "c1"))
+
+
+def test_chats_partial_lists_active_contexts(tmp_path) -> None:
+    asyncio.run(_seed(tmp_path))
+    client = _client(tmp_path)
+    r = client.get("/partials/chats", headers=AUTH)
+    assert r.status_code == 200
+    assert "Chats" in r.text
+    assert "c1" in r.text  # the active chat shows up
+    assert "Fitness coach" in r.text  # persona option available
+
+
+def test_bind_and_unbind_persona(tmp_path) -> None:
+    asyncio.run(_seed(tmp_path))
+    client = _client(tmp_path)
+
+    r = client.post(
+        "/chats/bind",
+        json={"channel": "telegram", "user_id": "u1", "chat_id": "c1", "persona": "coach"},
+        headers=AUTH,
+    )
+    assert r.status_code == 200
+    assert _binding(tmp_path) == "coach"
+
+    r = client.post(
+        "/chats/bind",
+        json={"channel": "telegram", "user_id": "u1", "chat_id": "c1", "persona": ""},
+        headers=AUTH,
+    )
+    assert r.status_code == 200
+    assert _binding(tmp_path) is None
+
+
+def test_bind_unknown_persona_404(tmp_path) -> None:
+    asyncio.run(_seed(tmp_path))
+    client = _client(tmp_path)
+    r = client.post(
+        "/chats/bind",
+        json={"channel": "telegram", "user_id": "u1", "chat_id": "c1", "persona": "ghost"},
+        headers=AUTH,
+    )
+    assert r.status_code == 404
+    assert _binding(tmp_path) is None

--- a/tests/test_per_chat_persona.py
+++ b/tests/test_per_chat_persona.py
@@ -164,24 +164,32 @@ def _fold(topics_enabled: bool, chat, message):
 
 def test_fold_off_by_default() -> None:
     chat = types.SimpleNamespace(id=-100123)
-    msg = types.SimpleNamespace(message_thread_id=45)
+    msg = types.SimpleNamespace(message_thread_id=45, is_topic_message=True)
     assert _fold(False, chat, msg) == -100123  # no folding when disabled
 
 
 def test_fold_topic_message() -> None:
     chat = types.SimpleNamespace(id=-100123)
-    msg = types.SimpleNamespace(message_thread_id=45)
+    msg = types.SimpleNamespace(message_thread_id=45, is_topic_message=True)
     assert _fold(True, chat, msg) == "-100123:45"
+
+
+def test_fold_reply_chain_is_not_a_topic() -> None:
+    # Non-forum reply-chains / discussion comments carry message_thread_id too,
+    # but is_topic_message is False — they must NOT fold into a separate context.
+    chat = types.SimpleNamespace(id=-100555)
+    msg = types.SimpleNamespace(message_thread_id=789, is_topic_message=False)
+    assert _fold(True, chat, msg) == -100555
 
 
 def test_fold_general_topic_is_bare_chat() -> None:
     chat = types.SimpleNamespace(id=-100123)
-    msg = types.SimpleNamespace(message_thread_id=None)
+    msg = types.SimpleNamespace(message_thread_id=None, is_topic_message=False)
     assert _fold(True, chat, msg) == -100123
 
 
 def test_fold_no_chat_returns_none() -> None:
-    msg = types.SimpleNamespace(message_thread_id=None)
+    msg = types.SimpleNamespace(message_thread_id=None, is_topic_message=False)
     assert _fold(True, None, msg) is None
 
 

--- a/tests/test_per_chat_persona.py
+++ b/tests/test_per_chat_persona.py
@@ -1,0 +1,192 @@
+"""Per-chat persona binding (#14): store layer, resolution ladder, topic folding."""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+
+from channels.telegram import TelegramChannel
+from core.agent import AgentCore
+from core.history import ConversationHistory
+from core.personae import PersonaStore
+
+# ---- History store: bindings + list_chats ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_persona_set_get_clear(tmp_path) -> None:
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    assert await h.get_chat_persona("telegram", "u1", "c1") is None
+    await h.set_chat_persona("telegram", "u1", "coach", "c1")
+    assert await h.get_chat_persona("telegram", "u1", "c1") == "coach"
+    # Upsert overwrites.
+    await h.set_chat_persona("telegram", "u1", "writer", "c1")
+    assert await h.get_chat_persona("telegram", "u1", "c1") == "writer"
+    # Scoped to the triple — a different chat is unaffected.
+    assert await h.get_chat_persona("telegram", "u1", "c2") is None
+    await h.clear_chat_persona("telegram", "u1", "c1")
+    assert await h.get_chat_persona("telegram", "u1", "c1") is None
+
+
+@pytest.mark.asyncio
+async def test_list_chats_unions_history_and_bindings(tmp_path) -> None:
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    # A chat known only from history.
+    await h.add_turn("telegram", "u1", "user", "hi", "c1")
+    # A chat known only from a binding (a topic auto-bound before its first msg).
+    await h.set_chat_persona("telegram", "u1", "coach", "c2")
+    chats = await h.list_chats()
+    by_chat = {c["chat_id"]: c for c in chats}
+    assert by_chat["c1"]["persona"] == ""  # unbound
+    assert by_chat["c2"]["persona"] == "coach"  # bound, no history yet
+    assert all({"channel", "user_id", "chat_id", "persona"} <= c.keys() for c in chats)
+
+
+@pytest.mark.asyncio
+async def test_clear_session_system_keeps_messages(tmp_path) -> None:
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    await h.append_session_message("telegram", "u1", {"role": "user", "content": "hi"}, "c1")
+    await h.set_session_system("telegram", "u1", "SYSTEM", "c1")
+    await h.clear_session_system("telegram", "u1", "c1")
+    assert await h.get_session_system("telegram", "u1", "c1") is None
+    # Conversation preserved.
+    assert await h.get_session("telegram", "u1", "c1") == [{"role": "user", "content": "hi"}]
+
+
+# ---- Agent resolution ladder + auto-bind -----------------------------------
+
+
+def _fake_agent(history: ConversationHistory, personae: PersonaStore, active: str = ""):
+    """A stand-in ``self`` carrying just what the persona methods touch, with the
+    real ``AgentCore`` methods bound to it — avoids constructing the heavy core."""
+    fa: Any = types.SimpleNamespace(
+        history=history,
+        personae=personae,
+        config=types.SimpleNamespace(agent=types.SimpleNamespace(active_persona=active)),
+    )
+    for name in (
+        "_load_persona",
+        "_resolve_persona",
+        "bind_chat_persona",
+        "bind_chat_persona_by_label",
+    ):
+        setattr(fa, name, types.MethodType(getattr(AgentCore, name), fa))
+    return fa
+
+
+async def _seed_personae(tmp_path) -> PersonaStore:
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "coach.md").write_text("---\nagent_name: Forge\nrole: Fitness coach\n---\n")
+    (seed / "writer.md").write_text("---\nrole: Writer\n---\n")
+    store = PersonaStore(db_path=str(tmp_path / "p.db"), seed_dir=str(seed))
+    await store.ensure_seeded()
+    return store
+
+
+@pytest.mark.asyncio
+async def test_resolve_persona_ladder(tmp_path) -> None:
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    store = await _seed_personae(tmp_path)
+
+    # 3. Default identity when nothing is set.
+    fa = _fake_agent(h, store, active="")
+    assert await fa._resolve_persona("telegram", "u1", "c1") is None
+
+    # 2. Global active persona.
+    fa = _fake_agent(h, store, active="writer")
+    p = await fa._resolve_persona("telegram", "u1", "c1")
+    assert p is not None and p.name == "writer"
+
+    # 1. Per-chat binding wins over global.
+    await h.set_chat_persona("telegram", "u1", "coach", "c1")
+    p = await fa._resolve_persona("telegram", "u1", "c1")
+    assert p is not None and p.name == "coach"
+    # A different chat still gets the global persona.
+    p2 = await fa._resolve_persona("telegram", "u1", "c2")
+    assert p2 is not None and p2.name == "writer"
+
+
+@pytest.mark.asyncio
+async def test_resolve_persona_missing_binding_falls_through(tmp_path) -> None:
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    store = await _seed_personae(tmp_path)
+    await h.set_chat_persona("telegram", "u1", "ghost", "c1")  # not a real persona
+    fa = _fake_agent(h, store, active="writer")
+    p = await fa._resolve_persona("telegram", "u1", "c1")
+    assert p is not None and p.name == "writer"  # falls through to global
+
+
+@pytest.mark.asyncio
+async def test_bind_by_label_matches_name_agentname_role(tmp_path) -> None:
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    store = await _seed_personae(tmp_path)
+    fa = _fake_agent(h, store)
+
+    # Match by agent_name ("Forge"), case-insensitive.
+    assert await fa.bind_chat_persona_by_label("telegram", "u1", "c1", "forge") == "coach"
+    assert await h.get_chat_persona("telegram", "u1", "c1") == "coach"
+
+    # Already bound → does not override a manual/earlier choice.
+    assert await fa.bind_chat_persona_by_label("telegram", "u1", "c1", "Writer") is None
+    assert await h.get_chat_persona("telegram", "u1", "c1") == "coach"
+
+    # No match → None, no binding.
+    assert await fa.bind_chat_persona_by_label("telegram", "u1", "c9", "nope") is None
+    assert await h.get_chat_persona("telegram", "u1", "c9") is None
+
+    # Match by role.
+    assert await fa.bind_chat_persona_by_label("telegram", "u1", "c2", "writer") == "writer"
+
+
+@pytest.mark.asyncio
+async def test_bind_chat_persona_clears_session_system(tmp_path) -> None:
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    store = await _seed_personae(tmp_path)
+    fa = _fake_agent(h, store)
+    await h.set_session_system("telegram", "u1", "OLD", "c1")
+    await fa.bind_chat_persona("telegram", "u1", "c1", "coach")
+    assert await h.get_session_system("telegram", "u1", "c1") is None
+    # Empty name unbinds.
+    await fa.bind_chat_persona("telegram", "u1", "c1", "")
+    assert await h.get_chat_persona("telegram", "u1", "c1") is None
+
+
+# ---- Telegram topic folding ------------------------------------------------
+
+
+def _fold(topics_enabled: bool, chat, message):
+    fake = types.SimpleNamespace(config=types.SimpleNamespace(topics_enabled=topics_enabled))
+    return TelegramChannel._fold(fake, chat, message)
+
+
+def test_fold_off_by_default() -> None:
+    chat = types.SimpleNamespace(id=-100123)
+    msg = types.SimpleNamespace(message_thread_id=45)
+    assert _fold(False, chat, msg) == -100123  # no folding when disabled
+
+
+def test_fold_topic_message() -> None:
+    chat = types.SimpleNamespace(id=-100123)
+    msg = types.SimpleNamespace(message_thread_id=45)
+    assert _fold(True, chat, msg) == "-100123:45"
+
+
+def test_fold_general_topic_is_bare_chat() -> None:
+    chat = types.SimpleNamespace(id=-100123)
+    msg = types.SimpleNamespace(message_thread_id=None)
+    assert _fold(True, chat, msg) == -100123
+
+
+def test_fold_no_chat_returns_none() -> None:
+    msg = types.SimpleNamespace(message_thread_id=None)
+    assert _fold(True, None, msg) is None
+
+
+def test_route_roundtrip() -> None:
+    assert TelegramChannel._route("-100123:45") == (-100123, {"message_thread_id": 45})
+    assert TelegramChannel._route(-100123) == (-100123, {})
+    assert TelegramChannel._route("12345") == ("12345", {})  # bare numeric string, no thread
+    assert TelegramChannel._route(12345) == (12345, {})


### PR DESCRIPTION
Closes #14.

## What this does
Lets each conversation bind its own persona, with an isolated context, across **any**
channel — the binding mechanism is channel-agnostic; Telegram forum topics are a thin,
optional adapter on top.

## How it works
**Resolution ladder** (`AgentCore._resolve_persona`):
1. per-chat binding for `(channel, user_id, chat_id)`
2. global `active_persona`
3. default identity

(A future `telegram:<persona>` bot rung is deferred to #29 — not wired here.)

**Binding store** — a `chat_persona` table in `history.db` (`get/set/clear/bind_chat_persona`,
plus `list_chats` and `clear_session_system`). Created via the existing schema script, so
pre-existing DBs pick it up with no migration. Binding a chat drops only the snapshotted
session system prompt so the new identity applies on the next turn **without** wiping the
conversation.

**Admin → Chats tab** — lists every active context (`channel · user · chat`) with a per-chat
persona dropdown; the canonical, channel-agnostic binding surface. Responsive at phone width.

**Telegram forum topics (opt-in, `channels.telegram.topics_enabled`)** — a topic message folds
its `message_thread_id` into the `chat_id` (`"<chat>:<thread>"`) so each topic is a separate
context; `_route()` splits it back out for outbound Bot API calls (`message_thread_id`). Folding
is gated on `is_topic_message` so ordinary reply-chains / discussion-group comments don't
fragment, and the General topic maps to the default context. Naming a topic after a persona
(name / agent_name / role) auto-binds it on create/rename; otherwise rebind from the Chats tab.
The flag is reachable from the Telegram channel editor (a checkbox) and documented in
`config.yml.example`.

## Acceptance criteria (#14)
- ✅ Two chats/threads keep separate histories **and** personas
- ✅ Topic-folding is additive — on: two topics = two contexts (auto-bound by name); off: 1:1 unchanged
- ✅ Binding works on WhatsApp & REPL via the web Chats page identically
- ✅ No regression to the default 1:1 DM flow (folding is a no-op when `topics_enabled` is False)

## Scope notes
- `/persona` command and `/room` modal fallback were intentionally dropped (see the rewritten
  issue); binding is the web Chats page + Telegram topic names.
- **Known limitation:** bindings are keyed `(channel, user_id, chat_id)` — i.e. per-user, matching
  the existing history keying. In a multi-user group topic the persona is per-user; the
  owner-centric single-user case (the #14 target) is exact. Multi-user group personas are #29/#30
  territory.

## Tests & review
- 365 tests pass (`uv run pytest`), including new coverage for the store layer, the resolution
  ladder, label auto-bind, topic folding (incl. the reply-chain non-fold case), the Chats admin
  routes, and the `topics_enabled` editor round-trip.
- Reviewed adversarially over three rounds (multi-lens find → independent verify); all confirmed
  findings fixed and converged to zero.

## Docs
README, `docs/personae.mdx`, `docs/admin-ui.mdx`, `docs/channels.mdx`, and `config.yml.example`
updated.

Feeds #29 (bot-per-persona).
