### PR TITLE
feat(artifacts): agent-crafted web pages served at /artifacts/<id>

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Voice** — Speech-to-text (faster-whisper) and text-to-speech (edge-tts)
 - **Web search** — Tavily integration for real-time information
 - **Browser automation** — Optional headless browser (Playwright) to read JS-heavy pages and act on sites, with persistent logged-in profiles and per-domain approval (off by default)
-- **Web artifacts** — The agent publishes self-contained HTML pages (reports, dashboards, charts, interactive trackers) as shareable links at `/artifacts/<id>`, with unguessable ids, a sandbox CSP, and automatic TTL cleanup
+- **Web artifacts** — The agent publishes pages, multi-file sites, or documents (PDF, image, slides) as shareable links at `/artifacts/<id>/`, with unguessable ids, a sandbox CSP, agent-chosen TTL cleanup, and approval before publishing an on-disk file
 - **Secrets vault** — Encrypted, two-tier secrets store: infrastructure keys (machine-key sealed, served into config via `${vault:NAME}`) and per-persona login/agent secrets (admin-password sealed, used by reference as `{{secret:NAME}}` in commands — values never enter the model's context). Bitwarden import + secure-link credential requests
 - **Permissions** — Glob-pattern rules (ALWAYS/ASK/NEVER) with interactive Telegram approval for write actions
 - **Admin UI** — Web dashboard for configuration, persona & per-chat binding, skills editing, memory inspection, job management, and agent lifecycle control

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Voice** — Speech-to-text (faster-whisper) and text-to-speech (edge-tts)
 - **Web search** — Tavily integration for real-time information
 - **Browser automation** — Optional headless browser (Playwright) to read JS-heavy pages and act on sites, with persistent logged-in profiles and per-domain approval (off by default)
+- **Web artifacts** — The agent publishes self-contained HTML pages (reports, dashboards, charts, interactive trackers) as shareable links at `/artifacts/<id>`, with unguessable ids, a sandbox CSP, and automatic TTL cleanup
 - **Secrets vault** — Encrypted, two-tier secrets store: infrastructure keys (machine-key sealed, served into config via `${vault:NAME}`) and per-persona login/agent secrets (admin-password sealed, used by reference as `{{secret:NAME}}` in commands — values never enter the model's context). Bitwarden import + secure-link credential requests
 - **Permissions** — Glob-pattern rules (ALWAYS/ASK/NEVER) with interactive Telegram approval for write actions
 - **Admin UI** — Web dashboard for configuration, persona & per-chat binding, skills editing, memory inspection, job management, and agent lifecycle control

--- a/api/admin.py
+++ b/api/admin.py
@@ -810,10 +810,15 @@ def create_admin_app(
         )
 
     async def _persona_editor_ctx() -> dict:
-        """Shared context for the persona editor: all skills + gateable tools."""
+        """Shared context for the persona editor: all skills + gateable tools.
+
+        A globally-disabled feature (e.g. artifacts) is dropped so its tool is
+        hidden from the persona scope UI.
+        """
         store = await _skills_store_from_config(config_store)
         all_skills = [s["name"] for s in await store.list_skills()]
-        return {"all_skills": all_skills, "all_tools": GATEABLE_TOOLS}
+        artifacts = await store_from_config(config_store)
+        return {"all_skills": all_skills, "all_tools": gateable_tools_for(artifacts.enabled)}
 
     @app.get("/admin/personae/new", response_model=None)
     async def admin_persona_new() -> Response:
@@ -1127,6 +1132,8 @@ def create_admin_app(
         except Exception:
             browser_profiles = []
 
+        artifacts = await store_from_config(config_store)
+
         return _render_partial(
             "partials/tools.html",
             tools=tool_registry(),
@@ -1139,6 +1146,9 @@ def create_admin_app(
             browser_ua=browser_ua,
             browser_profiles=browser_profiles,
             browser_rules=_browser_rules(),
+            artifacts_enabled="true" if artifacts.enabled else "false",
+            artifacts_directory=str(artifacts.dir),
+            artifacts_ttl_hours=str(artifacts.ttl_hours),
         )
 
     @app.post("/tools/gh/test", dependencies=[Depends(auth)])
@@ -3306,6 +3316,13 @@ GATEABLE_TOOLS = [
     "manage_jobs",
     "write_artifact",
 ]
+
+
+def gateable_tools_for(artifacts_enabled: bool) -> list[str]:
+    """GATEABLE_TOOLS minus tools whose feature is globally disabled."""
+    if artifacts_enabled:
+        return list(GATEABLE_TOOLS)
+    return [t for t in GATEABLE_TOOLS if t != "write_artifact"]
 
 
 # ---------------------------------------------------------------------------

--- a/api/admin.py
+++ b/api/admin.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import requests as http_requests
 from fastapi import Depends, FastAPI, HTTPException, Request
-from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse, Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
@@ -609,21 +609,30 @@ def create_admin_app(
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
     # ── Agent web artifacts (public; the random id is the only secret) ──
-    @app.get("/artifacts/{artifact_id}", response_class=HTMLResponse)
-    async def serve_artifact(artifact_id: str) -> HTMLResponse:
-        """Serve an agent-crafted HTML page. No auth — the unguessable id gates it.
+    @app.get("/artifacts/{artifact_id}", response_model=None)
+    async def artifact_root(artifact_id: str) -> Response:
+        # Redirect to the trailing-slash form so relative links inside the
+        # artifact (href="style.css", "img/logo.png") resolve under /artifacts/<id>/.
+        return RedirectResponse(f"/artifacts/{artifact_id}/", status_code=307)
 
-        Single path segment only (no `:path`), and the id is validated, so the
-        route cannot be listed or traversed. The CSP sandbox keeps the page's JS
-        off the admin origin's localStorage.
+    @app.get("/artifacts/{artifact_id}/{file_path:path}", response_model=None)
+    async def serve_artifact(artifact_id: str, file_path: str = "") -> Response:
+        """Serve a file from an artifact dir. No auth — the unguessable id gates it.
+
+        ``resolve`` validates the id, blocks traversal/dotfiles/symlinks/hardlinks
+        and anything outside the artifact dir. The CSP sandbox keeps artifact JS
+        off the admin origin's localStorage; nosniff stops MIME-sniffing.
         """
         store = await store_from_config(config_store)
-        path = store.path_for(artifact_id) if store.enabled else None
-        if path is None or not path.exists():
+        target = store.resolve(artifact_id, file_path) if store.enabled else None
+        if target is None:
             return HTMLResponse(NOT_FOUND_HTML, status_code=404)
-        return HTMLResponse(
-            path.read_text(encoding="utf-8"),
-            headers={"Content-Security-Policy": ARTIFACT_CSP},
+        return FileResponse(
+            target,
+            headers={
+                "Content-Security-Policy": ARTIFACT_CSP,
+                "X-Content-Type-Options": "nosniff",
+            },
         )
 
     auth = _make_auth_dependency(config_store, secret_store)

--- a/api/admin.py
+++ b/api/admin.py
@@ -31,7 +31,7 @@ from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
 
-from core.artifacts import ARTIFACT_CSP, NOT_FOUND_HTML, store_from_config
+from core.artifacts import ARTIFACT_CSP, NOT_FOUND_HTML, store_from_config, valid_id
 from core.config_store import ConfigStore
 from core.goal_decomposition import classify_complexity, decompose_goal
 from core.llm import LLMClient
@@ -613,6 +613,9 @@ def create_admin_app(
     async def artifact_root(artifact_id: str) -> Response:
         # Redirect to the trailing-slash form so relative links inside the
         # artifact (href="style.css", "img/logo.png") resolve under /artifacts/<id>/.
+        # Validate first so a malformed id never reaches the Location header.
+        if not valid_id(artifact_id):
+            return HTMLResponse(NOT_FOUND_HTML, status_code=404)
         return RedirectResponse(f"/artifacts/{artifact_id}/", status_code=307)
 
     @app.get("/artifacts/{artifact_id}/{file_path:path}", response_model=None)

--- a/api/admin.py
+++ b/api/admin.py
@@ -31,6 +31,7 @@ from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 from pydantic import BaseModel
 
+from core.artifacts import ARTIFACT_CSP, NOT_FOUND_HTML, store_from_config
 from core.config_store import ConfigStore
 from core.goal_decomposition import classify_complexity, decompose_goal
 from core.llm import LLMClient
@@ -606,6 +607,24 @@ def create_admin_app(
     static_dir = Path(__file__).parent / "static"
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    # ── Agent web artifacts (public; the random id is the only secret) ──
+    @app.get("/artifacts/{artifact_id}", response_class=HTMLResponse)
+    async def serve_artifact(artifact_id: str) -> HTMLResponse:
+        """Serve an agent-crafted HTML page. No auth — the unguessable id gates it.
+
+        Single path segment only (no `:path`), and the id is validated, so the
+        route cannot be listed or traversed. The CSP sandbox keeps the page's JS
+        off the admin origin's localStorage.
+        """
+        store = await store_from_config(config_store)
+        path = store.path_for(artifact_id) if store.enabled else None
+        if path is None or not path.exists():
+            return HTMLResponse(NOT_FOUND_HTML, status_code=404)
+        return HTMLResponse(
+            path.read_text(encoding="utf-8"),
+            headers={"Content-Security-Policy": ARTIFACT_CSP},
+        )
 
     auth = _make_auth_dependency(config_store, secret_store)
 
@@ -3273,6 +3292,7 @@ GATEABLE_TOOLS = [
     "create_calendar_event",
     "web_search",
     "manage_jobs",
+    "write_artifact",
 ]
 
 

--- a/api/templates/partials/tools.html
+++ b/api/templates/partials/tools.html
@@ -13,6 +13,69 @@
     </p>
   </div>
 
+  {# Web artifacts (built-in tool) #}
+  <div class="card" x-data="{
+    enabled: {{ artifacts_enabled|default('true', true)|tojson|forceescape }},
+    directory: {{ artifacts_directory|default('data/artifacts', true)|tojson|forceescape }},
+    ttl: {{ artifacts_ttl_hours|default('168', true)|tojson|forceescape }},
+    result: '', resultOk: false,
+    save() {
+      const vals = {
+        'artifacts.enabled': String(this.enabled === true || this.enabled === 'true'),
+        'artifacts.directory': this.directory,
+        'artifacts.ttl_hours': String(parseInt(this.ttl) || 0)
+      };
+      fetch('/config', {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json', 'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')},
+        body: JSON.stringify({values: vals})
+      })
+      .then(r => { this.resultOk = r.ok; return r.json(); })
+      .then(d => {
+        this.result = this.resultOk ? 'Artifact settings saved' : (d.detail || 'Error');
+        if (this.resultOk && window.showToast) { window.showToast('Artifact settings saved'); }
+      })
+      .catch(e => { this.resultOk = false; this.result = e.message; });
+    }
+  }">
+    <div class="flex items-center justify-between gap-3 mb-1">
+      <h3 class="text-sm text-accent">Web artifacts</h3>
+      <div class="flex items-center gap-2">
+        <label class="label mb-0">Enabled</label>
+        <input type="checkbox" x-model="enabled" :checked="enabled === 'true' || enabled === true">
+      </div>
+    </div>
+    <p class="text-muted text-xs mb-4">
+      Let the assistant publish pages, multi-file sites, or documents (PDF, image,
+      slides) as shareable links at <code>/artifacts/&lt;id&gt;/</code>. When disabled,
+      the tool is hidden from the assistant (and from the Personae tool scope) and
+      every artifact link returns 404. Assign it per persona in the
+      <strong>Personae</strong> editor.
+    </p>
+    <div class="space-y-3" x-show="enabled === 'true' || enabled === true">
+      <div>
+        <label class="label">Directory</label>
+        <input type="text" class="input-sm" style="max-width:500px" x-model="directory"
+               placeholder="data/artifacts">
+        <p class="text-muted text-xs mt-1">Where artifacts are stored on disk.</p>
+      </div>
+      <div>
+        <label class="label">Default TTL (hours)</label>
+        <input type="number" min="0" class="input-sm" style="max-width:200px" x-model="ttl">
+        <p class="text-muted text-xs mt-1">
+          Default lifetime before cleanup; the assistant may set its own per artifact.
+          <code>0</code> = keep forever.
+        </p>
+      </div>
+    </div>
+    <div class="flex items-center gap-2 mt-4">
+      <button class="btn-primary btn-sm" @click="save()">Save</button>
+    </div>
+    <template x-if="result">
+      <div :class="resultOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="result"></div>
+    </template>
+  </div>
+
   {# GitHub CLI (gh) #}
   <div class="card">
     <div class="flex items-center justify-between gap-3 mb-1">

--- a/config.yml.example
+++ b/config.yml.example
@@ -117,7 +117,7 @@ memory:
 
 # Agent-crafted web artifacts — the agent publishes self-contained HTML pages
 # (reports, dashboards, charts) served at /artifacts/<random-id>. Set
-# MPA_BASE_URL so the shared links are reachable from your devices.
+# the MPA_BASE_URL env var so the shared links are reachable from your devices.
 artifacts:
   enabled: true
   directory: "data/artifacts"  # where the HTML files live

--- a/config.yml.example
+++ b/config.yml.example
@@ -115,10 +115,10 @@ memory:
   hygiene_enabled: true
   hygiene_similarity_threshold: 0.45 # min similarity to cluster two memories
 
-# Agent-crafted web artifacts — the agent publishes self-contained HTML pages
-# (reports, dashboards, charts) served at /artifacts/<random-id>. Set
-# the MPA_BASE_URL env var so the shared links are reachable from your devices.
+# Agent-crafted web artifacts — the agent publishes pages, multi-file sites, or
+# documents (PDF, image, slides) served at /artifacts/<random-id>/. Set the
+# MPA_BASE_URL env var so the shared links are reachable from your devices.
 artifacts:
   enabled: true
-  directory: "data/artifacts"  # where the HTML files live
-  ttl_hours: 168               # auto-delete after this many hours (0 = keep forever)
+  directory: "data/artifacts"  # where artifacts live
+  ttl_hours: 168               # default lifetime; agent may pick its own (0 = forever)

--- a/config.yml.example
+++ b/config.yml.example
@@ -114,3 +114,11 @@ memory:
   # Tier 4 — long-term hygiene pass (cluster + merge near-duplicates)
   hygiene_enabled: true
   hygiene_similarity_threshold: 0.45 # min similarity to cluster two memories
+
+# Agent-crafted web artifacts — the agent publishes self-contained HTML pages
+# (reports, dashboards, charts) served at /artifacts/<random-id>. Set
+# MPA_BASE_URL so the shared links are reachable from your devices.
+artifacts:
+  enabled: true
+  directory: "data/artifacts"  # where the HTML files live
+  ttl_hours: 168               # auto-delete after this many hours (0 = keep forever)

--- a/core/agent.py
+++ b/core/agent.py
@@ -284,34 +284,72 @@ TOOLS = [
     {
         "name": "write_artifact",
         "description": (
-            "Publish a self-contained HTML page and get back a shareable link "
-            "(e.g. https://host/artifacts/AbC123xy). Use this whenever the answer "
-            "is richer than chat can show: reports, dashboards, charts, comparison "
-            "tables, interactive checklists/trackers, or any 'give me a mini-site "
-            "for X'. The page is ONE standalone HTML document — inline all CSS in "
-            "<style> and all JS in <script>; there is no server, build step, or "
-            "second file. Climb only as high as the request needs: plain semantic "
-            "HTML for a quick report; add a classless CSS framework (e.g. MVP.css "
-            "or Water.css via CDN) for clean docs; custom CSS or TailwindCSS v4 "
-            "(its browser CDN build: <script src='https://cdn.jsdelivr.net/npm/"
-            "@tailwindcss/browser@4'></script>) for designed/branded pages; add "
-            "JS, or Alpine.js (CDN), only when it must be interactive. After "
-            "writing, give the returned link to "
-            "the user — it expires after the configured TTL."
+            "Publish a web artifact and get back a shareable link (e.g. "
+            "https://host/artifacts/AbC123xy/). Use this whenever the answer is "
+            "richer than chat can show: reports, dashboards, charts, comparison "
+            "tables, interactive checklists/trackers, slide decks, or any 'give "
+            "me a mini-site / document for X'. The link serves a whole directory.\n"
+            "Provide EXACTLY ONE of:\n"
+            "- 'html': a full standalone HTML document (becomes index.html). Best "
+            "for a single page. Inline CSS in <style> and JS in <script>. Climb "
+            "only as high as needed: plain semantic HTML for a quick report; a "
+            "classless CSS framework (MVP.css / Water.css via CDN) for clean docs; "
+            "custom CSS or TailwindCSS v4 (browser build "
+            "<script src='https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4'>"
+            "</script>) for designed pages; JS or Alpine.js (CDN) only when "
+            "interactive.\n"
+            "- 'files': a {relative_path: text} map for a MULTI-FILE site — e.g. "
+            "{'index.html': '…', 'style.css': '…', 'app.js': '…'}. Link them with "
+            "relative URLs (href='style.css'). Must include index.html (or set "
+            "'entrypoint').\n"
+            "- 'source_path': an absolute path to a file or directory you already "
+            "produced on disk — a PDF, image, slides, doc, or a prebuilt site dir. "
+            "Use this for binary/generated outputs (e.g. write a PDF with pandoc to "
+            "/tmp, then publish it). Publishing an on-disk file asks the owner for "
+            "approval first.\n"
+            "Pick 'ttl_hours' to fit the content: a small number for things that go "
+            "stale fast (a daily report), a large number or 0 (keep forever) for "
+            "lasting references. Omit to use the configured default. After writing, "
+            "give the returned link to the user."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "html": {
                     "type": "string",
-                    "description": "The complete HTML document (a full <!doctype html> … page).",
+                    "description": "A complete HTML document; published as index.html.",
+                },
+                "files": {
+                    "type": "object",
+                    "description": (
+                        "Map of relative filename → text content for a multi-file "
+                        "artifact (e.g. index.html + style.css + app.js)."
+                    ),
+                    "additionalProperties": {"type": "string"},
+                },
+                "source_path": {
+                    "type": "string",
+                    "description": (
+                        "Absolute path to a file or directory to copy in (PDF, "
+                        "image, slides, doc, or a prebuilt site). Asks for approval."
+                    ),
+                },
+                "entrypoint": {
+                    "type": "string",
+                    "description": "File served at the root URL. Default 'index.html'.",
+                },
+                "ttl_hours": {
+                    "type": "integer",
+                    "description": (
+                        "How long to keep this artifact, in hours. 0 = forever. "
+                        "Omit for the configured default."
+                    ),
                 },
                 "title": {
                     "type": "string",
-                    "description": "Optional short title, for your own reference and the logs.",
+                    "description": "Optional short title, for your reference and the logs.",
                 },
             },
-            "required": ["html"],
         },
     },
 ]
@@ -1240,21 +1278,46 @@ class AgentCore:
         return os.getenv("MPA_BASE_URL", f"http://localhost:{self.config.admin.port}")
 
     def _tool_write_artifact(self, params: dict) -> dict:
-        """Persist a self-contained HTML artifact; return its shareable URL."""
+        """Publish a web artifact (page, multi-file site, or file); return its URL."""
         from core.artifacts import ArtifactStore
 
         cfg = self.config.artifacts
         if not cfg.enabled:
             return {"error": "Web artifacts are disabled in config (artifacts.enabled)."}
-        html = str(params.get("html") or "")
-        if not html.strip():
-            return {"error": "Missing 'html' content."}
+
+        files = params.get("files") or None
+        if files is not None and not isinstance(files, dict):
+            return {"error": "'files' must be a map of filename → text content."}
+        html = params.get("html")
+        if html and not files:
+            files = {"index.html": str(html)}
+        source_path = params.get("source_path") or None
+        if not files and not source_path:
+            return {"error": "Provide one of 'html', 'files', or 'source_path'."}
+        if files and source_path:
+            return {"error": "Provide only one of 'html'/'files' or 'source_path'."}
+
+        entrypoint = str(params.get("entrypoint") or "index.html")
+        ttl_hours = params.get("ttl_hours")
+        if ttl_hours is not None:
+            try:
+                ttl_hours = int(ttl_hours)
+            except TypeError, ValueError:
+                return {"error": "'ttl_hours' must be an integer (0 = keep forever)."}
         title = str(params.get("title", "")).strip()
+
+        store = ArtifactStore(cfg.directory, cfg.ttl_hours)
         try:
-            art_id = ArtifactStore(cfg.directory, cfg.ttl_hours).write(html, title=title)
-        except ValueError as exc:
+            art_id = store.create(
+                files=files,
+                source_path=source_path,
+                entrypoint=entrypoint,
+                ttl_hours=ttl_hours,
+                title=title,
+            )
+        except (ValueError, OSError) as exc:
             return {"error": str(exc)}
-        url = f"{self._base_url()}/artifacts/{art_id}"
+        url = f"{self._base_url()}/artifacts/{art_id}/"
         log.info("Tool call: write_artifact — %s (%s)", url, title or "untitled")
         return {"ok": True, "url": url, "title": title}
 

--- a/core/agent.py
+++ b/core/agent.py
@@ -293,8 +293,10 @@ TOOLS = [
             "second file. Climb only as high as the request needs: plain semantic "
             "HTML for a quick report; add a classless CSS framework (e.g. MVP.css "
             "or Water.css via CDN) for clean docs; custom CSS or TailwindCSS v4 "
-            "(CDN) for designed/branded pages; add JS, or Alpine.js (CDN), only "
-            "when it must be interactive. After writing, give the returned link to "
+            "(its browser CDN build: <script src='https://cdn.jsdelivr.net/npm/"
+            "@tailwindcss/browser@4'></script>) for designed/branded pages; add "
+            "JS, or Alpine.js (CDN), only when it must be interactive. After "
+            "writing, give the returned link to "
             "the user — it expires after the configured TTL."
         ),
         "input_schema": {
@@ -1248,7 +1250,10 @@ class AgentCore:
         if not html.strip():
             return {"error": "Missing 'html' content."}
         title = str(params.get("title", "")).strip()
-        art_id = ArtifactStore(cfg.directory, cfg.ttl_hours).write(html, title=title)
+        try:
+            art_id = ArtifactStore(cfg.directory, cfg.ttl_hours).write(html, title=title)
+        except ValueError as exc:
+            return {"error": str(exc)}
         url = f"{self._base_url()}/artifacts/{art_id}"
         log.info("Tool call: write_artifact — %s (%s)", url, title or "untitled")
         return {"ok": True, "url": url, "title": title}

--- a/core/agent.py
+++ b/core/agent.py
@@ -369,6 +369,20 @@ def scoped_tools(persona: Persona | None) -> list[dict]:
     return [t for t in TOOLS if persona.allows_tool(t["name"]) or t["name"] in _always]
 
 
+def apply_feature_gates(
+    tools: list[dict], *, secrets_available: bool, artifacts_enabled: bool
+) -> list[dict]:
+    """Drop tools whose backing feature is unavailable/disabled, so the model is
+    never offered a capability it can't use (defence in depth — the tool handlers
+    also refuse). Disabling ``artifacts`` here means no persona can call it."""
+    out = tools
+    if not secrets_available:
+        out = [t for t in out if t["name"] not in ("list_secrets", "request_secret")]
+    if not artifacts_enabled:
+        out = [t for t in out if t["name"] != "write_artifact"]
+    return out
+
+
 class AgentCore:
     def __init__(self, config: Config, secret_store: SecretStore | None = None):
         self.config = config
@@ -470,9 +484,11 @@ class AgentCore:
         # Resolve the active persona (its identity, skills + tool scope) — a
         # per-chat binding wins over the globally selected persona (#14).
         persona = await self._resolve_persona(channel, user_id, chat_id)
-        tools = scoped_tools(persona)
-        if self.secret_store is None:
-            tools = [t for t in tools if t["name"] not in ("list_secrets", "request_secret")]
+        tools = apply_feature_gates(
+            scoped_tools(persona),
+            secrets_available=self.secret_store is not None,
+            artifacts_enabled=self.config.artifacts.enabled,
+        )
 
         # Static system prompt. In session mode it is snapshotted once at the
         # start of the session and reused for every turn (so the static content

--- a/core/agent.py
+++ b/core/agent.py
@@ -1158,7 +1158,10 @@ class AgentCore:
             return await self._tool_request_secret(params, channel, user_id, request_state)
 
         if name == "write_artifact":
-            return self._tool_write_artifact(params)
+            result = self._tool_write_artifact(params)
+            if is_write_action and self._is_tool_success(result):
+                executed_writes.add(write_sig)
+            return result
 
         return {"error": f"Unknown tool: {name}"}
 

--- a/core/agent.py
+++ b/core/agent.py
@@ -281,6 +281,37 @@ TOOLS = [
             "required": ["name", "reason"],
         },
     },
+    {
+        "name": "write_artifact",
+        "description": (
+            "Publish a self-contained HTML page and get back a shareable link "
+            "(e.g. https://host/artifacts/AbC123xy). Use this whenever the answer "
+            "is richer than chat can show: reports, dashboards, charts, comparison "
+            "tables, interactive checklists/trackers, or any 'give me a mini-site "
+            "for X'. The page is ONE standalone HTML document — inline all CSS in "
+            "<style> and all JS in <script>; there is no server, build step, or "
+            "second file. Climb only as high as the request needs: plain semantic "
+            "HTML for a quick report; add a classless CSS framework (e.g. MVP.css "
+            "or Water.css via CDN) for clean docs; custom CSS or TailwindCSS v4 "
+            "(CDN) for designed/branded pages; add JS, or Alpine.js (CDN), only "
+            "when it must be interactive. After writing, give the returned link to "
+            "the user — it expires after the configured TTL."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "html": {
+                    "type": "string",
+                    "description": "The complete HTML document (a full <!doctype html> … page).",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional short title, for your own reference and the logs.",
+                },
+            },
+            "required": ["html"],
+        },
+    },
 ]
 
 
@@ -1086,6 +1117,9 @@ class AgentCore:
         if name == "request_secret":
             return await self._tool_request_secret(params, channel, user_id, request_state)
 
+        if name == "write_artifact":
+            return self._tool_write_artifact(params)
+
         return {"error": f"Unknown tool: {name}"}
 
     @staticmethod
@@ -1198,10 +1232,26 @@ class AgentCore:
         except Exception as exc:
             return {"error": str(exc)}
 
-    def _vault_base_url(self) -> str:
+    def _base_url(self) -> str:
         import os
 
         return os.getenv("MPA_BASE_URL", f"http://localhost:{self.config.admin.port}")
+
+    def _tool_write_artifact(self, params: dict) -> dict:
+        """Persist a self-contained HTML artifact; return its shareable URL."""
+        from core.artifacts import ArtifactStore
+
+        cfg = self.config.artifacts
+        if not cfg.enabled:
+            return {"error": "Web artifacts are disabled in config (artifacts.enabled)."}
+        html = str(params.get("html") or "")
+        if not html.strip():
+            return {"error": "Missing 'html' content."}
+        title = str(params.get("title", "")).strip()
+        art_id = ArtifactStore(cfg.directory, cfg.ttl_hours).write(html, title=title)
+        url = f"{self._base_url()}/artifacts/{art_id}"
+        log.info("Tool call: write_artifact — %s (%s)", url, title or "untitled")
+        return {"ok": True, "url": url, "title": title}
 
     async def _notify_secret_request(
         self, channel: str, user_id: str, name: str, reason: str, link: str
@@ -1242,7 +1292,7 @@ class AgentCore:
         token = await self.secret_store.create_request(
             sname, persona=persona_name, reason=reason, suggested_scope=scope
         )
-        link = f"{self._vault_base_url()}/vault/fill/{token}"
+        link = f"{self._base_url()}/vault/fill/{token}"
         await self._notify_secret_request(channel, user_id, sname, reason, link)
         return {
             "status": "requested",

--- a/core/artifacts.py
+++ b/core/artifacts.py
@@ -1,44 +1,52 @@
 """Agent-crafted web artifacts.
 
-The agent writes a self-contained HTML page (``write_artifact`` tool) and gets
-back a shareable link.  Pages are served read-only at ``/artifacts/<id>`` on the
-admin app — no auth, but the id is an unguessable random string so the route
-cannot be listed or walked.  A background loop deletes pages older than the
-configured TTL.
+The agent publishes an artifact (``write_artifact`` tool) and gets back a
+shareable link.  An artifact is a **directory** ``<base>/<id>/`` served read-only
+at ``/artifacts/<id>/`` — so it can be a single page, a multi-file site
+(``index.html`` linking sibling CSS/JS/assets), or any shareable file (PDF,
+image, slides, doc).  ``<id>`` is an unguessable random string, so the route
+cannot be listed or walked.
 
-One artifact == one standalone HTML document.  CSS goes inline in ``<style>``,
-JS inline in ``<script>``, and Tailwind/Alpine load from a CDN — so a single
-file covers every rung of the complexity ladder without a build step.
+Content arrives one of two ways:
+  * ``files`` — inline text the agent authored (HTML/CSS/JS/SVG/Markdown).
+  * ``source_path`` — a file or directory the agent already produced on disk
+    (e.g. a PDF from pandoc), copied into the artifact.
+
+Each artifact carries its own TTL (chosen by the agent, default from config;
+``0`` = keep forever) in a ``.meta.json`` sidecar; a background loop deletes
+expired ones.  ``.meta.json`` and any dotfile are never served.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 import secrets
+import shutil
 import time
 from pathlib import Path
 
 log = logging.getLogger(__name__)
 
 # How often the background loop sweeps for expired artifacts.
-# ponytail: fixed hourly sweep; the TTL is the tunable knob, not the cadence.
+# ponytail: fixed hourly sweep; the per-artifact TTL is the tunable knob.
 _CLEANUP_INTERVAL_S = 3600
 
-# Hard ceiling on a single artifact. The LLM's max_tokens already bounds a write
-# far below this; the cap is a cheap backstop at the write chokepoint against a
-# runaway loop or any future trusted caller, since write_artifact runs without
-# an approval prompt (permissions ALWAYS).
-MAX_ARTIFACT_BYTES = 5 * 1024 * 1024  # 5 MiB
+# Hard ceiling on a single artifact (sum of its files). Generous enough for a
+# PDF or a small image gallery; a cheap backstop at the write chokepoint against
+# a runaway loop, since inline writes run without an approval prompt.
+MAX_ARTIFACT_BYTES = 25 * 1024 * 1024  # 25 MiB
+
+_META_NAME = ".meta.json"
 
 # Artifact ids come from ``secrets.token_urlsafe`` → [A-Za-z0-9_-]. Validating
-# against this on read makes path traversal impossible: no '/', '.', or '\\'
-# ever reaches the filesystem join.
+# against this makes id-based traversal impossible.
 _ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 # Served with every artifact response. ``sandbox`` puts the page in a unique
-# opaque origin, so its (agent-authored) JS cannot read the admin origin's
+# opaque origin, so its (agent-authored) JS/SVG cannot read the admin origin's
 # localStorage — where the admin API key lives. CDN scripts, inline scripts,
 # forms and popups still work; only same-origin privilege is dropped.
 ARTIFACT_CSP = "sandbox allow-scripts allow-forms allow-popups allow-modals allow-downloads"
@@ -55,66 +63,156 @@ NOT_FOUND_HTML = (
 )
 
 
+def _safe_rel(name: str) -> str | None:
+    """Normalize a relative filename, or ``None`` if it is unsafe to write/serve.
+
+    Rejects absolute paths, ``..`` components, and any dotfile (so a copied tree
+    can't expose ``.git``/``.env`` and ``.meta.json`` stays internal).
+    """
+    name = str(name).strip().replace("\\", "/").lstrip("/")
+    if not name:
+        return None
+    parts = [p for p in name.split("/") if p not in ("", ".")]
+    if not parts or any(p == ".." or p.startswith(".") for p in parts):
+        return None
+    return "/".join(parts)
+
+
+def _dir_size(base: Path) -> int:
+    return sum(f.stat().st_size for f in base.rglob("*") if f.is_file() and not f.is_symlink())
+
+
 class ArtifactStore:
-    """Filesystem-backed store for self-contained HTML artifacts."""
+    """Filesystem-backed store for web artifacts (one directory per artifact)."""
 
     def __init__(self, directory: str | Path, ttl_hours: int = 168, enabled: bool = True):
         self.dir = Path(directory)
-        self.ttl_hours = ttl_hours
+        self.ttl_hours = ttl_hours  # default TTL when an artifact doesn't set its own
         self.enabled = enabled
 
-    def write(self, html: str, *, title: str = "") -> str:
-        """Write ``html`` under a fresh random id; return that id.
+    def create(
+        self,
+        *,
+        files: dict[str, str] | None = None,
+        source_path: str | Path | None = None,
+        entrypoint: str = "index.html",
+        ttl_hours: int | None = None,
+        title: str = "",
+    ) -> str:
+        """Create a new artifact directory; return its random id.
 
-        Raises ``ValueError`` if the body exceeds ``MAX_ARTIFACT_BYTES``.
+        Provide exactly one of ``files`` (name → text) or ``source_path`` (a file
+        or directory to copy in). Raises ``ValueError`` on bad input or oversize.
         """
-        data = html.encode("utf-8")
-        if len(data) > MAX_ARTIFACT_BYTES:
-            raise ValueError(f"artifact too large ({len(data)} bytes, max {MAX_ARTIFACT_BYTES})")
-        self.dir.mkdir(parents=True, exist_ok=True)
+        if bool(files) == bool(source_path):
+            raise ValueError("provide exactly one of 'files' or 'source_path'")
+
         art_id = secrets.token_urlsafe(12)
-        (self.dir / f"{art_id}.html").write_bytes(data)
-        log.info("Artifact written: %s (%d bytes) %s", art_id, len(data), title)
+        base = self.dir / art_id
+        base.mkdir(parents=True, exist_ok=False)
+        try:
+            if files:
+                for name, content in files.items():
+                    rel = _safe_rel(name)
+                    if rel is None:
+                        raise ValueError(f"unsafe filename: {name!r}")
+                    target = base / rel
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text(str(content), encoding="utf-8")
+            else:
+                src = Path(source_path)  # type: ignore[arg-type]
+                if not src.exists():
+                    raise ValueError(f"source_path not found: {source_path}")
+                if src.is_dir():
+                    # symlinks=True preserves links as links so the serve-time
+                    # guard rejects them, rather than inlining their target bytes.
+                    shutil.copytree(src, base, dirs_exist_ok=True, symlinks=True)
+                else:
+                    shutil.copy2(src, base / src.name)
+                    if entrypoint == "index.html":
+                        entrypoint = src.name
+
+            total = _dir_size(base)
+            if total > MAX_ARTIFACT_BYTES:
+                raise ValueError(f"artifact too large ({total} bytes, max {MAX_ARTIFACT_BYTES})")
+
+            ttl = self.ttl_hours if ttl_hours is None else ttl_hours
+            expires_at = None if ttl <= 0 else time.time() + ttl * 3600
+            meta = {"expires_at": expires_at, "title": title, "entrypoint": entrypoint}
+            (base / _META_NAME).write_text(json.dumps(meta), encoding="utf-8")
+        except BaseException:
+            shutil.rmtree(base, ignore_errors=True)
+            raise
+
+        log.info("Artifact written: %s (%d bytes, entry=%s) %s", art_id, total, entrypoint, title)
         return art_id
 
-    def path_for(self, art_id: str) -> Path | None:
-        """Resolve an id to its file path, or ``None`` if it is unsafe to serve.
+    def _meta(self, art_id: str) -> dict | None:
+        try:
+            return json.loads((self.dir / art_id / _META_NAME).read_text(encoding="utf-8"))
+        except OSError, ValueError:
+            return None
 
-        The id regex blocks traversal in the id itself; the symlink/containment
-        check then refuses anything resolving outside the artifacts dir — so a
-        planted symlink (e.g. to ``data/master.key``) can't be read through the
-        public, unauthenticated route.
+    def resolve(self, art_id: str, file_path: str = "") -> Path | None:
+        """Resolve a request to a servable file, or ``None`` if unsafe/missing.
+
+        Blocks traversal, dotfiles (incl. ``.meta.json``), symlinks, hardlinks,
+        and anything resolving outside the artifact dir — so the public route
+        can't be tricked into serving e.g. a planted link to ``data/master.key``.
         """
         if not _ID_RE.match(art_id):
             return None
-        path = self.dir / f"{art_id}.html"
-        if path.is_symlink() or not path.resolve().is_relative_to(self.dir.resolve()):
+        base = self.dir / art_id
+        if not base.is_dir():
             return None
-        # A hardlink (st_nlink > 1) or a directory could also point the public
-        # route at content we never wrote; only a plain single-reference file is
-        # served. Missing files fall through and 404 at the caller.
-        if path.exists() and path.stat().st_nlink > 1:
+        if not file_path:
+            meta = self._meta(art_id)
+            file_path = (meta or {}).get("entrypoint") or "index.html"
+        rel = _safe_rel(file_path)
+        if rel is None:
             return None
-        return path
+        target = base / rel
+        try:
+            resolved = target.resolve()
+        except OSError:
+            return None
+        if target.is_symlink() or not resolved.is_relative_to(base.resolve()):
+            return None
+        if not target.is_file():
+            return None
+        if target.stat().st_nlink > 1:  # hardlink to a file elsewhere on the volume
+            return None
+        return target
 
     def cleanup(self) -> int:
-        """Delete artifacts older than ``ttl_hours``; return the count removed.
+        """Delete artifacts whose stored expiry has passed; return count removed.
 
-        ``ttl_hours <= 0`` keeps artifacts forever (no-op).
+        Per-artifact ``expires_at`` (``None`` = keep forever) lives in the
+        sidecar. A dir missing/with-unreadable metadata falls back to its mtime
+        plus the configured default TTL.
         """
-        if self.ttl_hours <= 0 or not self.dir.exists():
+        if not self.dir.exists():
             return 0
-        cutoff = time.time() - self.ttl_hours * 3600
+        now = time.time()
         removed = 0
-        for f in self.dir.glob("*.html"):
-            try:
-                if f.stat().st_mtime < cutoff:
-                    f.unlink()
-                    removed += 1
-            except OSError:
-                log.warning("Failed to remove expired artifact: %s", f)
+        for child in self.dir.iterdir():
+            if not child.is_dir():
+                continue
+            meta = self._meta(child.name)
+            if meta is not None:
+                expires_at = meta.get("expires_at")
+            elif self.ttl_hours > 0:
+                try:
+                    expires_at = child.stat().st_mtime + self.ttl_hours * 3600
+                except OSError:
+                    continue
+            else:
+                expires_at = None
+            if expires_at is not None and now > expires_at:
+                shutil.rmtree(child, ignore_errors=True)
+                removed += 1
         if removed:
-            log.info("Artifact cleanup removed %d expired file(s)", removed)
+            log.info("Artifact cleanup removed %d expired artifact(s)", removed)
         return removed
 
 

--- a/core/artifacts.py
+++ b/core/artifacts.py
@@ -90,6 +90,11 @@ class ArtifactStore:
         path = self.dir / f"{art_id}.html"
         if path.is_symlink() or not path.resolve().is_relative_to(self.dir.resolve()):
             return None
+        # A hardlink (st_nlink > 1) or a directory could also point the public
+        # route at content we never wrote; only a plain single-reference file is
+        # served. Missing files fall through and 404 at the caller.
+        if path.exists() and path.stat().st_nlink > 1:
+            return None
         return path
 
     def cleanup(self) -> int:

--- a/core/artifacts.py
+++ b/core/artifacts.py
@@ -26,6 +26,12 @@ log = logging.getLogger(__name__)
 # ponytail: fixed hourly sweep; the TTL is the tunable knob, not the cadence.
 _CLEANUP_INTERVAL_S = 3600
 
+# Hard ceiling on a single artifact. The LLM's max_tokens already bounds a write
+# far below this; the cap is a cheap backstop at the write chokepoint against a
+# runaway loop or any future trusted caller, since write_artifact runs without
+# an approval prompt (permissions ALWAYS).
+MAX_ARTIFACT_BYTES = 5 * 1024 * 1024  # 5 MiB
+
 # Artifact ids come from ``secrets.token_urlsafe`` → [A-Za-z0-9_-]. Validating
 # against this on read makes path traversal impossible: no '/', '.', or '\\'
 # ever reaches the filesystem join.
@@ -58,18 +64,33 @@ class ArtifactStore:
         self.enabled = enabled
 
     def write(self, html: str, *, title: str = "") -> str:
-        """Write ``html`` under a fresh random id; return that id."""
+        """Write ``html`` under a fresh random id; return that id.
+
+        Raises ``ValueError`` if the body exceeds ``MAX_ARTIFACT_BYTES``.
+        """
+        data = html.encode("utf-8")
+        if len(data) > MAX_ARTIFACT_BYTES:
+            raise ValueError(f"artifact too large ({len(data)} bytes, max {MAX_ARTIFACT_BYTES})")
         self.dir.mkdir(parents=True, exist_ok=True)
         art_id = secrets.token_urlsafe(12)
-        (self.dir / f"{art_id}.html").write_text(html, encoding="utf-8")
-        log.info("Artifact written: %s (%d bytes) %s", art_id, len(html), title)
+        (self.dir / f"{art_id}.html").write_bytes(data)
+        log.info("Artifact written: %s (%d bytes) %s", art_id, len(data), title)
         return art_id
 
     def path_for(self, art_id: str) -> Path | None:
-        """Resolve an id to its file path, or ``None`` if the id is malformed."""
+        """Resolve an id to its file path, or ``None`` if it is unsafe to serve.
+
+        The id regex blocks traversal in the id itself; the symlink/containment
+        check then refuses anything resolving outside the artifacts dir — so a
+        planted symlink (e.g. to ``data/master.key``) can't be read through the
+        public, unauthenticated route.
+        """
         if not _ID_RE.match(art_id):
             return None
-        return self.dir / f"{art_id}.html"
+        path = self.dir / f"{art_id}.html"
+        if path.is_symlink() or not path.resolve().is_relative_to(self.dir.resolve()):
+            return None
+        return path
 
     def cleanup(self) -> int:
         """Delete artifacts older than ``ttl_hours``; return the count removed.

--- a/core/artifacts.py
+++ b/core/artifacts.py
@@ -1,0 +1,120 @@
+"""Agent-crafted web artifacts.
+
+The agent writes a self-contained HTML page (``write_artifact`` tool) and gets
+back a shareable link.  Pages are served read-only at ``/artifacts/<id>`` on the
+admin app — no auth, but the id is an unguessable random string so the route
+cannot be listed or walked.  A background loop deletes pages older than the
+configured TTL.
+
+One artifact == one standalone HTML document.  CSS goes inline in ``<style>``,
+JS inline in ``<script>``, and Tailwind/Alpine load from a CDN — so a single
+file covers every rung of the complexity ladder without a build step.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import secrets
+import time
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# How often the background loop sweeps for expired artifacts.
+# ponytail: fixed hourly sweep; the TTL is the tunable knob, not the cadence.
+_CLEANUP_INTERVAL_S = 3600
+
+# Artifact ids come from ``secrets.token_urlsafe`` → [A-Za-z0-9_-]. Validating
+# against this on read makes path traversal impossible: no '/', '.', or '\\'
+# ever reaches the filesystem join.
+_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+# Served with every artifact response. ``sandbox`` puts the page in a unique
+# opaque origin, so its (agent-authored) JS cannot read the admin origin's
+# localStorage — where the admin API key lives. CDN scripts, inline scripts,
+# forms and popups still work; only same-origin privilege is dropped.
+ARTIFACT_CSP = "sandbox allow-scripts allow-forms allow-popups allow-modals allow-downloads"
+
+NOT_FOUND_HTML = (
+    "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+    "<title>Not found</title><meta name='viewport' "
+    "content='width=device-width, initial-scale=1'>"
+    "<style>body{font-family:system-ui,sans-serif;display:grid;place-items:center;"
+    "min-height:100vh;margin:0;color:#444;background:#fafafa}"
+    "div{text-align:center}h1{font-size:3rem;margin:0}</style></head>"
+    "<body><div><h1>404</h1><p>This artifact does not exist or has expired.</p>"
+    "</div></body></html>"
+)
+
+
+class ArtifactStore:
+    """Filesystem-backed store for self-contained HTML artifacts."""
+
+    def __init__(self, directory: str | Path, ttl_hours: int = 168, enabled: bool = True):
+        self.dir = Path(directory)
+        self.ttl_hours = ttl_hours
+        self.enabled = enabled
+
+    def write(self, html: str, *, title: str = "") -> str:
+        """Write ``html`` under a fresh random id; return that id."""
+        self.dir.mkdir(parents=True, exist_ok=True)
+        art_id = secrets.token_urlsafe(12)
+        (self.dir / f"{art_id}.html").write_text(html, encoding="utf-8")
+        log.info("Artifact written: %s (%d bytes) %s", art_id, len(html), title)
+        return art_id
+
+    def path_for(self, art_id: str) -> Path | None:
+        """Resolve an id to its file path, or ``None`` if the id is malformed."""
+        if not _ID_RE.match(art_id):
+            return None
+        return self.dir / f"{art_id}.html"
+
+    def cleanup(self) -> int:
+        """Delete artifacts older than ``ttl_hours``; return the count removed.
+
+        ``ttl_hours <= 0`` keeps artifacts forever (no-op).
+        """
+        if self.ttl_hours <= 0 or not self.dir.exists():
+            return 0
+        cutoff = time.time() - self.ttl_hours * 3600
+        removed = 0
+        for f in self.dir.glob("*.html"):
+            try:
+                if f.stat().st_mtime < cutoff:
+                    f.unlink()
+                    removed += 1
+            except OSError:
+                log.warning("Failed to remove expired artifact: %s", f)
+        if removed:
+            log.info("Artifact cleanup removed %d expired file(s)", removed)
+        return removed
+
+
+async def store_from_config(config_store) -> ArtifactStore:
+    """Build an ArtifactStore from the live config store (its source of truth).
+
+    Reads the ``artifacts.*`` keys directly so it works even for installs seeded
+    before this feature existed (missing keys → Pydantic defaults).
+    """
+    from core.config import ArtifactsConfig
+
+    flat = await config_store.get_many("artifacts.")
+    data = {k.split(".", 1)[1]: v for k, v in flat.items()}
+    cfg = ArtifactsConfig.model_validate(data) if data else ArtifactsConfig()
+    return ArtifactStore(cfg.directory, cfg.ttl_hours, cfg.enabled)
+
+
+async def cleanup_loop(config_store) -> None:
+    """Forever: sweep expired artifacts, then sleep. Cancel to stop."""
+    while True:
+        try:
+            store = await store_from_config(config_store)
+            if store.enabled:
+                store.cleanup()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("Artifact cleanup cycle failed")
+        await asyncio.sleep(_CLEANUP_INTERVAL_S)

--- a/core/artifacts.py
+++ b/core/artifacts.py
@@ -78,6 +78,11 @@ def _safe_rel(name: str) -> str | None:
     return "/".join(parts)
 
 
+def valid_id(art_id: str) -> bool:
+    """True if ``art_id`` is a well-formed artifact id (no traversal/control chars)."""
+    return bool(_ID_RE.match(art_id))
+
+
 def _dir_size(base: Path) -> int:
     return sum(f.stat().st_size for f in base.rglob("*") if f.is_file() and not f.is_symlink())
 

--- a/core/artifacts.py
+++ b/core/artifacts.py
@@ -70,7 +70,9 @@ def _safe_rel(name: str) -> str | None:
     can't expose ``.git``/``.env`` and ``.meta.json`` stays internal).
     """
     name = str(name).strip().replace("\\", "/").lstrip("/")
-    if not name:
+    # Reject control chars (incl. the null byte, which makes Path.resolve raise a
+    # ValueError that would otherwise surface as a 500 on the public route).
+    if not name or any(ord(c) < 32 for c in name):
         return None
     parts = [p for p in name.split("/") if p not in ("", ".")]
     if not parts or any(p == ".." or p.startswith(".") for p in parts):
@@ -134,12 +136,13 @@ class ArtifactStore:
                     shutil.copytree(src, base, dirs_exist_ok=True, symlinks=True)
                 else:
                     shutil.copy2(src, base / src.name)
-                    if entrypoint == "index.html":
-                        entrypoint = src.name
+                    entrypoint = src.name  # one file → it IS the entry, ignore default
 
             total = _dir_size(base)
             if total > MAX_ARTIFACT_BYTES:
                 raise ValueError(f"artifact too large ({total} bytes, max {MAX_ARTIFACT_BYTES})")
+
+            entrypoint = self._resolve_entrypoint(base, entrypoint)
 
             ttl = self.ttl_hours if ttl_hours is None else ttl_hours
             expires_at = None if ttl <= 0 else time.time() + ttl * 3600
@@ -151,6 +154,25 @@ class ArtifactStore:
 
         log.info("Artifact written: %s (%d bytes, entry=%s) %s", art_id, total, entrypoint, title)
         return art_id
+
+    @staticmethod
+    def _resolve_entrypoint(base: Path, entrypoint: str) -> str:
+        """Return the file served at the artifact root, or raise if none works.
+
+        Auto-picks the sole top-level file when the default ``index.html`` is
+        absent; otherwise the agent must name a valid ``entrypoint``.
+        """
+        rel = _safe_rel(entrypoint)
+        if rel and (base / rel).is_file():
+            return rel
+        if entrypoint == "index.html":
+            tops = [p.name for p in base.iterdir() if p.is_file() and not p.name.startswith(".")]
+            if len(tops) == 1:
+                return tops[0]
+        raise ValueError(
+            f"entrypoint {entrypoint!r} not found in the artifact; "
+            "include an index.html or pass a valid 'entrypoint'"
+        )
 
     def _meta(self, art_id: str) -> dict | None:
         try:
@@ -179,7 +201,7 @@ class ArtifactStore:
         target = base / rel
         try:
             resolved = target.resolve()
-        except OSError:
+        except OSError, ValueError:
             return None
         if target.is_symlink() or not resolved.is_relative_to(base.resolve()):
             return None

--- a/core/config.py
+++ b/core/config.py
@@ -293,6 +293,14 @@ class ToolsConfig(BaseModel):
     browser: BrowserToolConfig = BrowserToolConfig()
 
 
+class ArtifactsConfig(BaseModel):
+    """Agent-crafted web artifacts served at /artifacts/<id> (see core/artifacts.py)."""
+
+    enabled: bool = True
+    directory: str = "data/artifacts"
+    ttl_hours: int = 168  # 7 days; 0 = keep forever (no auto-cleanup)
+
+
 class Config(BaseModel):
     agent: AgentConfig = AgentConfig()
     channels: ChannelsConfig = ChannelsConfig()
@@ -310,6 +318,7 @@ class Config(BaseModel):
     you: YouConfig = YouConfig()
     prompt: PromptConfig = PromptConfig()
     tools: ToolsConfig = ToolsConfig()
+    artifacts: ArtifactsConfig = ArtifactsConfig()
 
 
 def load_config(path: str | Path = "config.yml") -> Config:

--- a/core/main.py
+++ b/core/main.py
@@ -14,8 +14,9 @@ Usage:
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from os import environ
 
 import uvicorn
@@ -156,6 +157,11 @@ async def _lifespan(application):  # noqa: ANN001
         await _secret_store.ensure_wrapped_dek(seed_pw)
     await materialize_himalaya_config(_config_store)
 
+    # Background sweep of expired web artifacts (runs regardless of setup state).
+    from core.artifacts import cleanup_loop
+
+    application.state.artifacts_task = asyncio.create_task(cleanup_loop(_config_store))
+
     setup_complete = await _config_store.is_setup_complete()
 
     if setup_complete:
@@ -175,6 +181,11 @@ async def _lifespan(application):  # noqa: ANN001
 
     # -- shutdown --
     log.info("Shutting down…")
+    artifacts_task = getattr(application.state, "artifacts_task", None)
+    if artifacts_task:
+        artifacts_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await artifacts_task
     if _agent_state.agent:
         _agent_state.status = "STOPPING"
         await _stop_agent(_agent_state.agent)

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -127,9 +127,12 @@ DEFAULT_RULES: dict[str, str] = {
     "run_command:himalaya*move*": "ASK",
     "schedule_task": "ASK",
     "manage_jobs": "ASK",
-    # Writing a local HTML artifact served at an unguessable URL is low-risk and
-    # reversible (TTL cleanup) — no prompt, like web_search / load_skill.
+    # Publishing inline content the agent authored is low-risk and reversible
+    # (TTL cleanup) — no prompt, like web_search / load_skill. But copying an
+    # on-disk file to a public URL can expose data the agent didn't author, so
+    # that variant (source_path) asks first.
     "write_artifact": "ALWAYS",
+    "write_artifact:publish_file": "ASK",
     # Dangerous — never allow
     "run_command:sqlite3*DROP*": "NEVER",
     "run_command:sqlite3*ALTER*": "NEVER",
@@ -182,6 +185,9 @@ class PermissionEngine:
     def _build_match_key(self, tool_name: str, params: dict | None = None) -> str:
         if tool_name == "run_command" and params and "command" in params:
             return f"run_command:{params['command']}"
+        # Publishing an on-disk file is gated separately from inline writes.
+        if tool_name == "write_artifact" and params and params.get("source_path"):
+            return "write_artifact:publish_file"
         return tool_name
 
     @staticmethod
@@ -228,6 +234,11 @@ class PermissionEngine:
             "manage_jobs",
         }:
             return True
+
+        # Inline artifact writes are not write-actions (frictionless); publishing
+        # an on-disk file is (it exposes a file and needs per-call approval).
+        if tool_name == "write_artifact":
+            return bool(params and params.get("source_path"))
 
         match_key = self._build_match_key(tool_name, params)
         if match_key.startswith("run_command:"):
@@ -392,4 +403,6 @@ def format_approval_message(tool_name: str, params: dict) -> str:
         cmd = params.get("command", "?")
         purpose = params.get("purpose", "")
         return f"Run command: {cmd}" + (f"\n({purpose})" if purpose else "")
+    if tool_name == "write_artifact":
+        return f"Publish a file as a public web artifact:\n{params.get('source_path', '?')}"
     return f"{tool_name}: {params}"

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -127,6 +127,9 @@ DEFAULT_RULES: dict[str, str] = {
     "run_command:himalaya*move*": "ASK",
     "schedule_task": "ASK",
     "manage_jobs": "ASK",
+    # Writing a local HTML artifact served at an unguessable URL is low-risk and
+    # reversible (TTL cleanup) — no prompt, like web_search / load_skill.
+    "write_artifact": "ALWAYS",
     # Dangerous — never allow
     "run_command:sqlite3*DROP*": "NEVER",
     "run_command:sqlite3*ALTER*": "NEVER",

--- a/docs/content/docs/artifacts.mdx
+++ b/docs/content/docs/artifacts.mdx
@@ -85,6 +85,8 @@ artifacts:
   ttl_hours: 168               # default lifetime; agent may override per artifact (0 = forever)
 ```
 
-Set `enabled: false` to turn the feature off entirely: the tool refuses to write and the
-`/artifacts/<id>/` route returns 404 for everything. These keys are editable from the admin
-**Config** tab, and `write_artifact` can be allowed/denied per persona in the persona editor.
+These settings are managed from the admin **Tools** tab (enable/disable, directory, default
+TTL). Setting `enabled: false` turns the feature off **entirely**: `write_artifact` is hidden
+from the assistant *and* from the Personae tool-scope UI, no persona can call it, and every
+`/artifacts/<id>/` link returns 404. When enabled, allow or deny it per persona in the
+**Personae** editor.

--- a/docs/content/docs/artifacts.mdx
+++ b/docs/content/docs/artifacts.mdx
@@ -1,26 +1,34 @@
 ---
 title: Web artifacts
-description: The agent publishes self-contained HTML pages — reports, dashboards, charts, mini-tools — served as shareable links at /artifacts/<id>.
+description: The agent publishes pages, multi-file sites, or documents (PDF, image, slides) as shareable links at /artifacts/<id>.
 ---
 
 # Web artifacts
 
 When an answer is richer than a chat bubble can show — a monthly expense dashboard,
 a chart comparing two options, an interactive checklist, a visual summary of GitHub
-activity — the agent can publish it as a **web artifact**: one self-contained HTML
-page served at `/artifacts/<id>` on the admin app, handed back to you as a link.
+activity, a generated PDF report — the agent can publish it as a **web artifact**:
+a small site served at `/artifacts/<id>/` on the admin app, handed back to you as a link.
 
-It is the agent's "give me a mini-site for X" capability. No nginx, no build step,
-no second file — just a URL you can open on any device.
+It is the agent's "give me a mini-site / document for X" capability. No nginx, no build
+step — just a URL you can open on any device.
 
 ## How it works
 
-The agent calls the `write_artifact` tool with a complete HTML document. The page is
-saved under `artifacts.directory` (default `data/artifacts/`) with a random,
-unguessable id, and the agent replies with the link:
+An artifact is a **directory** served at `/artifacts/<id>/` under a random, unguessable
+id. The agent calls the `write_artifact` tool one of three ways:
+
+- **A single page** — pass `html`, a complete HTML document. Becomes `index.html`.
+- **A multi-file site** — pass `files`, a map of `{ "index.html": …, "style.css": …,
+  "app.js": … }`. Files link each other with relative URLs (`href="style.css"`).
+- **A file the agent generated** — pass `source_path`, an absolute path to a file or
+  directory already on disk (a PDF from `pandoc`, an image, slides, a doc, or a prebuilt
+  site). It is copied into the artifact.
+
+The agent gets back the link and shares it:
 
 ```
-http://your-host:8000/artifacts/AbC123xy
+http://your-host:8000/artifacts/AbC123xy/
 ```
 
 Set [`MPA_BASE_URL`](/docs/configuration) to your reachable admin URL so the links
@@ -28,8 +36,7 @@ work from your phone, not just `localhost`.
 
 ### The complexity ladder
 
-One artifact is **one standalone HTML file**, so the agent inlines everything and
-climbs only as high as the request needs:
+For HTML, the agent climbs only as high as the request needs:
 
 | Need | What the agent reaches for |
 |---|---|
@@ -38,35 +45,46 @@ climbs only as high as the request needs:
 | Branded / designed page | Custom CSS in `<style>`, or TailwindCSS v4 via its browser CDN build (`@tailwindcss/browser@4`) |
 | Interactivity | Inline JS, or Alpine.js via CDN |
 
-CSS goes inline in `<style>`, JS inline in `<script>`, and richer libraries load from
-a CDN — so a single file covers every rung without a server or bundler.
+### Lifetime
+
+The agent picks each artifact's TTL to fit the content — a short one for things that go
+stale fast (a daily report), a long one or `0` (keep forever) for lasting references. If
+it doesn't choose, the configured `ttl_hours` default applies. A background sweep deletes
+artifacts once their TTL passes.
 
 ## Security & hygiene
 
 - **Unguessable links.** Each artifact gets a random id (`secrets.token_urlsafe`), so
   the route can't be listed or walked. There is no index — an unknown id returns a 404.
-- **No path traversal.** Ids are validated against `[A-Za-z0-9_-]`, so `/`, `.` and `\`
-  never reach the filesystem.
-- **Sandboxed pages.** Every artifact is served with a `Content-Security-Policy: sandbox`
-  header, putting it in a unique opaque origin. Its (agent-authored) JavaScript therefore
-  **cannot read the admin origin's `localStorage`** — where the admin API key lives — or
-  its cookies. CDN scripts, inline scripts, forms and popups still work.
-- **Automatic expiry.** A background sweep deletes artifacts older than `ttl_hours`
-  (default 168 = 7 days; set `0` to keep them forever).
+- **No traversal or link escape.** Ids and file paths are validated; symlinks, hardlinks,
+  dotfiles (including the internal `.meta.json`), and anything resolving outside the
+  artifact dir are refused — so the public route can't be tricked into serving e.g.
+  `data/master.key`.
+- **Sandboxed pages.** Every artifact is served with `Content-Security-Policy: sandbox`
+  (and `X-Content-Type-Options: nosniff`), putting it in a unique opaque origin. Its
+  (agent-authored) JavaScript therefore **cannot read the admin origin's `localStorage`** —
+  where the admin API key lives — or its cookies. CDN scripts, inline scripts, forms and
+  popups still work.
+- **Publishing a file asks first.** Inline content (`html` / `files`) the agent authored is
+  written without a prompt. Copying an on-disk file (`source_path`) to a public URL can
+  expose data the agent didn't author, so that variant requires your approval each time.
+- **Size cap.** A single artifact is capped (25 MiB) as a backstop against a runaway loop.
+- **Automatic expiry** via the TTL sweep.
 - **Per-persona scope.** `write_artifact` is a [gateable tool](/docs/personae) — a persona
   with a restricted tool scope can be denied the ability to publish artifacts.
 
 Artifacts are served **without authentication** by design — anyone with the link can
-open the page. The unguessable id is the access control. Don't put secrets in an artifact.
+open it. The unguessable id is the access control. Don't put secrets in an artifact.
 
 ## Configuration
 
 ```yaml
 artifacts:
   enabled: true
-  directory: "data/artifacts"  # where the HTML files live
-  ttl_hours: 168               # auto-delete after this many hours (0 = keep forever)
+  directory: "data/artifacts"  # where artifacts live
+  ttl_hours: 168               # default lifetime; agent may override per artifact (0 = forever)
 ```
 
 Set `enabled: false` to turn the feature off entirely: the tool refuses to write and the
-`/artifacts/<id>` route returns 404 for everything.
+`/artifacts/<id>/` route returns 404 for everything. These keys are editable from the admin
+**Config** tab, and `write_artifact` can be allowed/denied per persona in the persona editor.

--- a/docs/content/docs/artifacts.mdx
+++ b/docs/content/docs/artifacts.mdx
@@ -1,0 +1,72 @@
+---
+title: Web artifacts
+description: The agent publishes self-contained HTML pages — reports, dashboards, charts, mini-tools — served as shareable links at /artifacts/<id>.
+---
+
+# Web artifacts
+
+When an answer is richer than a chat bubble can show — a monthly expense dashboard,
+a chart comparing two options, an interactive checklist, a visual summary of GitHub
+activity — the agent can publish it as a **web artifact**: one self-contained HTML
+page served at `/artifacts/<id>` on the admin app, handed back to you as a link.
+
+It is the agent's "give me a mini-site for X" capability. No nginx, no build step,
+no second file — just a URL you can open on any device.
+
+## How it works
+
+The agent calls the `write_artifact` tool with a complete HTML document. The page is
+saved under `artifacts.directory` (default `data/artifacts/`) with a random,
+unguessable id, and the agent replies with the link:
+
+```
+http://your-host:8000/artifacts/AbC123xy
+```
+
+Set [`MPA_BASE_URL`](/docs/configuration) to your reachable admin URL so the links
+work from your phone, not just `localhost`.
+
+### The complexity ladder
+
+One artifact is **one standalone HTML file**, so the agent inlines everything and
+climbs only as high as the request needs:
+
+| Need | What the agent reaches for |
+|---|---|
+| Quick report | Plain semantic HTML, no styling |
+| Clean readable doc | A classless CSS framework (MVP.css / Water.css) via CDN |
+| Branded / designed page | Custom CSS in `<style>`, or TailwindCSS v4 via CDN |
+| Interactivity | Inline JS, or Alpine.js via CDN |
+
+CSS goes inline in `<style>`, JS inline in `<script>`, and richer libraries load from
+a CDN — so a single file covers every rung without a server or bundler.
+
+## Security & hygiene
+
+- **Unguessable links.** Each artifact gets a random id (`secrets.token_urlsafe`), so
+  the route can't be listed or walked. There is no index — an unknown id returns a 404.
+- **No path traversal.** Ids are validated against `[A-Za-z0-9_-]`, so `/`, `.` and `\`
+  never reach the filesystem.
+- **Sandboxed pages.** Every artifact is served with a `Content-Security-Policy: sandbox`
+  header, putting it in a unique opaque origin. Its (agent-authored) JavaScript therefore
+  **cannot read the admin origin's `localStorage`** — where the admin API key lives — or
+  its cookies. CDN scripts, inline scripts, forms and popups still work.
+- **Automatic expiry.** A background sweep deletes artifacts older than `ttl_hours`
+  (default 168 = 7 days; set `0` to keep them forever).
+- **Per-persona scope.** `write_artifact` is a [gateable tool](/docs/personae) — a persona
+  with a restricted tool scope can be denied the ability to publish artifacts.
+
+Artifacts are served **without authentication** by design — anyone with the link can
+open the page. The unguessable id is the access control. Don't put secrets in an artifact.
+
+## Configuration
+
+```yaml
+artifacts:
+  enabled: true
+  directory: "data/artifacts"  # where the HTML files live
+  ttl_hours: 168               # auto-delete after this many hours (0 = keep forever)
+```
+
+Set `enabled: false` to turn the feature off entirely: the tool refuses to write and the
+`/artifacts/<id>` route returns 404 for everything.

--- a/docs/content/docs/artifacts.mdx
+++ b/docs/content/docs/artifacts.mdx
@@ -35,7 +35,7 @@ climbs only as high as the request needs:
 |---|---|
 | Quick report | Plain semantic HTML, no styling |
 | Clean readable doc | A classless CSS framework (MVP.css / Water.css) via CDN |
-| Branded / designed page | Custom CSS in `<style>`, or TailwindCSS v4 via CDN |
+| Branded / designed page | Custom CSS in `<style>`, or TailwindCSS v4 via its browser CDN build (`@tailwindcss/browser@4`) |
 | Interactivity | Inline JS, or Alpine.js via CDN |
 
 CSS goes inline in `<style>`, JS inline in `<script>`, and richer libraries load from

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -38,7 +38,7 @@ Key variables:
 | `GOOGLE_EMAIL` | Google account for calendar |
 | `GOOGLE_APP_PASSWORD` | Google app-specific password |
 | `MPA_MASTER_KEY` | Infra [secrets vault](/docs/secrets) machine key (optional; a `data/master.key` keyfile is used if unset) |
-| `MPA_BASE_URL` | Base URL for secure "provide a secret" links (defaults to `http://localhost:<admin port>`) |
+| `MPA_BASE_URL` | Base URL for secure "provide a secret" links and [web artifact](/docs/artifacts) links (defaults to `http://localhost:<admin port>`) |
 
 ## Agent config (`config.yml`)
 
@@ -173,6 +173,10 @@ Conversation history settings. `max_turns` controls how many user-assistant pair
 #### `memory`
 
 Memory system settings. `extraction_model` is the cheap/fast model used for post-turn memory extraction. See [Memory](/docs/memory) for details.
+
+#### `artifacts`
+
+Agent-crafted [web artifacts](/docs/artifacts). `directory` is where the HTML files live, and `ttl_hours` sets how long they are kept before the background sweep deletes them (`0` = keep forever). Set `MPA_BASE_URL` so the shared links are reachable from your devices. Enabled by default.
 
 ## Character and identity files
 

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -176,7 +176,7 @@ Memory system settings. `extraction_model` is the cheap/fast model used for post
 
 #### `artifacts`
 
-Agent-crafted [web artifacts](/docs/artifacts) — pages, multi-file sites, or documents served at `/artifacts/<id>/`. `directory` is where they live; `ttl_hours` is the **default** lifetime before the background sweep deletes them (`0` = keep forever), which the agent may override per artifact. Set `MPA_BASE_URL` so the shared links are reachable from your devices. Enabled by default.
+Agent-crafted [web artifacts](/docs/artifacts) — pages, multi-file sites, or documents served at `/artifacts/<id>/`. `directory` is where they live; `ttl_hours` is the **default** lifetime before the background sweep deletes them (`0` = keep forever), which the agent may override per artifact. Set `MPA_BASE_URL` so the shared links are reachable from your devices. Enabled by default, and managed from the admin **Tools** tab; `enabled: false` hides the tool everywhere and 404s all links.
 
 ## Character and identity files
 

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -176,7 +176,7 @@ Memory system settings. `extraction_model` is the cheap/fast model used for post
 
 #### `artifacts`
 
-Agent-crafted [web artifacts](/docs/artifacts). `directory` is where the HTML files live, and `ttl_hours` sets how long they are kept before the background sweep deletes them (`0` = keep forever). Set `MPA_BASE_URL` so the shared links are reachable from your devices. Enabled by default.
+Agent-crafted [web artifacts](/docs/artifacts) — pages, multi-file sites, or documents served at `/artifacts/<id>/`. `directory` is where they live; `ttl_hours` is the **default** lifetime before the background sweep deletes them (`0` = keep forever), which the agent may override per artifact. Set `MPA_BASE_URL` so the shared links are reachable from your devices. Enabled by default.
 
 ## Character and identity files
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -15,6 +15,7 @@
     "secrets",
     "scheduler",
     "voice",
+    "artifacts",
     "admin-ui",
     "---",
     "development",

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from types import SimpleNamespace
 from typing import cast
 
+import pytest
 from fastapi.testclient import TestClient
 
+import core.artifacts as artifacts_mod
 from api.admin import AgentState, create_admin_app
-from core.artifacts import ArtifactStore
+from core.artifacts import MAX_ARTIFACT_BYTES, ArtifactStore, cleanup_loop
 from core.config_store import ConfigStore
 
 # -- ArtifactStore unit tests -------------------------------------------------
@@ -57,6 +60,24 @@ def test_cleanup_ttl_zero_is_noop(tmp_path) -> None:
     assert path.exists()
 
 
+def test_write_rejects_oversized(tmp_path) -> None:
+    store = ArtifactStore(tmp_path)
+    with pytest.raises(ValueError, match="too large"):
+        store.write("x" * (MAX_ARTIFACT_BYTES + 1))
+
+
+def test_path_for_rejects_symlink_escape(tmp_path) -> None:
+    # A planted symlink whose target escapes the dir must not resolve — it would
+    # otherwise let the public route read e.g. a secret keyfile.
+    outside = tmp_path / "secret.txt"
+    outside.write_text("top secret")
+    store_dir = tmp_path / "artifacts"
+    store_dir.mkdir()
+    link = store_dir / "abcdef12.html"
+    link.symlink_to(outside)
+    assert ArtifactStore(store_dir).path_for("abcdef12") is None
+
+
 # -- /artifacts route tests ---------------------------------------------------
 
 
@@ -87,12 +108,21 @@ def test_serve_artifact_round_trip(tmp_path) -> None:
     resp = _client(_Store(tmp_path)).get(f"/artifacts/{art_id}")
     assert resp.status_code == 200
     assert "<h1>dashboard</h1>" in resp.text
-    # CSP sandbox keeps artifact JS off the admin origin's localStorage.
-    assert "sandbox" in resp.headers["content-security-policy"]
+    # CSP sandbox keeps artifact JS off the admin origin's localStorage — the
+    # protection is the *absence* of allow-same-origin, so assert that too.
+    csp = resp.headers["content-security-policy"]
+    assert "sandbox" in csp
+    assert "allow-same-origin" not in csp
 
 
 def test_serve_missing_artifact_404(tmp_path) -> None:
     resp = _client(_Store(tmp_path)).get("/artifacts/doesnotexist123")
+    assert resp.status_code == 404
+
+
+def test_serve_rejects_encoded_traversal(tmp_path) -> None:
+    # Guards the real HTTP boundary against a future {artifact_id:path} regression.
+    resp = _client(_Store(tmp_path)).get("/artifacts/..%2f..%2fetc%2fpasswd")
     assert resp.status_code == 404
 
 
@@ -107,6 +137,31 @@ def test_serve_route_is_public(tmp_path) -> None:
     art_id = ArtifactStore(tmp_path).write("<h1>x</h1>")
     resp = _client(_Store(tmp_path)).get(f"/artifacts/{art_id}")
     assert resp.status_code == 200
+
+
+# -- cleanup_loop (the scheduled async task) ----------------------------------
+
+
+async def test_cleanup_loop_sweeps_then_cancels(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(artifacts_mod, "_CLEANUP_INTERVAL_S", 0.01)
+    store = ArtifactStore(tmp_path, ttl_hours=1)
+    art_id = store.write("<p>old</p>")
+    path = store.path_for(art_id)
+    assert path is not None
+    backdated = time.time() - 2 * 3600
+    os.utime(path, (backdated, backdated))
+
+    task = asyncio.create_task(cleanup_loop(_Store(tmp_path, ttl_hours=1)))
+    for _ in range(100):  # let at least one sweep run
+        await asyncio.sleep(0.01)
+        if not path.exists():
+            break
+    assert not path.exists()
+
+    # Cancellation must propagate (graceful shutdown relies on it).
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 # -- write_artifact tool handler ----------------------------------------------
@@ -129,6 +184,10 @@ def test_tool_write_artifact(tmp_path) -> None:
 
     # Empty content is rejected.
     assert "error" in AgentCore._tool_write_artifact(fake, {"html": "   "})
+
+    # Oversized content is rejected (ValueError → error result).
+    oversized = AgentCore._tool_write_artifact(fake, {"html": "x" * (MAX_ARTIFACT_BYTES + 1)})
+    assert "error" in oversized and "too large" in oversized["error"]
 
     # Disabled feature is rejected.
     fake.config.artifacts.enabled = False

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -78,6 +78,17 @@ def test_path_for_rejects_symlink_escape(tmp_path) -> None:
     assert ArtifactStore(store_dir).path_for("abcdef12") is None
 
 
+def test_path_for_rejects_hardlink_escape(tmp_path) -> None:
+    # A hardlink to a file outside the dir is not a symlink and resolves inside
+    # the dir, so only the st_nlink check catches it.
+    outside = tmp_path / "secret.txt"
+    outside.write_text("top secret")
+    store_dir = tmp_path / "artifacts"
+    store_dir.mkdir()
+    os.link(outside, store_dir / "abcdef34.html")
+    assert ArtifactStore(store_dir).path_for("abcdef34") is None
+
+
 # -- /artifacts route tests ---------------------------------------------------
 
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import time
 from types import SimpleNamespace
@@ -13,83 +14,130 @@ from fastapi.testclient import TestClient
 
 import core.artifacts as artifacts_mod
 from api.admin import AgentState, create_admin_app
-from core.artifacts import MAX_ARTIFACT_BYTES, ArtifactStore, cleanup_loop
+from core.artifacts import ArtifactStore, cleanup_loop
 from core.config_store import ConfigStore
+from core.permissions import PermissionEngine, PermissionLevel
 
-# -- ArtifactStore unit tests -------------------------------------------------
+# -- ArtifactStore: create + resolve ------------------------------------------
 
 
-def test_write_and_resolve_round_trip(tmp_path) -> None:
+def test_create_html_single_page(tmp_path) -> None:
     store = ArtifactStore(tmp_path)
-    art_id = store.write("<p>hello</p>", title="greeting")
-    path = store.path_for(art_id)
-    assert path is not None
-    assert path.read_text(encoding="utf-8") == "<p>hello</p>"
+    art_id = store.create(files={"index.html": "<h1>hello</h1>"}, title="greeting")
+    served = store.resolve(art_id)  # empty path → entrypoint
+    assert served is not None
+    assert served.read_text(encoding="utf-8") == "<h1>hello</h1>"
+    assert served.name == "index.html"
 
 
-def test_path_for_rejects_traversal_and_malformed(tmp_path) -> None:
+def test_create_multi_file_and_resolve_each(tmp_path) -> None:
     store = ArtifactStore(tmp_path)
-    for bad in ["../etc/passwd", "a/b", "a.b", "", "x" * 65, "foo bar", "..", "a%2fb"]:
-        assert store.path_for(bad) is None, bad
-    # A well-formed id resolves (file need not exist yet).
-    assert store.path_for("AbC-123_xy") is not None
+    art_id = store.create(
+        files={"index.html": "<link href='style.css'>", "style.css": "body{}", "js/app.js": "1"}
+    )
+    assert store.resolve(art_id, "style.css").read_text() == "body{}"
+    assert store.resolve(art_id, "js/app.js").read_text() == "1"
+    assert store.resolve(art_id).name == "index.html"  # default entrypoint
 
 
-def test_cleanup_removes_expired_keeps_fresh(tmp_path) -> None:
-    store = ArtifactStore(tmp_path, ttl_hours=1)
-    old_id = store.write("<p>old</p>")
-    old_path = store.path_for(old_id)
-    assert old_path is not None
-    backdated = time.time() - 2 * 3600  # 2h ago, past the 1h TTL
-    os.utime(old_path, (backdated, backdated))
-    fresh_id = store.write("<p>new</p>")
-
-    assert store.cleanup() == 1
-    assert not old_path.exists()
-    fresh_path = store.path_for(fresh_id)
-    assert fresh_path is not None and fresh_path.exists()
+def test_create_source_path_file_sets_entrypoint(tmp_path) -> None:
+    src = tmp_path / "report.pdf"
+    src.write_bytes(b"%PDF-1.4 fake")
+    store = ArtifactStore(tmp_path / "store")
+    art_id = store.create(source_path=str(src))
+    served = store.resolve(art_id)  # entrypoint became report.pdf
+    assert served is not None and served.name == "report.pdf"
+    assert served.read_bytes() == b"%PDF-1.4 fake"
 
 
-def test_cleanup_ttl_zero_is_noop(tmp_path) -> None:
-    store = ArtifactStore(tmp_path, ttl_hours=0)
-    art_id = store.write("<p>x</p>")
-    path = store.path_for(art_id)
-    assert path is not None
-    os.utime(path, (0, 0))  # ancient mtime
-    assert store.cleanup() == 0
-    assert path.exists()
+def test_create_source_path_directory(tmp_path) -> None:
+    site = tmp_path / "site"
+    site.mkdir()
+    (site / "index.html").write_text("<h1>site</h1>")
+    (site / "a.css").write_text("x{}")
+    store = ArtifactStore(tmp_path / "store")
+    art_id = store.create(source_path=str(site))
+    assert store.resolve(art_id).read_text() == "<h1>site</h1>"
+    assert store.resolve(art_id, "a.css").read_text() == "x{}"
 
 
-def test_write_rejects_oversized(tmp_path) -> None:
+def test_create_requires_exactly_one_source(tmp_path) -> None:
+    store = ArtifactStore(tmp_path)
+    with pytest.raises(ValueError):
+        store.create()  # neither
+    with pytest.raises(ValueError):
+        store.create(files={"index.html": "x"}, source_path=str(tmp_path))  # both
+
+
+def test_create_rejects_oversized_and_cleans_up(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(artifacts_mod, "MAX_ARTIFACT_BYTES", 16)
     store = ArtifactStore(tmp_path)
     with pytest.raises(ValueError, match="too large"):
-        store.write("x" * (MAX_ARTIFACT_BYTES + 1))
+        store.create(files={"index.html": "x" * 64})
+    # The partial directory must not linger.
+    assert list(tmp_path.iterdir()) == []
 
 
-def test_path_for_rejects_symlink_escape(tmp_path) -> None:
-    # A planted symlink whose target escapes the dir must not resolve — it would
-    # otherwise let the public route read e.g. a secret keyfile.
+# -- resolve: containment / safety --------------------------------------------
+
+
+def test_resolve_rejects_traversal_and_dotfiles(tmp_path) -> None:
+    store = ArtifactStore(tmp_path)
+    art_id = store.create(files={"index.html": "<h1>x</h1>"})
+    for bad in ["../../etc/passwd", "..", ".meta.json", "a/../../b", "x" * 80]:
+        assert store.resolve(art_id, bad) is None, bad
+    assert store.resolve("bad id!", "index.html") is None  # malformed id
+    assert store.resolve(art_id, "missing.css") is None  # absent file
+
+
+def test_resolve_rejects_symlink_escape(tmp_path) -> None:
     outside = tmp_path / "secret.txt"
     outside.write_text("top secret")
-    store_dir = tmp_path / "artifacts"
-    store_dir.mkdir()
-    link = store_dir / "abcdef12.html"
-    link.symlink_to(outside)
-    assert ArtifactStore(store_dir).path_for("abcdef12") is None
+    store = ArtifactStore(tmp_path / "store")
+    art_id = store.create(files={"index.html": "<h1>x</h1>"})
+    (store.dir / art_id / "leak.html").symlink_to(outside)
+    assert store.resolve(art_id, "leak.html") is None
 
 
-def test_path_for_rejects_hardlink_escape(tmp_path) -> None:
-    # A hardlink to a file outside the dir is not a symlink and resolves inside
-    # the dir, so only the st_nlink check catches it.
+def test_resolve_rejects_hardlink_escape(tmp_path) -> None:
     outside = tmp_path / "secret.txt"
     outside.write_text("top secret")
-    store_dir = tmp_path / "artifacts"
-    store_dir.mkdir()
-    os.link(outside, store_dir / "abcdef34.html")
-    assert ArtifactStore(store_dir).path_for("abcdef34") is None
+    store = ArtifactStore(tmp_path / "store")
+    art_id = store.create(files={"index.html": "<h1>x</h1>"})
+    os.link(outside, store.dir / art_id / "leak.html")
+    assert store.resolve(art_id, "leak.html") is None
 
 
-# -- /artifacts route tests ---------------------------------------------------
+# -- cleanup: per-artifact TTL ------------------------------------------------
+
+
+def test_cleanup_respects_per_artifact_ttl(tmp_path) -> None:
+    store = ArtifactStore(tmp_path, ttl_hours=168)
+    keep = store.create(files={"index.html": "a"}, ttl_hours=0)  # forever
+    expire = store.create(files={"index.html": "b"}, ttl_hours=1)
+    # Backdate the expiring artifact's stored expiry into the past.
+    meta_path = tmp_path / expire / ".meta.json"
+    meta = json.loads(meta_path.read_text())
+    meta["expires_at"] = time.time() - 10
+    meta_path.write_text(json.dumps(meta))
+
+    assert store.cleanup() == 1
+    assert (tmp_path / keep).exists()
+    assert not (tmp_path / expire).exists()
+
+
+def test_cleanup_falls_back_to_mtime_without_meta(tmp_path) -> None:
+    store = ArtifactStore(tmp_path, ttl_hours=1)
+    orphan = tmp_path / "orphan"
+    orphan.mkdir()
+    (orphan / "index.html").write_text("x")  # no .meta.json
+    old = time.time() - 2 * 3600
+    os.utime(orphan, (old, old))
+    assert store.cleanup() == 1
+    assert not orphan.exists()
+
+
+# -- /artifacts route ---------------------------------------------------------
 
 
 class _Store:
@@ -114,40 +162,53 @@ def _client(store: _Store) -> TestClient:
     return TestClient(app)
 
 
-def test_serve_artifact_round_trip(tmp_path) -> None:
-    art_id = ArtifactStore(tmp_path).write("<h1>dashboard</h1>")
-    resp = _client(_Store(tmp_path)).get(f"/artifacts/{art_id}")
-    assert resp.status_code == 200
-    assert "<h1>dashboard</h1>" in resp.text
-    # CSP sandbox keeps artifact JS off the admin origin's localStorage — the
-    # protection is the *absence* of allow-same-origin, so assert that too.
-    csp = resp.headers["content-security-policy"]
-    assert "sandbox" in csp
-    assert "allow-same-origin" not in csp
+def test_serve_index_and_subfile_with_content_types(tmp_path) -> None:
+    art_id = ArtifactStore(tmp_path).create(
+        files={"index.html": "<h1>dash</h1>", "data.json": "{}"}
+    )
+    client = _client(_Store(tmp_path))
+
+    root = client.get(f"/artifacts/{art_id}/")
+    assert root.status_code == 200
+    assert "<h1>dash</h1>" in root.text
+    assert "text/html" in root.headers["content-type"]
+    # CSP sandbox + nosniff on every artifact response; absence of allow-same-origin
+    # is the actual protection for the admin localStorage.
+    assert "sandbox" in root.headers["content-security-policy"]
+    assert "allow-same-origin" not in root.headers["content-security-policy"]
+    assert root.headers["x-content-type-options"] == "nosniff"
+
+    sub = client.get(f"/artifacts/{art_id}/data.json")
+    assert sub.status_code == 200
+    assert "json" in sub.headers["content-type"]
 
 
-def test_serve_missing_artifact_404(tmp_path) -> None:
-    resp = _client(_Store(tmp_path)).get("/artifacts/doesnotexist123")
-    assert resp.status_code == 404
+def test_no_slash_redirects_to_slash(tmp_path) -> None:
+    art_id = ArtifactStore(tmp_path).create(files={"index.html": "<h1>x</h1>"})
+    client = _client(_Store(tmp_path))
+    r = client.get(f"/artifacts/{art_id}", follow_redirects=False)
+    assert r.status_code == 307
+    assert r.headers["location"] == f"/artifacts/{art_id}/"
+    assert client.get(f"/artifacts/{art_id}", follow_redirects=True).status_code == 200
 
 
-def test_serve_rejects_encoded_traversal(tmp_path) -> None:
-    # Guards the real HTTP boundary against a future {artifact_id:path} regression.
-    resp = _client(_Store(tmp_path)).get("/artifacts/..%2f..%2fetc%2fpasswd")
-    assert resp.status_code == 404
+def test_meta_and_traversal_not_served(tmp_path) -> None:
+    art_id = ArtifactStore(tmp_path).create(files={"index.html": "<h1>x</h1>"})
+    client = _client(_Store(tmp_path))
+    assert client.get(f"/artifacts/{art_id}/.meta.json").status_code == 404
+    assert client.get("/artifacts/anything/..%2f..%2fetc%2fpasswd").status_code == 404
 
 
-def test_serve_when_disabled_404(tmp_path) -> None:
-    art_id = ArtifactStore(tmp_path).write("<h1>x</h1>")
-    resp = _client(_Store(tmp_path, enabled=False)).get(f"/artifacts/{art_id}")
-    assert resp.status_code == 404
+def test_serve_missing_and_disabled(tmp_path) -> None:
+    art_id = ArtifactStore(tmp_path).create(files={"index.html": "<h1>x</h1>"})
+    assert _client(_Store(tmp_path)).get("/artifacts/nope/").status_code == 404
+    assert _client(_Store(tmp_path, enabled=False)).get(f"/artifacts/{art_id}/").status_code == 404
 
 
 def test_serve_route_is_public(tmp_path) -> None:
     # No Authorization header — artifacts are gated by the unguessable id, not auth.
-    art_id = ArtifactStore(tmp_path).write("<h1>x</h1>")
-    resp = _client(_Store(tmp_path)).get(f"/artifacts/{art_id}")
-    assert resp.status_code == 200
+    art_id = ArtifactStore(tmp_path).create(files={"index.html": "<h1>x</h1>"})
+    assert _client(_Store(tmp_path)).get(f"/artifacts/{art_id}/").status_code == 200
 
 
 # -- cleanup_loop (the scheduled async task) ----------------------------------
@@ -156,20 +217,19 @@ def test_serve_route_is_public(tmp_path) -> None:
 async def test_cleanup_loop_sweeps_then_cancels(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(artifacts_mod, "_CLEANUP_INTERVAL_S", 0.01)
     store = ArtifactStore(tmp_path, ttl_hours=1)
-    art_id = store.write("<p>old</p>")
-    path = store.path_for(art_id)
-    assert path is not None
-    backdated = time.time() - 2 * 3600
-    os.utime(path, (backdated, backdated))
+    art_id = store.create(files={"index.html": "old"}, ttl_hours=1)
+    meta_path = tmp_path / art_id / ".meta.json"
+    meta = json.loads(meta_path.read_text())
+    meta["expires_at"] = time.time() - 10
+    meta_path.write_text(json.dumps(meta))
 
     task = asyncio.create_task(cleanup_loop(_Store(tmp_path, ttl_hours=1)))
-    for _ in range(100):  # let at least one sweep run
+    for _ in range(100):
         await asyncio.sleep(0.01)
-        if not path.exists():
+        if not (tmp_path / art_id).exists():
             break
-    assert not path.exists()
+    assert not (tmp_path / art_id).exists()
 
-    # Cancellation must propagate (graceful shutdown relies on it).
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
@@ -178,28 +238,56 @@ async def test_cleanup_loop_sweeps_then_cancels(tmp_path, monkeypatch) -> None:
 # -- write_artifact tool handler ----------------------------------------------
 
 
-def test_tool_write_artifact(tmp_path) -> None:
-    from core.agent import AgentCore
+def _fake_agent(tmp_path):
     from core.config import ArtifactsConfig
 
-    fake = SimpleNamespace(
+    return SimpleNamespace(
         config=SimpleNamespace(artifacts=ArtifactsConfig(directory=str(tmp_path))),
         _base_url=lambda: "http://host:8000",
     )
 
+
+def test_tool_write_artifact_html_and_files(tmp_path) -> None:
+    from core.agent import AgentCore
+
+    fake = _fake_agent(tmp_path)
     res = AgentCore._tool_write_artifact(fake, {"html": "<h1>hi</h1>", "title": "t"})
     assert res["ok"] is True
     assert res["url"].startswith("http://host:8000/artifacts/")
-    art_id = res["url"].rsplit("/", 1)[1]
-    assert (tmp_path / f"{art_id}.html").read_text(encoding="utf-8") == "<h1>hi</h1>"
+    assert res["url"].endswith("/")  # trailing slash so relative links resolve
 
-    # Empty content is rejected.
-    assert "error" in AgentCore._tool_write_artifact(fake, {"html": "   "})
+    multi = AgentCore._tool_write_artifact(
+        fake, {"files": {"index.html": "<h1>m</h1>", "a.css": "x"}}
+    )
+    assert multi["ok"] is True
 
-    # Oversized content is rejected (ValueError → error result).
-    oversized = AgentCore._tool_write_artifact(fake, {"html": "x" * (MAX_ARTIFACT_BYTES + 1)})
-    assert "error" in oversized and "too large" in oversized["error"]
 
-    # Disabled feature is rejected.
+def test_tool_write_artifact_validation(tmp_path) -> None:
+    from core.agent import AgentCore
+
+    fake = _fake_agent(tmp_path)
+    assert "error" in AgentCore._tool_write_artifact(fake, {})  # nothing
+    assert "error" in AgentCore._tool_write_artifact(fake, {"files": "notadict"})
+    assert "error" in AgentCore._tool_write_artifact(
+        fake, {"html": "<p>x</p>", "source_path": str(tmp_path)}
+    )  # both
+    assert "error" in AgentCore._tool_write_artifact(fake, {"html": "x", "ttl_hours": "soon"})
+
     fake.config.artifacts.enabled = False
     assert "error" in AgentCore._tool_write_artifact(fake, {"html": "<p>x</p>"})
+
+
+# -- permissions: inline ALWAYS, source_path ASK ------------------------------
+
+
+def test_publishing_file_requires_approval(tmp_path) -> None:
+    engine = PermissionEngine(db_path=str(tmp_path / "config.db"))
+
+    inline = {"html": "<h1>x</h1>"}
+    publish = {"source_path": "/tmp/report.pdf"}
+
+    assert engine.check("write_artifact", inline) == PermissionLevel.ALWAYS
+    assert engine.is_write_action("write_artifact", inline) is False
+
+    assert engine.check("write_artifact", publish) == PermissionLevel.ASK
+    assert engine.is_write_action("write_artifact", publish) is True

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -335,3 +335,31 @@ def test_publishing_file_requires_approval(tmp_path) -> None:
 
     assert engine.check("write_artifact", publish) == PermissionLevel.ASK
     assert engine.is_write_action("write_artifact", publish) is True
+
+
+# -- global disable removes the tool everywhere --------------------------------
+
+
+def test_disabled_drops_write_artifact_from_llm_tools() -> None:
+    from core.agent import TOOLS, apply_feature_gates
+
+    def names(ts):
+        return {t["name"] for t in ts}
+
+    assert "write_artifact" in names(
+        apply_feature_gates(TOOLS, secrets_available=True, artifacts_enabled=True)
+    )
+    assert "write_artifact" not in names(
+        apply_feature_gates(TOOLS, secrets_available=True, artifacts_enabled=False)
+    )
+    # The secrets gate still composes independently.
+    no_secrets = names(apply_feature_gates(TOOLS, secrets_available=False, artifacts_enabled=True))
+    assert "list_secrets" not in no_secrets and "request_secret" not in no_secrets
+
+
+def test_disabled_hides_write_artifact_from_persona_scope() -> None:
+    from api.admin import GATEABLE_TOOLS, gateable_tools_for
+
+    assert "write_artifact" in gateable_tools_for(True)
+    assert set(gateable_tools_for(True)) == set(GATEABLE_TOOLS)
+    assert "write_artifact" not in gateable_tools_for(False)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,135 @@
+"""Tests for agent-crafted web artifacts (core/artifacts.py + /artifacts route)."""
+
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+from typing import cast
+
+from fastapi.testclient import TestClient
+
+from api.admin import AgentState, create_admin_app
+from core.artifacts import ArtifactStore
+from core.config_store import ConfigStore
+
+# -- ArtifactStore unit tests -------------------------------------------------
+
+
+def test_write_and_resolve_round_trip(tmp_path) -> None:
+    store = ArtifactStore(tmp_path)
+    art_id = store.write("<p>hello</p>", title="greeting")
+    path = store.path_for(art_id)
+    assert path is not None
+    assert path.read_text(encoding="utf-8") == "<p>hello</p>"
+
+
+def test_path_for_rejects_traversal_and_malformed(tmp_path) -> None:
+    store = ArtifactStore(tmp_path)
+    for bad in ["../etc/passwd", "a/b", "a.b", "", "x" * 65, "foo bar", "..", "a%2fb"]:
+        assert store.path_for(bad) is None, bad
+    # A well-formed id resolves (file need not exist yet).
+    assert store.path_for("AbC-123_xy") is not None
+
+
+def test_cleanup_removes_expired_keeps_fresh(tmp_path) -> None:
+    store = ArtifactStore(tmp_path, ttl_hours=1)
+    old_id = store.write("<p>old</p>")
+    old_path = store.path_for(old_id)
+    assert old_path is not None
+    backdated = time.time() - 2 * 3600  # 2h ago, past the 1h TTL
+    os.utime(old_path, (backdated, backdated))
+    fresh_id = store.write("<p>new</p>")
+
+    assert store.cleanup() == 1
+    assert not old_path.exists()
+    fresh_path = store.path_for(fresh_id)
+    assert fresh_path is not None and fresh_path.exists()
+
+
+def test_cleanup_ttl_zero_is_noop(tmp_path) -> None:
+    store = ArtifactStore(tmp_path, ttl_hours=0)
+    art_id = store.write("<p>x</p>")
+    path = store.path_for(art_id)
+    assert path is not None
+    os.utime(path, (0, 0))  # ancient mtime
+    assert store.cleanup() == 0
+    assert path.exists()
+
+
+# -- /artifacts route tests ---------------------------------------------------
+
+
+class _Store:
+    """Minimal ConfigStore stub exposing only what the artifacts route reads."""
+
+    def __init__(self, directory, *, enabled: bool = True, ttl_hours: int = 168):
+        self._vals = {
+            "artifacts.directory": str(directory),
+            "artifacts.enabled": "true" if enabled else "false",
+            "artifacts.ttl_hours": str(ttl_hours),
+        }
+
+    async def get_many(self, prefix: str = "") -> dict:
+        return {k: v for k, v in self._vals.items() if k.startswith(prefix)}
+
+    async def is_setup_complete(self) -> bool:
+        return True
+
+
+def _client(store: _Store) -> TestClient:
+    app, _auth = create_admin_app(AgentState(agent=None), cast(ConfigStore, store))
+    return TestClient(app)
+
+
+def test_serve_artifact_round_trip(tmp_path) -> None:
+    art_id = ArtifactStore(tmp_path).write("<h1>dashboard</h1>")
+    resp = _client(_Store(tmp_path)).get(f"/artifacts/{art_id}")
+    assert resp.status_code == 200
+    assert "<h1>dashboard</h1>" in resp.text
+    # CSP sandbox keeps artifact JS off the admin origin's localStorage.
+    assert "sandbox" in resp.headers["content-security-policy"]
+
+
+def test_serve_missing_artifact_404(tmp_path) -> None:
+    resp = _client(_Store(tmp_path)).get("/artifacts/doesnotexist123")
+    assert resp.status_code == 404
+
+
+def test_serve_when_disabled_404(tmp_path) -> None:
+    art_id = ArtifactStore(tmp_path).write("<h1>x</h1>")
+    resp = _client(_Store(tmp_path, enabled=False)).get(f"/artifacts/{art_id}")
+    assert resp.status_code == 404
+
+
+def test_serve_route_is_public(tmp_path) -> None:
+    # No Authorization header — artifacts are gated by the unguessable id, not auth.
+    art_id = ArtifactStore(tmp_path).write("<h1>x</h1>")
+    resp = _client(_Store(tmp_path)).get(f"/artifacts/{art_id}")
+    assert resp.status_code == 200
+
+
+# -- write_artifact tool handler ----------------------------------------------
+
+
+def test_tool_write_artifact(tmp_path) -> None:
+    from core.agent import AgentCore
+    from core.config import ArtifactsConfig
+
+    fake = SimpleNamespace(
+        config=SimpleNamespace(artifacts=ArtifactsConfig(directory=str(tmp_path))),
+        _base_url=lambda: "http://host:8000",
+    )
+
+    res = AgentCore._tool_write_artifact(fake, {"html": "<h1>hi</h1>", "title": "t"})
+    assert res["ok"] is True
+    assert res["url"].startswith("http://host:8000/artifacts/")
+    art_id = res["url"].rsplit("/", 1)[1]
+    assert (tmp_path / f"{art_id}.html").read_text(encoding="utf-8") == "<h1>hi</h1>"
+
+    # Empty content is rejected.
+    assert "error" in AgentCore._tool_write_artifact(fake, {"html": "   "})
+
+    # Disabled feature is rejected.
+    fake.config.artifacts.enabled = False
+    assert "error" in AgentCore._tool_write_artifact(fake, {"html": "<p>x</p>"})

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -190,6 +190,8 @@ def test_no_slash_redirects_to_slash(tmp_path) -> None:
     assert r.status_code == 307
     assert r.headers["location"] == f"/artifacts/{art_id}/"
     assert client.get(f"/artifacts/{art_id}", follow_redirects=True).status_code == 200
+    # A malformed id is 404'd, not echoed into the Location header.
+    assert client.get("/artifacts/bad!id", follow_redirects=False).status_code == 404
 
 
 def test_meta_and_traversal_not_served(tmp_path) -> None:

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -108,6 +108,48 @@ def test_resolve_rejects_hardlink_escape(tmp_path) -> None:
     assert store.resolve(art_id, "leak.html") is None
 
 
+def test_resolve_rejects_null_byte(tmp_path) -> None:
+    # A null byte makes Path.resolve raise ValueError; must degrade to None, not 500.
+    store = ArtifactStore(tmp_path)
+    art_id = store.create(files={"index.html": "<h1>x</h1>"})
+    assert store.resolve(art_id, "foo\x00.png") is None
+
+
+def test_route_null_byte_is_404_not_500(tmp_path) -> None:
+    art_id = ArtifactStore(tmp_path).create(files={"index.html": "<h1>x</h1>"})
+    r = _client(_Store(tmp_path)).get(f"/artifacts/{art_id}/foo%00.png")
+    assert r.status_code == 404
+
+
+# -- entrypoint resolution for source_path ------------------------------------
+
+
+def test_source_dir_autopicks_single_file_entrypoint(tmp_path) -> None:
+    site = tmp_path / "site"
+    site.mkdir()
+    (site / "report.pdf").write_bytes(b"%PDF fake")  # no index.html, one file
+    art_id = ArtifactStore(tmp_path / "store").create(source_path=str(site))
+    served = ArtifactStore(tmp_path / "store").resolve(art_id)
+    assert served is not None and served.name == "report.pdf"
+
+
+def test_source_dir_without_index_and_multiple_files_errors(tmp_path) -> None:
+    site = tmp_path / "site"
+    site.mkdir()
+    (site / "a.html").write_text("a")
+    (site / "b.html").write_text("b")
+    with pytest.raises(ValueError, match="entrypoint"):
+        ArtifactStore(tmp_path / "store").create(source_path=str(site))
+
+
+def test_single_file_source_ignores_explicit_entrypoint(tmp_path) -> None:
+    src = tmp_path / "r.pdf"
+    src.write_bytes(b"%PDF fake")
+    store = ArtifactStore(tmp_path / "store")
+    art_id = store.create(source_path=str(src), entrypoint="index.html")
+    assert store.resolve(art_id).name == "r.pdf"
+
+
 # -- cleanup: per-artifact TTL ------------------------------------------------
 
 


### PR DESCRIPTION
Closes #34.

## What

Adds **agent-crafted web artifacts**: the agent publishes a self-contained HTML page and gets back a shareable link, served read-only at `/artifacts/<id>` on the existing admin app. For anything richer than a chat bubble — reports, dashboards, charts, comparison tables, interactive checklists, "give me a mini-site for X".

## How it works

- New **`write_artifact`** tool: takes a complete HTML document, writes it under a random unguessable id, returns the URL for the agent to hand to the user.
- New **`/artifacts/{id}`** route on the admin FastAPI app — public (the id is the secret), single path segment, id-validated.
- One artifact = **one standalone HTML file**: CSS inline in `<style>`, JS inline in `<script>`, Tailwind v4 / Alpine via CDN — so a single file covers the whole complexity ladder with no build step.
- Background **TTL sweep** deletes artifacts older than `ttl_hours` (default 7 days; `0` = keep forever), started/stopped in the app lifespan.

## Config

```yaml
artifacts:
  enabled: true
  directory: "data/artifacts"
  ttl_hours: 168   # 0 = keep forever
```

Set `MPA_BASE_URL` so the links are reachable off-device. `write_artifact` is a gateable per-persona tool; permission is `ALWAYS` (a local, reversible write).

## Security / hygiene (per the issue + two adversarial review rounds)

- **Unguessable ids** (`secrets.token_urlsafe`, 96 bits) — route can't be listed or walked; unknown id → custom 404 page.
- **No path traversal** — ids validated against `[A-Za-z0-9_-]`; FastAPI matches a single segment.
- **No symlink / hardlink escape** — `path_for` refuses a symlink, a hardlink (`st_nlink > 1`), or anything resolving outside the artifacts dir, so the public route can't be tricked into serving e.g. `data/master.key`.
- **Sandboxed pages** — every artifact is served with `Content-Security-Policy: sandbox` (no `allow-same-origin`), so artifact JS runs in an opaque origin and can't read the admin origin's `localStorage` (where the admin key lives). CDN scripts, inline scripts, forms and popups still work.
- **Size cap** — 5 MiB per artifact at the write chokepoint (backstop against a runaway loop given the no-prompt permission).
- **Automatic expiry** via the TTL sweep.

Out of scope per the issue (no nginx, no custom domains, no per-artifact auth) respected.

## Docs

New `docs/content/docs/artifacts.mdx` (+ nav), `configuration.mdx` section, README feature bullet, `config.yml.example` + `.env` notes.

## Tests

`tests/test_artifacts.py` — store round-trip, traversal + symlink + hardlink rejection, TTL boundary + `ttl=0` no-op, size cap, the `/artifacts` route (serve / 404 / disabled / public / encoded-traversal / CSP omits `allow-same-origin`), the `cleanup_loop` sweep+cancel, and the `write_artifact` tool handler. Full suite green (409 passed), `ruff check` + `ruff format` clean.
