### PR TITLE
Show CoT thinking trace in admin UI log tab (#33)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -404,6 +404,10 @@ _LOG_BUFFER: collections.deque[str] = collections.deque(maxlen=500)
 _LOG_INCLUDE_PREFIXES = ("core.", "channels.", "voice.", "tools.")
 _LOG_INCLUDE_NAMES = {"core", "channels", "voice", "tools"}
 
+# Model chain-of-thought logger (see core/llm.py). The admin log viewer styles
+# lines from this logger distinctly; the template detects them by this name.
+_REASONING_LOGGER = "core.llm.reasoning"
+
 
 def _should_capture_log_record(record: logging.LogRecord) -> bool:
     """Return True when a record should be visible in the admin log viewer."""
@@ -426,10 +430,25 @@ class _BufferHandler(logging.Handler):
 
 
 def install_log_buffer() -> None:
-    """Attach the ring-buffer handler to the root logger."""
-    handler = _BufferHandler()
+    """Attach the ring-buffer handler to the root logger.
+
+    Also surface model chain-of-thought in the viewer: the reasoning logger is
+    silent (WARNING) by default so it never spams server stdout, but the admin
+    UI wants it. Bump it to INFO so its records reach the buffer, and filter it
+    off the pre-existing console handlers so server logs stay clean.
+    """
+    root = logging.getLogger()
+    logging.getLogger(_REASONING_LOGGER).setLevel(logging.INFO)
+
+    def _drop_reasoning(record: logging.LogRecord) -> bool:
+        return record.name != _REASONING_LOGGER
+
+    for existing in root.handlers:  # console handler(s) from basicConfig
+        existing.addFilter(_drop_reasoning)
+
+    handler = _BufferHandler()  # added after, so it keeps the reasoning records
     handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(name)s — %(message)s"))
-    logging.getLogger().addHandler(handler)
+    root.addHandler(handler)
 
 
 # ---------------------------------------------------------------------------

--- a/api/static/input.css
+++ b/api/static/input.css
@@ -178,6 +178,11 @@
     font-family: var(--font-mono);
   }
 
+  /* Model chain-of-thought lines, set apart from regular log output */
+  .log-thinking {
+    @apply block border-l-2 border-accent pl-2 my-0.5 text-muted italic;
+  }
+
   /* Hint text */
   .hint {
     @apply text-xs text-muted mt-0.5;

--- a/api/templates/partials/logs_content.html
+++ b/api/templates/partials/logs_content.html
@@ -1,3 +1,6 @@
-{# Log content — swapped into #log-content by HTMX #}
-{% for line in lines %}{{ line }}
-{% endfor %}
+{# Log content — swapped into #log-content by HTMX.
+   Reasoning/CoT lines (logger core.llm.reasoning) render in a distinct style
+   so the model's thinking trace stands apart from regular log lines. #}
+{% for line in lines %}{% if 'core.llm.reasoning' in line %}<span class="log-thinking">💭 {{ line }}</span>
+{% else %}{{ line }}
+{% endif %}{% endfor %}

--- a/api/templates/partials/logs_content.html
+++ b/api/templates/partials/logs_content.html
@@ -1,6 +1,6 @@
 {# Log content — swapped into #log-content by HTMX.
    Reasoning/CoT lines (logger core.llm.reasoning) render in a distinct style
    so the model's thinking trace stands apart from regular log lines. #}
-{% for line in lines %}{% if 'core.llm.reasoning' in line %}<span class="log-thinking">💭 {{ line }}</span>
+{% for line in lines %}{% if 'core.llm.reasoning — ' in line %}<span class="log-thinking">💭 {{ line }}</span>
 {% else %}{{ line }}
 {% endif %}{% endfor %}

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -116,3 +116,41 @@ def test_agent_status_reports_channels_and_jobs() -> None:
         "channels": ["telegram"],
         "scheduler_jobs": 2,
     }
+
+
+def test_install_log_buffer_routes_reasoning_to_buffer_not_console() -> None:
+    """Model CoT reaches the admin viewer buffer but stays off the console."""
+    import logging
+
+    from api.admin import _LOG_BUFFER, _REASONING_LOGGER, install_log_buffer
+
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    reasoning_logger = logging.getLogger(_REASONING_LOGGER)
+    agent_logger = logging.getLogger("core.agent")
+    saved_reasoning_level = reasoning_logger.level
+
+    console_seen: list[str] = []
+    console = logging.Handler()
+    console.emit = lambda record: console_seen.append(record.name)  # type: ignore[method-assign]
+
+    try:
+        root.handlers = [console]
+        root.setLevel(logging.INFO)
+        agent_logger.setLevel(logging.INFO)
+        _LOG_BUFFER.clear()
+
+        install_log_buffer()
+        reasoning_logger.info("secret chain of thought")
+        agent_logger.info("ordinary log line")
+
+        buffered = "\n".join(_LOG_BUFFER)
+        assert "secret chain of thought" in buffered  # CoT surfaced in admin UI
+        assert "ordinary log line" in buffered
+        assert _REASONING_LOGGER not in console_seen  # but kept off the console
+        assert "core.agent" in console_seen
+    finally:
+        root.handlers = saved_handlers
+        root.setLevel(saved_level)
+        reasoning_logger.setLevel(saved_reasoning_level)
+        _LOG_BUFFER.clear()


### PR DESCRIPTION
Closes #33.

## Problem

The model's chain-of-thought (CoT) reasoning was extracted into `LLMResponse.reasoning` and logged via the `core.llm.reasoning` logger, but that logger sits at `WARNING` by default (silent on the server, REPL bumps it to INFO for live streaming). So its INFO records never reached the admin log ring buffer — the admin UI log tab never showed any thinking trace.

## Fix

- **Surface it**: `install_log_buffer()` (server bootstrap) bumps `core.llm.reasoning` to INFO so its records reach the in-memory buffer the log tab reads from. To honor the original "don't spam server stdout" intent, a filter drops reasoning records from the pre-existing console handlers — the buffer handler is added *after* the filter loop, so it keeps them.
- **Distinguish it**: CoT lines render in a distinct style in the log tab (left accent border, dim italic, 💭 marker) via a new `.log-thinking` class. The template detects them by the formatted logger prefix `core.llm.reasoning — `.

No change to `core/llm.py` or `core/agent.py` — reasoning already flowed through `reasoning_log.info()`; this only routes and styles it. REPL is unaffected (it replaces root handlers and manages the logger level itself).

## Notes
- `core.llm.reasoning` is captured by the buffer's existing `core.` prefix filter.
- Multi-line reasoning is a single log record → single buffer entry → one styled block (HTML-escaped, `white-space: pre-wrap`).
- Import order verified empirically: `api/admin.py` imports `core.llm` at module top, so its `setLevel(WARNING)` runs before `install_log_buffer()`; the level stays INFO.

## Tests
- New `test_install_log_buffer_routes_reasoning_to_buffer_not_console` asserts reasoning reaches the buffer but not the console, and normal lines reach both.
- Existing admin + llm suites pass.

## Review
Ran an adversarial review pass: one flagged "multiline breaks HTML" was a false alarm (deque entries, not physical lines — verified by rendering), and the import-order concern was verified a non-issue. The one real finding (substring false positives) is fixed in the second commit by matching the formatted logger prefix.