### PR TITLE
feat: bot-per-persona — each persona as its own Telegram bot (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Email** — Read, compose, and manage emails via [Himalaya](https://github.com/pimalaya/himalaya) CLI
 - **Calendar** — CalDAV integration (Google Calendar, iCloud, etc.)
 - **Contacts** — CardDAV providers via the built-in contacts CLI
-- **Personae** — Swappable agent identities (own character, skill/tool scope, voice). Bind one per chat — and, on Telegram, per forum topic — so several run concurrently, each with its own isolated context
+- **Personae** — Swappable agent identities (own character, skill/tool scope, voice). Bind one per chat — and, on Telegram, per forum topic — so several run concurrently, each with its own isolated context. Give a persona its own bot token and it becomes a separate Telegram contact (bot-per-persona)
 - **Memory** — Two-tier system: permanent long-term facts and expiring short-term context, both extracted automatically from conversations
 - **Scheduled tasks** — Cron-based jobs for morning briefings, email checks, contact sync, and custom tasks
 - **Voice** — Speech-to-text (faster-whisper) and text-to-speech (edge-tts)

--- a/api/admin.py
+++ b/api/admin.py
@@ -482,6 +482,21 @@ class SkillUpsertIn(BaseModel):
     content: str
 
 
+def _persona_public(persona) -> dict:
+    """Persona as JSON for read-only APIs, with the bot token redacted (#29).
+
+    Mirrors how the global Telegram token is redacted in config reads — the token
+    is a secret and must not leave the server in cleartext (exports, list views).
+    """
+    from dataclasses import asdict, replace
+
+    from core.config_store import _redact
+    from core.personae import to_markdown
+
+    safe = replace(persona, bot_token=_redact(persona.bot_token))
+    return {**asdict(safe), "markdown": to_markdown(safe)}
+
+
 class PersonaUpsertIn(BaseModel):
     name: str
     agent_name: str = ""
@@ -2312,30 +2327,22 @@ def create_admin_app(
 
     @app.get("/personae", dependencies=[Depends(auth)])
     async def list_personae() -> dict:
-        from dataclasses import asdict
-
-        from core.personae import to_markdown
-
         store = await _persona_store_from_config(config_store)
         personae = await store.list_personae()
         active = (await config_store.get("agent.active_persona") or "").strip()
         return {
             "count": len(personae),
             "active": active,
-            "personae": [{**asdict(p), "markdown": to_markdown(p)} for p in personae],
+            "personae": [_persona_public(p) for p in personae],
         }
 
     @app.get("/personae/{name}", dependencies=[Depends(auth)])
     async def get_persona(name: str) -> dict:
-        from dataclasses import asdict
-
-        from core.personae import to_markdown
-
         store = await _persona_store_from_config(config_store)
         persona = await store.get(name)
         if not persona:
             raise HTTPException(404, f"Persona not found: {name}")
-        return {**asdict(persona), "markdown": to_markdown(persona)}
+        return _persona_public(persona)
 
     @app.post("/personae", dependencies=[Depends(auth)])
     async def upsert_persona(body: PersonaUpsertIn) -> HTMLResponse:

--- a/api/admin.py
+++ b/api/admin.py
@@ -493,6 +493,8 @@ class PersonaUpsertIn(BaseModel):
     skills: list[str] = []
     tools: list[str] = []
     secrets: list[str] = []
+    bot_token: str = ""  # per-persona Telegram bot (#29); empty = no own bot
+    allowed_user_ids: str = ""  # comma/newline-separated; empty = inherit global
     raw: str = ""  # when set, the markdown doc is parsed instead of the fields above
 
 
@@ -2337,7 +2339,7 @@ def create_admin_app(
 
     @app.post("/personae", dependencies=[Depends(auth)])
     async def upsert_persona(body: PersonaUpsertIn) -> HTMLResponse:
-        from core.personae import Persona, parse_markdown
+        from core.personae import Persona, _as_int_list, parse_markdown
 
         name = body.name.strip()
         if not name:
@@ -2357,6 +2359,8 @@ def create_admin_app(
                 skills=[s.strip() for s in body.skills if s.strip()],
                 tools=[t.strip() for t in body.tools if t.strip()],
                 secrets=[s.strip() for s in body.secrets if s.strip()],
+                bot_token=body.bot_token.strip(),
+                allowed_user_ids=_as_int_list(body.allowed_user_ids),
             )
         store = await _persona_store_from_config(config_store)
         await store.upsert(persona)

--- a/api/templates/persona_editor.html
+++ b/api/templates/persona_editor.html
@@ -55,6 +55,19 @@
         </div>
       </div>
 
+      <div class="card space-y-3">
+        <h3 class="text-xs text-muted uppercase tracking-wider">Own Telegram bot <span class="text-muted normal-case tracking-normal">— optional</span></h3>
+        <p class="text-xs text-muted">Give this persona its own bot token and it becomes a separate Telegram contact. Leave blank to keep it reachable only via the default bot. Restart the agent after changing.</p>
+        <div>
+          <label class="label">Bot token <span class="text-muted">(from @BotFather)</span></label>
+          <input class="input-sm" type="password" x-model="bot_token" autocomplete="off" placeholder="123456:ABC-DEF…">
+        </div>
+        <div>
+          <label class="label">Allowed user IDs <span class="text-muted">(comma-separated; blank = inherit global)</span></label>
+          <input class="input-sm" x-model="allowedUserIds" placeholder="111111111, 222222222">
+        </div>
+      </div>
+
       <div class="card">
         <label class="label">Personalia <span class="text-muted">— who the agent is in this persona</span></label>
         <textarea class="textarea" x-model="personalia" style="min-height:160px; font-size:0.8rem; line-height:1.5"
@@ -109,7 +122,7 @@
   <div x-show="mode === 'raw'" class="card">
     <label class="label">Markdown (YAML frontmatter)</label>
     <textarea class="textarea" x-model="raw" style="min-height:460px; font-size:0.8rem; line-height:1.5; tab-size:2"></textarea>
-    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, emoji, voice, skills, tools, secrets, personalia, character).</p>
+    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, emoji, voice, bot_token, allowed_user_ids, skills, tools, secrets, personalia, character).</p>
   </div>
 
   <div class="flex items-center gap-2 mt-3">
@@ -127,6 +140,8 @@
       role: {{ persona.role|tojson }},
       emoji: {{ persona.emoji|tojson }},
       voice: {{ persona.voice|tojson }},
+      bot_token: {{ persona.bot_token|tojson }},
+      allowedUserIds: {{ (persona.allowed_user_ids|join(', '))|tojson }},
       personalia: {{ persona.personalia|tojson }},
       character: {{ persona.character|tojson }},
       skills: {{ persona.skills|tojson }},
@@ -141,12 +156,15 @@
         const esc = (s) => (s || '').replace(/\n/g, '\n  ');
         const list = (a) => a && a.length ? '[' + a.join(', ') + ']' : '[]';
         const secrets = this.secretsText.split('\n').map(s => s.trim()).filter(Boolean);
+        const userIds = this.allowedUserIds.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
         this.raw =
           '---\n' +
           'agent_name: ' + (this.agent_name || '') + '\n' +
           'role: ' + (this.role || '') + '\n' +
           'emoji: ' + (this.emoji || '') + '\n' +
           'voice: ' + (this.voice || '') + '\n' +
+          'bot_token: ' + JSON.stringify(this.bot_token || '') + '\n' +
+          'allowed_user_ids: ' + list(userIds) + '\n' +
           'skills: ' + list(this.skills) + '\n' +
           'tools: ' + list(this.tools) + '\n' +
           'secrets: ' + list(secrets) + '\n' +
@@ -166,6 +184,7 @@
               personalia: this.personalia, character: this.character,
               skills: this.skills, tools: this.tools,
               secrets: this.secretsText.split('\n').map(s => s.trim()).filter(Boolean),
+              bot_token: this.bot_token, allowed_user_ids: this.allowedUserIds,
             };
         fetch('/personae', {
           method: 'POST',

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -37,11 +37,19 @@ _HTML_TAG_RE = re.compile(
 
 class TelegramChannel:
     def __init__(
-        self, config: TelegramConfig, agent: AgentCore, voice: VoicePipeline | None = None
+        self,
+        config: TelegramConfig,
+        agent: AgentCore,
+        voice: VoicePipeline | None = None,
+        channel_name: str = "telegram",
     ):
         self.config = config
         self.agent = agent
         self.voice = voice
+        # The channel string this bot reports to the agent. The default bot is
+        # bare "telegram"; a per-persona bot is "telegram:<persona>" (#29), which
+        # silos history and resolves straight to that persona.
+        self.channel_name = channel_name
         # Last chat a user wrote from, used to route approval prompts. Holds a
         # folded "<chat>:<thread>" string when the message came from a topic.
         self._last_chat_for_user: dict[int, int | str] = {}
@@ -273,7 +281,9 @@ class TelegramChannel:
         if user_id is None or not self._is_allowed(user_id):
             return
         chat_id = f"{chat.id}:{thread}"
-        bound = await self.agent.bind_chat_persona_by_label("telegram", str(user_id), chat_id, name)
+        bound = await self.agent.bind_chat_persona_by_label(
+            self.channel_name, str(user_id), chat_id, name
+        )
         if bound:
             await self.send(chat_id, f"Bound this topic to {bound}.")
 
@@ -423,7 +433,7 @@ class TelegramChannel:
         async with self._typing(chat_id), self._progress(chat_id):
             response = await self.agent.process(
                 message=text,
-                channel="telegram",
+                channel=self.channel_name,
                 user_id=str(user_id),
                 chat_id=str(chat_id),
             )
@@ -459,7 +469,7 @@ class TelegramChannel:
                 content = f"{reply_context}{content}"
             response = await self.agent.process(
                 message=content,
-                channel="telegram",
+                channel=self.channel_name,
                 user_id=str(user_id),
                 chat_id=str(chat_id),
             )
@@ -504,7 +514,7 @@ class TelegramChannel:
                 content = f"{reply_context}{content}" if content else reply_context
             response = await self.agent.process(
                 message=content,
-                channel="telegram",
+                channel=self.channel_name,
                 user_id=str(user_id),
                 attachments=attachments,
                 chat_id=str(chat_id),

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -57,7 +57,10 @@ class TelegramChannel:
         self.app.add_handler(MessageHandler(filters.TEXT, self._on_text))
         self.app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, self._on_voice))
         self.app.add_handler(MessageHandler(filters.PHOTO | filters.Document.IMAGE, self._on_photo))
-        if config.topics_enabled:
+        # Topic→persona auto-bind only makes sense on the default bot: a persona
+        # bot resolves straight to its own persona (rung 0), so a per-topic binding
+        # would be ignored. Topic *folding* (history isolation) still applies below.
+        if config.topics_enabled and channel_name == "telegram":
             self.app.add_handler(
                 MessageHandler(
                     filters.StatusUpdate.FORUM_TOPIC_CREATED
@@ -378,6 +381,13 @@ class TelegramChannel:
         poll it and edit a single Telegram message in place (the chat equivalent
         of the REPL's self-updating spinner line). No-op when nothing is running.
         """
+        # ponytail: the explore status file is a single global singleton, so only
+        # the default bot mirrors it — otherwise a run triggered via one persona-bot
+        # would bubble into every other bot's chat (#29). Per-run scoping (a status
+        # path keyed by channel/profile) belongs in the browser tool — follow-up.
+        if self.channel_name != "telegram":
+            yield
+            return
         status = Path("/app/data" if Path("/app/data").exists() else "data")
         status = status / "browser" / "last" / "explore.status"
         cid, kw = self._route(chat_id)  # split a folded "<chat>:<thread>" topic id

--- a/core/agent.py
+++ b/core/agent.py
@@ -520,14 +520,20 @@ class AgentCore:
     async def _resolve_persona(self, channel: str, user_id: str, chat_id: str) -> Persona | None:
         """Resolve the active persona for this request, in precedence order:
 
+        0. a per-persona bot — a ``"telegram:<name>"`` channel binds straight to
+           persona ``<name>``: the bot that received the message *is* the persona (#29),
         1. the per-chat binding for ``(channel, user_id, chat_id)`` (#14),
         2. the globally-selected persona (``config.agent.active_persona``, #13),
         3. the default identity (``None``).
-
-        A future per-persona bot (#29) will add a rung above (1): a
-        ``"telegram:<name>"`` channel would resolve straight to that persona.
-        Not wired here — no such channel exists yet.
         """
+        # 0. Bot-per-persona: the channel name carries the persona (e.g. "telegram:coach").
+        _, sep, persona_name = channel.partition(":")
+        if sep and persona_name:
+            persona = await self._load_persona(persona_name)
+            if persona:
+                return persona
+            # Unknown/deleted persona — fall through to the ordinary ladder.
+
         # 1. Per-chat binding.
         bound = await self.history.get_chat_persona(channel, user_id, chat_id)
         if bound:

--- a/core/agent.py
+++ b/core/agent.py
@@ -448,6 +448,7 @@ class AgentCore:
         user_id: str,
         attachments: list[Attachment] | None = None,
         chat_id: str = "",
+        persona_name: str | None = None,
     ) -> AgentResponse:
         """Process an incoming message through the LLM with tool-use loop.
 
@@ -455,6 +456,11 @@ class AgentCore:
         a private Telegram chat vs. a group chat).  Each unique
         (channel, user_id, chat_id) triple gets its own conversation history,
         preventing context leakage across chats.
+
+        ``persona_name`` forces the identity instead of resolving it from the
+        channel/binding ladder — used by the scheduler so a ``telegram:<persona>``
+        job is generated *as* that persona while keeping the ``system`` execution
+        mode (auto-approved writes, no memory/reflection) (#29).
         """
 
         # Handle /new (alias /clear) command — clear conversational context.
@@ -482,8 +488,12 @@ class AgentCore:
         preamble = self._turn_preamble(decomposed_goal)
 
         # Resolve the active persona (its identity, skills + tool scope) — a
-        # per-chat binding wins over the globally selected persona (#14).
-        persona = await self._resolve_persona(channel, user_id, chat_id)
+        # per-chat binding wins over the globally selected persona (#14). An
+        # explicit override (scheduler) skips the ladder (#29).
+        if persona_name:
+            persona = await self._load_persona(persona_name)
+        else:
+            persona = await self._resolve_persona(channel, user_id, chat_id)
         tools = apply_feature_gates(
             scoped_tools(persona),
             secrets_available=self.secret_store is not None,

--- a/core/main.py
+++ b/core/main.py
@@ -85,52 +85,87 @@ async def _start_agent(config_store: ConfigStore):
         )
         agent.voice = voice
 
-    # -- Telegram --
-    async def _start_tg(tg: TelegramChannel, name: str) -> None:
-        agent.channels[name] = tg
-        log.info("Starting Telegram bot (%s)…", name)
-        await tg.app.initialize()
-        await tg.app.start()
-        if tg.app.updater is not None:
-            await tg.app.updater.start_polling()
+    # -- Telegram: the default bot plus one bot per persona that carries a token (#29).
+    # A single bad/revoked token must never abort the others, WhatsApp, or the
+    # scheduler — each bot is brought up independently and failures are isolated.
+    async def _start_tg(conf, name: str, channel_name: str = "telegram") -> None:
+        try:
+            tg = TelegramChannel(conf, agent, voice=voice, channel_name=channel_name)
+            await tg.app.initialize()
+            await tg.app.start()
+            if tg.app.updater is not None:
+                await tg.app.updater.start_polling()
+            agent.channels[name] = tg  # registered only once it is actually polling
+            log.info("Telegram bot started (%s)", name)
+        except Exception:
+            log.exception("Failed to start Telegram bot %s — skipping", name)
 
-    tg_global = config.channels.telegram
-    if tg_global.enabled and tg_global.bot_token:
-        await _start_tg(TelegramChannel(tg_global, agent, voice=voice), "telegram")
+    try:
+        tg_global = config.channels.telegram
+        seen_tokens: set[str] = set()
+        if tg_global.enabled and tg_global.bot_token:
+            seen_tokens.add(tg_global.bot_token)
+            await _start_tg(tg_global, "telegram")
 
-    # -- Per-persona Telegram bots (#29): each persona with its own token is its
-    # own contact. Channel name "telegram:<persona>" silos history and resolves
-    # straight to that persona. ACL inherits the global allowlist when unset.
-    for persona in await agent.personae.list_personae():
-        token = (persona.bot_token or "").strip()
-        if not token or token == tg_global.bot_token:
-            continue  # no token, or shares the default bot's token — skip
-        pconf = TelegramConfig(
-            enabled=True,
-            bot_token=token,
-            allowed_user_ids=persona.allowed_user_ids or tg_global.allowed_user_ids,
-            topics_enabled=tg_global.topics_enabled,
-        )
-        await _start_tg(
-            TelegramChannel(pconf, agent, voice=voice, channel_name=f"telegram:{persona.name}"),
-            f"telegram:{persona.name}",
-        )
+        for persona in await agent.personae.list_personae():
+            token = (persona.bot_token or "").strip()
+            if not token:
+                continue  # no own bot — reachable only via the default bot
+            if token in seen_tokens:
+                log.warning(
+                    "Persona %s shares a bot token with another bot — skipping its bot "
+                    "(one token can only be polled once)",
+                    persona.name,
+                )
+                continue
+            seen_tokens.add(token)
+            pconf = TelegramConfig(
+                enabled=True,
+                bot_token=token,
+                allowed_user_ids=persona.allowed_user_ids or tg_global.allowed_user_ids,
+                topics_enabled=tg_global.topics_enabled,
+            )
+            await _start_tg(pconf, f"telegram:{persona.name}", f"telegram:{persona.name}")
 
-    # -- WhatsApp --
-    if config.channels.whatsapp.enabled:
-        from core.wacli import WacliManager
+        # -- WhatsApp --
+        if config.channels.whatsapp.enabled:
+            from core.wacli import WacliManager
 
-        wacli = WacliManager()
-        wa = WhatsAppChannel(config.channels.whatsapp, agent, wacli=wacli)
-        agent.channels["whatsapp"] = wa
-        log.info("WhatsApp channel enabled (wacli)")
+            wacli = WacliManager()
+            wa = WhatsAppChannel(config.channels.whatsapp, agent, wacli=wacli)
+            agent.channels["whatsapp"] = wa
+            log.info("WhatsApp channel enabled (wacli)")
 
-    # -- Scheduler --
-    await agent.scheduler.load_jobs()
-    agent.scheduler.start()
-    log.info("Scheduler started with %d jobs", len(agent.scheduler.scheduler.get_jobs()))
+        # -- Scheduler --
+        await agent.scheduler.load_jobs()
+        agent.scheduler.start()
+        log.info("Scheduler started with %d jobs", len(agent.scheduler.scheduler.get_jobs()))
+    except Exception:
+        # Bring-up failed after some bots were already polling — stop them so we
+        # don't leak orphaned pollers (which would 409 on the next start).
+        await _stop_telegram_bots(agent)
+        raise
 
     return agent
+
+
+async def _stop_telegram_bots(agent) -> None:
+    """Stop and deregister the default bot and every per-persona bot (#29).
+
+    Each bot is torn down independently: one that fails to stop must not strand
+    the rest still polling (which would 409 on the next start).
+    """
+    for name, ch in list(agent.channels.items()):
+        if name != "telegram" and not name.startswith("telegram:"):
+            continue
+        try:
+            if ch.app.updater is not None:
+                await ch.app.updater.stop()
+            await ch.app.stop()
+            await ch.app.shutdown()
+        except Exception:
+            log.exception("Error stopping Telegram bot %s", name)
+        agent.channels.pop(name, None)
 
 
 async def _stop_agent(agent) -> None:
@@ -141,12 +176,7 @@ async def _stop_agent(agent) -> None:
 
     set_agent_context(None)
 
-    # Stop the default bot and every per-persona bot ("telegram:<persona>", #29).
-    for name, ch in list(agent.channels.items()):
-        if name == "telegram" or name.startswith("telegram:"):
-            await ch.app.updater.stop()
-            await ch.app.stop()
-            await ch.app.shutdown()
+    await _stop_telegram_bots(agent)
 
 
 # ---------------------------------------------------------------------------

--- a/core/main.py
+++ b/core/main.py
@@ -46,6 +46,7 @@ async def _start_agent(config_store: ConfigStore):
     from channels.telegram import TelegramChannel
     from channels.whatsapp import WhatsAppChannel
     from core.agent import AgentCore
+    from core.config import TelegramConfig
     from voice.pipeline import VoicePipeline
 
     # Decrypt infra secrets into memory so ${vault:NAME} resolves at config load
@@ -85,16 +86,35 @@ async def _start_agent(config_store: ConfigStore):
         agent.voice = voice
 
     # -- Telegram --
-    if config.channels.telegram.enabled and config.channels.telegram.bot_token:
-        tg = TelegramChannel(config.channels.telegram, agent, voice=voice)
-        agent.channels["telegram"] = tg
-        log.info("Starting Telegram bot…")
-
+    async def _start_tg(tg: TelegramChannel, name: str) -> None:
+        agent.channels[name] = tg
+        log.info("Starting Telegram bot (%s)…", name)
         await tg.app.initialize()
         await tg.app.start()
-        updater = tg.app.updater
-        if updater is not None:
-            await updater.start_polling()
+        if tg.app.updater is not None:
+            await tg.app.updater.start_polling()
+
+    tg_global = config.channels.telegram
+    if tg_global.enabled and tg_global.bot_token:
+        await _start_tg(TelegramChannel(tg_global, agent, voice=voice), "telegram")
+
+    # -- Per-persona Telegram bots (#29): each persona with its own token is its
+    # own contact. Channel name "telegram:<persona>" silos history and resolves
+    # straight to that persona. ACL inherits the global allowlist when unset.
+    for persona in await agent.personae.list_personae():
+        token = (persona.bot_token or "").strip()
+        if not token or token == tg_global.bot_token:
+            continue  # no token, or shares the default bot's token — skip
+        pconf = TelegramConfig(
+            enabled=True,
+            bot_token=token,
+            allowed_user_ids=persona.allowed_user_ids or tg_global.allowed_user_ids,
+            topics_enabled=tg_global.topics_enabled,
+        )
+        await _start_tg(
+            TelegramChannel(pconf, agent, voice=voice, channel_name=f"telegram:{persona.name}"),
+            f"telegram:{persona.name}",
+        )
 
     # -- WhatsApp --
     if config.channels.whatsapp.enabled:
@@ -121,11 +141,12 @@ async def _stop_agent(agent) -> None:
 
     set_agent_context(None)
 
-    if "telegram" in agent.channels:
-        tg = agent.channels["telegram"]
-        await tg.app.updater.stop()
-        await tg.app.stop()
-        await tg.app.shutdown()
+    # Stop the default bot and every per-persona bot ("telegram:<persona>", #29).
+    for name, ch in list(agent.channels.items()):
+        if name == "telegram" or name.startswith("telegram:"):
+            await ch.app.updater.stop()
+            await ch.app.stop()
+            await ch.app.shutdown()
 
 
 # ---------------------------------------------------------------------------

--- a/core/personae.py
+++ b/core/personae.py
@@ -34,10 +34,18 @@ CREATE TABLE IF NOT EXISTS personae (
     skills TEXT DEFAULT '',
     tools TEXT DEFAULT '',
     secrets TEXT DEFAULT '',
+    bot_token TEXT DEFAULT '',
+    allowed_user_ids TEXT DEFAULT '',
     created_at DATETIME DEFAULT (datetime('now')),
     updated_at DATETIME DEFAULT (datetime('now'))
 );
 """
+
+# Columns added after the table first shipped — applied to existing DBs on open.
+_MIGRATIONS = (
+    "ALTER TABLE personae ADD COLUMN bot_token TEXT DEFAULT ''",  # #29
+    "ALTER TABLE personae ADD COLUMN allowed_user_ids TEXT DEFAULT ''",  # #29
+)
 
 
 @dataclass(slots=True)
@@ -54,6 +62,8 @@ class Persona:
     skills: list[str] = field(default_factory=list)  # allowlist; [] = all
     tools: list[str] = field(default_factory=list)  # allowlist; [] = all
     secrets: list[str] = field(default_factory=list)  # vault scope; stored only (#19)
+    bot_token: str = ""  # own Telegram bot; empty = reachable only via the default bot (#29)
+    allowed_user_ids: list[int] = field(default_factory=list)  # bot ACL; [] = inherit global
 
     def allows_skill(self, name: str) -> bool:
         return not self.skills or name in self.skills
@@ -72,6 +82,17 @@ def _as_list(value: object) -> list[str]:
     if isinstance(value, (list, tuple)):
         return [str(p).strip() for p in value if str(p).strip()]
     return []
+
+
+def _as_int_list(value: object) -> list[int]:
+    """Coerce a frontmatter / form value into a clean list of ints (drops non-numeric)."""
+    out: list[int] = []
+    for item in _as_list(value):
+        try:
+            out.append(int(item))
+        except ValueError:
+            continue
+    return out
 
 
 def parse_markdown(text: str, *, name: str) -> Persona:
@@ -117,6 +138,8 @@ def parse_markdown(text: str, *, name: str) -> Persona:
         skills=_as_list(fm.get("skills")),
         tools=_as_list(fm.get("tools")),
         secrets=_as_list(fm.get("secrets")),
+        bot_token=str(fm.get("bot_token", "") or ""),
+        allowed_user_ids=_as_int_list(fm.get("allowed_user_ids")),
     )
 
 
@@ -127,6 +150,8 @@ def to_markdown(p: Persona) -> str:
         "role": p.role,
         "emoji": p.emoji,
         "voice": p.voice,
+        "bot_token": p.bot_token,
+        "allowed_user_ids": p.allowed_user_ids,
         "skills": p.skills,
         "tools": p.tools,
         "secrets": p.secrets,
@@ -151,6 +176,12 @@ class PersonaStore:
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
         async with aiosqlite.connect(self.db_path) as db:
             await db.executescript(_SCHEMA)
+            for stmt in _MIGRATIONS:
+                try:
+                    await db.execute(stmt)
+                except aiosqlite.OperationalError:
+                    pass  # column already present
+            await db.commit()
         self._ready = True
 
     async def ensure_seeded(self) -> bool:
@@ -175,13 +206,15 @@ class PersonaStore:
     async def _upsert(db: aiosqlite.Connection, p: Persona) -> None:
         await db.execute(
             "INSERT INTO personae "
-            "(name, agent_name, role, emoji, voice, personalia, character, skills, tools, secrets) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "(name, agent_name, role, emoji, voice, personalia, character, skills, tools, "
+            "secrets, bot_token, allowed_user_ids) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(name) DO UPDATE SET "
             "agent_name=excluded.agent_name, role=excluded.role, emoji=excluded.emoji, "
             "voice=excluded.voice, personalia=excluded.personalia, character=excluded.character, "
-            "skills=excluded.skills, tools=excluded.tools, "
-            "secrets=excluded.secrets, updated_at=datetime('now')",
+            "skills=excluded.skills, tools=excluded.tools, secrets=excluded.secrets, "
+            "bot_token=excluded.bot_token, allowed_user_ids=excluded.allowed_user_ids, "
+            "updated_at=datetime('now')",
             (
                 p.name,
                 p.agent_name,
@@ -193,6 +226,8 @@ class PersonaStore:
                 "\n".join(p.skills),
                 "\n".join(p.tools),
                 "\n".join(p.secrets),
+                p.bot_token,
+                "\n".join(str(i) for i in p.allowed_user_ids),
             ),
         )
 
@@ -209,6 +244,10 @@ class PersonaStore:
             skills=_as_list(row["skills"]),
             tools=_as_list(row["tools"]),
             secrets=_as_list(row["secrets"]),
+            bot_token=(row["bot_token"] if "bot_token" in row.keys() else "") or "",
+            allowed_user_ids=_as_int_list(
+                row["allowed_user_ids"] if "allowed_user_ids" in row.keys() else ""
+            ),
         )
 
     async def list_personae(self) -> list[Persona]:
@@ -251,6 +290,8 @@ tools:
   - run_command
   - send_message
 secrets: []
+bot_token: "123:ABC"
+allowed_user_ids: [111, 222]
 personalia: |
   You are Forge, a strength coach.
 character: |
@@ -264,6 +305,8 @@ Extra prose in the body.
     assert p.emoji == "🏋️"
     assert p.skills == ["scheduling", "memory"], p.skills
     assert p.tools == ["run_command", "send_message"], p.tools
+    assert p.bot_token == "123:ABC", p.bot_token
+    assert p.allowed_user_ids == [111, 222], p.allowed_user_ids
     assert "Forge" in p.personalia
     assert "motivating" in p.character and "Extra prose" in p.character  # body appended
     assert p.allows_skill("scheduling") and not p.allows_skill("email")
@@ -277,4 +320,5 @@ Extra prose in the body.
     p2 = parse_markdown(to_markdown(p), name="fitness-coach")
     assert p2.agent_name == p.agent_name and p2.skills == p.skills and p2.tools == p.tools
     assert p2.personalia.strip() == p.personalia.strip()
+    assert p2.bot_token == p.bot_token and p2.allowed_user_ids == p.allowed_user_ids
     print("personae.py self-check OK")

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -64,12 +64,17 @@ async def run_agent_task(
         )
 
     log.info("Scheduler running agent task: %s", task[:100])
+    # A "telegram:<persona>" job is generated AS that persona (#29) so the bot
+    # that delivers it also writes it — while keeping the "system" execution mode
+    # (auto-approved writes, no memory/reflection). Bare channels keep the default.
+    gen_persona = channel.split(":", 1)[1] if channel.startswith("telegram:") else None
     try:
         response = await agent.process(
             message=task,
             channel="system",
             user_id="scheduler",
             chat_id="scheduler",
+            persona_name=gen_persona,
         )
 
         # Deliver the response to the target channel

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -146,12 +146,22 @@ async def run_memory_consolidation() -> None:
 
 
 def _get_owner_chat_id(agent: AgentCore, channel: str) -> int | str | None:
-    """Get the owner's chat ID for proactive messages."""
-    if channel == "telegram":
-        tg_config = agent.config.channels.telegram
-        if tg_config.allowed_user_ids:
-            return tg_config.allowed_user_ids[0]
-    return None
+    """Get the owner's chat ID for proactive messages.
+
+    Works for the default ``telegram`` bot and every per-persona ``telegram:<persona>``
+    bot (#29): each registered channel carries its own allowlist (a persona bot
+    inherits the global one when unset), so the owner is its first allowed user.
+    """
+    if channel != "telegram" and not channel.startswith("telegram:"):
+        return None
+    # Persona bots carry their own allowlist (inheriting global when unset).
+    if channel.startswith("telegram:"):
+        ch = agent.channels.get(channel)
+        ids = getattr(getattr(ch, "config", None), "allowed_user_ids", None)
+        if ids:
+            return ids[0]
+    ids = agent.config.channels.telegram.allowed_user_ids
+    return ids[0] if ids else None
 
 
 def _parse_cron(expr: str) -> dict:

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -34,6 +34,16 @@ channels:
 - **Inline keyboards** — used for permission approval flow (Approve / Edit / Deny)
 - **User ID whitelist** — only allowed users can interact with the bot
 - **Forum topics** (opt-in) — with `topics_enabled`, each topic in a group becomes its own context with its own bound persona; see [Per-chat personae](/docs/personae#per-chat-personae)
+- **Bot-per-persona** (opt-in) — give a persona its own bot token and it becomes a separate Telegram contact, running alongside the default bot in the same process; see below
+
+### Bot-per-persona
+
+The `bot_token` above configures the **default** bot. Any persona can additionally carry its
+own token (set on the persona, not here), turning it into an independently-addressable
+contact. Each persona-bot registers as the channel `telegram:<persona>`, isolating its
+history, approvals, and scheduled jobs from the default bot and from every other persona.
+Configure it on the persona and restart the agent — see
+[Bot-per-persona](/docs/personae#bot-per-persona).
 
 ### Permission approvals
 

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -109,6 +109,8 @@ By default the active persona is global. You can instead bind a persona to a sin
 conversation — it overrides the global one **only there**. Resolution runs a ladder in
 `AgentCore._resolve_persona(channel, user_id, chat_id)`:
 
+0. a **per-persona bot** — a `telegram:<persona>` channel binds straight to that persona
+   (see [Bot-per-persona](#bot-per-persona)),
 1. the per-chat binding for `(channel, user_id, chat_id)`,
 2. the global active persona,
 3. the default identity.
@@ -127,13 +129,37 @@ history and its own persona binding; the group's General topic maps to the defau
 Name a topic after a persona (its name, agent name, or role) and it auto-binds when the topic
 is created or renamed; rebind any topic from the Chats tab.
 
+## Bot-per-persona
+
+Give a persona its own Telegram **bot token** and it becomes a separate contact in your
+address book — its own name, emoji, and voice — addressable independently of every other
+persona ([#29](https://github.com/mattmezza/mpa/issues/29)). Set it on the persona, not the
+channel: the bot is part of the persona's identity.
+
+- **Configure** — open the persona in the admin UI and fill in *Own Telegram bot* (token from
+  [@BotFather](https://t.me/botfather), plus optional allowed user IDs — blank inherits the
+  global Telegram allowlist). In raw markdown, the frontmatter keys are `bot_token` and
+  `allowed_user_ids`. Leave the token blank and the persona stays reachable only through the
+  default bot. **Restart the agent** after adding or changing a token.
+- **How it routes** — each persona-bot registers as the channel `telegram:<persona>` and runs
+  in the same process. That one composite name does three jobs: it **isolates history** (a
+  Telegram DM has `chat_id == user_id` for every bot, so without it two bots' DMs with you
+  would collide), it **routes approvals and proactive messages** back through the bot that
+  fired them, and it **resolves the persona** with no lookup (rung 0 above). The default bot
+  stays the bare `telegram` channel.
+- **Scheduled jobs** — a job's `channel` accepts `telegram:<persona>` to deliver through that
+  bot; bare `telegram` still targets the default bot, so existing jobs are unchanged.
+
+Same process, N bots today; a separate deployment per persona (one token each) is a later
+step that needs no further code.
+
 ## Roadmap
 
 Persona resolution is deliberately funnelled through one seam,
 `AgentCore._resolve_persona(channel, user_id, chat_id)`, so future work is additive:
 
-- **Bot-per-persona** ([#29](https://github.com/mattmezza/mpa/issues/29)) — run each persona
-  as its own Telegram bot, so agents become separate, independently-addressable contacts.
+- **Group multi-agent** ([#30](https://github.com/mattmezza/mpa/issues/30)) — several
+  persona-bots in one group chat, taking turns. Builds directly on bot-per-persona.
 
 The **secret scope** facet is now enforced by the [secrets vault](/docs/secrets) — a persona
 uses a secret by reference (`{{secret:NAME}}`) only if it is shared or in scope, and values

--- a/tests/test_per_chat_persona.py
+++ b/tests/test_per_chat_persona.py
@@ -110,6 +110,22 @@ async def test_resolve_persona_ladder(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_persona_bot_per_persona_channel(tmp_path) -> None:
+    # Rung 0 (#29): a "telegram:<name>" channel binds straight to that persona,
+    # outranking the per-chat binding and the global active persona.
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    store = await _seed_personae(tmp_path)
+    await h.set_chat_persona("telegram:coach", "u1", "writer", "c1")  # ignored by rung 0
+    fa = _fake_agent(h, store, active="writer")
+    p = await fa._resolve_persona("telegram:coach", "u1", "c1")
+    assert p is not None and p.name == "coach"
+
+    # Unknown persona in the channel name → fall through to the ordinary ladder.
+    p2 = await fa._resolve_persona("telegram:ghost", "u1", "c2")
+    assert p2 is not None and p2.name == "writer"  # global active persona
+
+
+@pytest.mark.asyncio
 async def test_resolve_persona_missing_binding_falls_through(tmp_path) -> None:
     h = ConversationHistory(db_path=str(tmp_path / "h.db"))
     store = await _seed_personae(tmp_path)

--- a/tests/test_personae_admin.py
+++ b/tests/test_personae_admin.py
@@ -106,6 +106,26 @@ def test_persona_raw_markdown_upsert(tmp_path) -> None:
     assert "Editor." in got["personalia"]
 
 
+def test_persona_bot_fields_persist(tmp_path) -> None:
+    # Per-persona Telegram bot (#29): token + ACL survive the round-trip and the
+    # ACL is parsed from a comma-separated string into ints.
+    client, _ = _client(tmp_path)
+    r = client.post(
+        "/personae",
+        json={
+            "name": "coach",
+            "role": "Coach",
+            "bot_token": "123456:ABC-DEF",
+            "allowed_user_ids": "111, 222",
+        },
+        headers=AUTH,
+    )
+    assert r.status_code == 200
+    got = client.get("/personae/coach", headers=AUTH).json()
+    assert got["bot_token"] == "123456:ABC-DEF"
+    assert got["allowed_user_ids"] == [111, 222]
+
+
 def test_activate_unknown_persona_404(tmp_path) -> None:
     client, _ = _client(tmp_path)
     assert (

--- a/tests/test_personae_admin.py
+++ b/tests/test_personae_admin.py
@@ -107,8 +107,9 @@ def test_persona_raw_markdown_upsert(tmp_path) -> None:
 
 
 def test_persona_bot_fields_persist(tmp_path) -> None:
-    # Per-persona Telegram bot (#29): token + ACL survive the round-trip and the
-    # ACL is parsed from a comma-separated string into ints.
+    # Per-persona Telegram bot (#29): token + ACL survive the round-trip; the ACL
+    # is parsed from a comma-separated string into ints; the token is REDACTED on
+    # read (a secret, like the global Telegram token) but stored in full.
     client, _ = _client(tmp_path)
     r = client.post(
         "/personae",
@@ -122,7 +123,11 @@ def test_persona_bot_fields_persist(tmp_path) -> None:
     )
     assert r.status_code == 200
     got = client.get("/personae/coach", headers=AUTH).json()
-    assert got["bot_token"] == "123456:ABC-DEF"
+    # Redacted on read, but head/tail prove the full value reached storage.
+    assert "***" in got["bot_token"]
+    assert got["bot_token"].startswith("1234") and got["bot_token"].endswith("-DEF")
+    assert got["bot_token"] != "123456:ABC-DEF"
+    assert "123456:ABC-DEF" not in got["markdown"]  # not leaked via the raw view either
     assert got["allowed_user_ids"] == [111, 222]
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -94,6 +94,31 @@ async def test_run_agent_task_sends_to_owner() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_agent_task_persona_job_generates_as_persona() -> None:
+    # A "telegram:<persona>" job (#29) is generated AS that persona (persona_name
+    # forced) while keeping the "system" execution mode, and delivered via that
+    # bot to its own owner (the bot's allowlist, not the global one).
+    channel = AsyncMock()
+    channel.config = SimpleNamespace(allowed_user_ids=[99])
+    agent = SimpleNamespace(
+        channels={"telegram:coach": channel},
+        process=AsyncMock(return_value=SimpleNamespace(text="done")),
+        config=SimpleNamespace(
+            channels=SimpleNamespace(telegram=SimpleNamespace(allowed_user_ids=[1]))
+        ),
+        job_store=None,
+    )
+    set_agent_context(agent)
+
+    await run_agent_task("ping", channel="telegram:coach")
+
+    _, kwargs = agent.process.call_args
+    assert kwargs["persona_name"] == "coach"
+    assert kwargs["channel"] == "system"  # execution mode unchanged
+    channel.send.assert_awaited_once_with(99, "done")  # coach bot → coach's owner
+
+
+@pytest.mark.asyncio
 async def test_run_agent_task_marks_oneshot_done() -> None:
     """One-shot jobs should be marked 'done' after execution."""
     channel = AsyncMock()


### PR DESCRIPTION
Closes #29.

Run each persona as its own Telegram bot — its own contact in your address book. The persona that handles a message is determined by **which bot received it**.

## Design — one composite channel name

A persona-bot registers as `agent.channels["telegram:<persona>"]`; the default bot stays bare `telegram`. Inbound passes `channel="telegram:<persona>"` to `process()`. That one convention does three jobs at once:

1. **History isolation** — in a Telegram DM `chat_id == user_id` for every bot, so the composite name is what stops two bots' DMs with the same user from sharing a `(channel, user, chat)` key.
2. **Outbound + approval routing** — `agent.channels["telegram:<persona>"].send(...)`, scheduler `job.channel="telegram:<persona>"`, and approvals reply via the bot that fired them (the channel string is threaded from `process()` straight to `_await_approval` → `self.channels.get(channel)`).
3. **Persona resolution** — `telegram:<name>` → persona `<name>` with no lookup (new top rung of the `_resolve_persona` ladder from #14).

## What changed

- **Persona model** — optional `bot_token` (+ optional `allowed_user_ids`, else inherit the global list). Empty token ⇒ not a bot, reachable only via the default bot. Stored on the `personae` table (new columns + migration for existing DBs); round-trips through markdown frontmatter and the admin editor.
- **`main.py`** — same process, N bots: the default bot plus one `TelegramChannel` per persona that carries a token, each polled in-process. One bad/revoked/duplicate token can't take down the others (or WhatsApp/the scheduler); partial bring-up failure tears down already-started bots so none are left orphaned.
- **`_resolve_persona`** — top rung parses `telegram:<name>`; falls through to the existing ladder for unknown names.
- **Scheduler/jobs** — `channel` accepts `telegram:<persona>` (back-compat: bare `telegram` = default bot, no migration). A persona job is generated **as** that persona while keeping the `system` execution mode (auto-approved writes, no memory/reflection).
- **Admin UI** — an *Own Telegram bot* card on the persona editor (token + allowed users); the token is redacted on read like the global one.
- **Docs** — `personae.mdx` (new Bot-per-persona section, rung 0, roadmap repointed to #30), `channels.mdx`, README.

## Out of scope (per the issue)

Group multi-agent / turn-taking (#30); per-bot config beyond token + allowed-users.

## Quality

Built understanding-first, then implemented, then ran two multi-agent adversarial review passes:

- **Review** — 4 reviewer lenses (correctness, issue-completeness, concurrency/lifecycle, security), each finding independently verified against the real code. 13 confirmed findings; the substantive ones are fixed in this branch (startup-abort/orphan-poller hardening, persona-correct scheduled jobs, token redaction, token dedup, no cross-bot progress spam, no dead topic auto-bind on persona bots).
- **Verify** — 6 adversarial probes over the fixes: **0 broken, 0 regressions** (it actually removed two pre-existing shutdown/startup bugs). GO.

All 418 tests green, `ruff` clean. New tests cover composite-channel resolution, persona-bot field persistence + token redaction, and persona-correct scheduled delivery.
