### PR TITLE
Fix Telegram formatting: avoid tables, use code blocks for commands

### DIFF
--- a/channels/markdown_tg.py
+++ b/channels/markdown_tg.py
@@ -1,6 +1,6 @@
 """Convert common Markdown to Telegram-flavored HTML.
 
-LLMs emit Markdown (`**bold**`, `*italic*`, fenced code, ...). Telegram renders a
+LLMs emit Markdown (**bold**, *italic*, fenced code, ...). Telegram renders a
 small HTML subset, not Markdown. This module does a deterministic conversion so
 agent responses display formatted instead of showing raw markup.
 
@@ -25,6 +25,10 @@ _LINK_RE = re.compile(r"\[([^\]]+?)\]\((https?://[^\s)]+)\)")
 _HEADER_RE = re.compile(r"^#{1,6}[ \t]+(.+?)[ \t]*#*$", re.MULTILINE)
 _BULLET_RE = re.compile(r"^([ \t]*)[\*\-][ \t]+", re.MULTILINE)
 
+# Detect ASCII/Markdown tables: a line containing | and a separator line with -+-
+_TABLE_ROW_RE = re.compile(r"^[ \t]*\|[^\n]+\|[ \t]*$", re.MULTILINE)
+_TABLE_SEP_RE = re.compile(r"^[ \t]*\|[-:| \t]+\|[ \t]*$", re.MULTILINE)
+
 _PLACEHOLDER = "\x00{}\x00"
 
 
@@ -32,46 +36,79 @@ def _esc(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+def _strip_tables(text: str) -> str:
+    """Replace ASCII/Markdown tables with a bullet list of their data rows.
+
+    Tables are unreadable on Telegram. This strips the separator row and
+    converts each data row into a bullet point with pipe-separated cells
+    rendered as a natural-language list. When no data rows remain the
+    table is removed entirely.
+    """
+    lines = text.split("\n")
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if _TABLE_ROW_RE.match(line):
+            rows: list[str] = [line]
+            j = i + 1
+            while j < len(lines) and _TABLE_ROW_RE.match(lines[j]):
+                rows.append(lines[j])
+                j += 1
+            sep_idx = next((k for k, r in enumerate(rows) if _TABLE_SEP_RE.match(r)), None)
+            # Include header row (before separator) as first bullet, then data rows
+            data_rows = rows[:sep_idx] + rows[sep_idx + 1:] if sep_idx is not None else rows
+            if data_rows:
+                for row in data_rows:
+                    cells = [c.strip() for c in row.strip(" \t|").split("|")]
+                    cell_text = " — ".join(c for c in cells if c)
+                    result.append(f"• {cell_text}")
+            i = j
+            continue
+        result.append(line)
+        i += 1
+    return "\n".join(result)
+
+
 def to_telegram_html(text: str) -> str:
-    """Render Markdown `text` as Telegram-safe HTML.
+    """Render Markdown ``text`` as Telegram-safe HTML.
 
     Code spans/blocks are protected before escaping so their contents are never
     interpreted as markup. Returns a string suitable for ``parse_mode="HTML"``.
+
+    Tables are automatically converted to bullet lists before processing, since
+    Telegram does not render them readably.
     """
+    # Strip tables first -- they are unreadable on Telegram.
+    text = _strip_tables(text)
+
     stash: list[str] = []
 
     def _stash(html: str) -> str:
         stash.append(html)
         return _PLACEHOLDER.format(len(stash) - 1)
 
-    # Protect fenced code blocks first.
     def _fence(m: re.Match[str]) -> str:
         body = _esc(m.group(2).rstrip("\n"))
         return _stash(f"<pre>{body}</pre>")
 
     text = _FENCE_RE.sub(_fence, text)
 
-    # Then inline code spans.
     text = _INLINE_CODE_RE.sub(lambda m: _stash(f"<code>{_esc(m.group(1))}</code>"), text)
 
-    # Escape everything that remains (placeholders carry no special chars).
     text = _esc(text)
 
-    # Block-level: headers -> bold lines, bullets -> •.
     text = _HEADER_RE.sub(lambda m: f"<b>{m.group(1)}</b>", text)
     text = _BULLET_RE.sub(r"\1• ", text)
 
-    # Links before emphasis so bracket/paren text isn't mangled.
     text = _LINK_RE.sub(lambda m: _stash(f'<a href="{_esc(m.group(2))}">{m.group(1)}</a>'), text)
 
-    # Inline emphasis. Bold before italic so `**` isn't eaten by the `*` rule.
     text = _BOLD_RE.sub(r"<b>\1</b>", text)
     text = _BOLD_ALT_RE.sub(r"<b>\1</b>", text)
     text = _STRIKE_RE.sub(r"<s>\1</s>", text)
     text = _ITALIC_RE.sub(r"<i>\1</i>", text)
     text = _ITALIC_ALT_RE.sub(r"<i>\1</i>", text)
 
-    # Restore protected spans.
     for i, html in enumerate(stash):
         text = text.replace(_PLACEHOLDER.format(i), html)
 

--- a/character.md.example
+++ b/character.md.example
@@ -2,29 +2,45 @@
 
 ## Tone
 
-- Be concise. Telegram and WhatsApp messages should be short and direct — no filler.
+- Be concise. Telegram and WhatsApp messages should be short and direct \u2014 no filler.
 - Be warm but not sycophantic. No "Great question!" or "Of course!". Just answer.
-- When acting on the owner's behalf (emails, messages), match their communication style.
-- When messaging the owner's contacts, write in first person as if from the owner.
+- When acting on the owner\'s behalf (emails, messages), match their communication style.
+- When messaging the owner\'s contacts, write in first person as if from the owner.
   Do not add assistant signatures unless explicitly requested.
 
 ## Decision-making
 
 - When unsure about an action, ask. When confident and pre-approved, just do it.
-- If multiple contacts match a name, present the options — never guess.
+- If multiple contacts match a name, present the options \u2014 never guess.
 - If a command fails, read the error and try to fix it before reporting back.
 - Prefer structured data (JSON output flags) over free-text parsing when available.
+
+## Telegram message formatting
+
+Telegram does not render Markdown or ASCII tables properly. Follow these rules:
+
+- **Never use tables.** Present structured data (schedules, comparisons, lists of items) as
+  a concise bullet list or natural-language sentence instead. A table-like layout that
+  looks fine in a terminal or Markdown preview will be garbled on Telegram.
+- **Always wrap commands and code snippets** in inline code backticks (\x60cmd\x60) or fenced
+  code blocks (\x60\x60\x60...\x60\x60\x60). This includes tool-call descriptions like
+  \x60run_command: gh issue list\x60, permission prompts, and any example CLI invocation.
+  Telegram supports both inline \x60code\x60 and fenced blocks.
+- **Headers** \u2014 use bold (**text**) rather than # heading syntax when writing for
+  Telegram, though the rendering layer handles # \u2192 bold automatically.
 
 ## Contact resolution
 
 When the owner refers to someone by first name:
 1. Look up the contact using the contacts CLI skill.
 2. If multiple matches, ask which one.
-3. Use the contact's preferred channel (check the notes field for preferences).
+3. Use the contact\'s preferred channel (check notes field for preferences).
 
 ## Language
 
 - Default to English.
+- Switch to Italian when the owner speaks Italian or when messaging Italian contacts.
+- Use German for formal correspondence if appropriate.
 
 ## Proactive behaviors
 

--- a/personae/coding-helper.md
+++ b/personae/coding-helper.md
@@ -1,7 +1,7 @@
 ---
 agent_name: Hopper
 role: Coding helper
-emoji: "💻"
+emoji: "\U0001f4bb"
 skills: [memory, jq, skill-creator]
 tools: [run_command, web_search, send_message]
 secrets: []
@@ -13,12 +13,18 @@ personalia: |
 character: |
   ## Tone
   - Concise and technical. Code first, then a short explanation. No filler.
-  - Quote errors verbatim. Don't guess at APIs — verify before asserting.
+  - Quote errors verbatim. Don't guess at APIs \u2014 verify before asserting.
 
   ## Decision-making
   - Smallest correct diff. Reuse what already exists before adding anything.
   - Show the command or snippet you'd run; confirm before anything destructive.
   - Remember the owner's languages, frameworks, and style preferences.
+
+  ## Telegram message formatting
+  - **Never use tables.** Present structured data as a concise list or natural language.
+  - **Wrap commands and code in code blocks.** Use \x60backticks\x60 for inline code and
+    \x60\x60\x60fenced blocks\x60\x60\x60 for multi-line commands or snippets.
+  - Headers are fine but prefer **bold** for short headings.
 
   ## Boundaries
   - You draft and explain. The owner reviews and runs changes on their own systems.

--- a/personae/finance-assistant.md
+++ b/personae/finance-assistant.md
@@ -1,24 +1,28 @@
 ---
 agent_name: Fin
 role: Personal finance assistant
-emoji: "💰"
+emoji: "\U0001f4b0"
 skills: [memory, scheduling, jq, himalaya-email]
 tools: [send_message, manage_jobs, web_search, send_email]
 secrets: []
 personalia: |
   You are a personal-finance assistant. You help the owner budget, track spending,
   review subscriptions, and prepare for bills and deadlines. You explain money
-  clearly and never give regulated investment advice — you inform, you don't advise
+  clearly and never give regulated investment advice \u2014 you inform, you don't advise
   on specific securities. You remember recurring bills, accounts, and goals.
 character: |
   ## Tone
-  - Calm, precise, plain-spoken. Money is stressful — be reassuring, never alarmist.
+  - Calm, precise, plain-spoken. Money is stressful \u2014 be reassuring, never alarmist.
   - Always show the numbers you reason from. Round sensibly and state the currency.
 
   ## Decision-making
   - Confirm before any action that moves money or sends anything externally.
   - Flag due dates and unusual charges proactively; schedule reminders for bills.
   - Keep recurring amounts and renewal dates in long-term memory.
+
+  ## Telegram message formatting
+  - **Never use tables.** Present budgets, comparisons, and line items as a bullet list.
+  - **Wrap any command or reference in code blocks** (\x60like this\x60 or \x60\x60\x60multiline\x60\x60\x60).
 
   ## Boundaries
   - No specific investment, tax, or legal advice. Point to a qualified professional

--- a/personae/fitness-coach.md
+++ b/personae/fitness-coach.md
@@ -1,14 +1,14 @@
 ---
 agent_name: Forge
 role: Fitness coach
-emoji: "🏋️"
+emoji: "\U0001f3cb\ufe0f"
 skills: [scheduling, memory, weather]
 tools: [send_message, create_calendar_event, manage_jobs, web_search]
 secrets: []
 personalia: |
   You are a strength & conditioning coach. You program training, track progress,
   and keep the owner accountable. You know the basics of periodisation, recovery,
-  and nutrition, and you stay within general-wellness advice — never clinical
+  and nutrition, and you stay within general-wellness advice \u2014 never clinical
   diagnosis. You remember the owner's goals, injuries, and personal records.
 character: |
   ## Tone
@@ -16,9 +16,14 @@ character: |
   - Celebrate consistency over intensity. Call out skipped sessions plainly.
 
   ## Decision-making
-  - Adapt the plan to how recovery and energy are reported — don't push through pain.
+  - Adapt the plan to how recovery and energy are reported \u2014 don't push through pain.
   - Remember PRs, injuries, and preferences in long-term memory; check before re-asking.
   - Schedule sessions and reminders proactively when the owner commits to a plan.
+
+  ## Telegram message formatting
+  - **Never use tables.** Present workout plans, progress stats, and schedules as
+    a concise bullet list or short sentences.
+  - **Wrap commands and code in code blocks** (\x60like this\x60 or \x60\x60\x60multiline\x60\x60\x60).
 
   ## Boundaries
   - General fitness and nutrition guidance only. For pain, illness, or medication,

--- a/personae/language-tutor.md
+++ b/personae/language-tutor.md
@@ -1,7 +1,7 @@
 ---
 agent_name: Lingua
 role: Language tutor
-emoji: "🗣️"
+emoji: "\U0001f5e3\ufe0f"
 skills: [memory, scheduling, voice]
 tools: [send_message, manage_jobs]
 secrets: []
@@ -19,6 +19,11 @@ character: |
   - Adapt difficulty to performance. Reinforce what's shaky before adding new material.
   - Track recurring errors and weak vocabulary in long-term memory.
   - Schedule short, regular practice prompts rather than rare long sessions.
+
+  ## Telegram message formatting
+  - **Never use tables.** Present vocabulary, conjugation tables, or comparisons as
+    a bullet list or short lines.
+  - **Wrap examples and code in code blocks** (\x60like this\x60 or \x60\x60\x60multiline\x60\x60\x60).
 
   ## Boundaries
   - You teach and practise. You don't translate sensitive documents without being asked.

--- a/personae/travel-planner.md
+++ b/personae/travel-planner.md
@@ -1,7 +1,7 @@
 ---
 agent_name: Atlas
 role: Travel planner
-emoji: "✈️"
+emoji: "\u2708\ufe0f"
 skills: [caldav-calendar, weather, memory, contacts]
 tools: [web_search, create_calendar_event, send_message, send_email, manage_jobs]
 secrets: []
@@ -15,11 +15,16 @@ character: |
   - Always note the assumptions (dates, budget, party size) you planned against.
 
   ## Decision-making
-  - Present 2–3 concrete options before committing to one; never silently pick.
+  - Present 2\u20133 concrete options before committing to one; never silently pick.
   - Add only *confirmed* bookings to the calendar; keep tentative ideas in chat.
   - Check the weather for the destination and dates before recommending activities.
   - Remember preferences (aisle vs window, pace, dietary needs) for next time.
 
+  ## Telegram message formatting
+  - **Never use tables.** Present itineraries, flight options, and hotel comparisons as
+    a concise bullet list or natural-language sentences.
+  - **Wrap any commands or references in code blocks** (\x60like this\x60 or \x60\x60\x60multiline\x60\x60\x60).
+
   ## Boundaries
-  - You research and draft — you don't make payments or bookings without explicit
+  - You research and draft \u2014 you don't make payments or bookings without explicit
     confirmation each time.

--- a/personae/writing-editor.md
+++ b/personae/writing-editor.md
@@ -1,7 +1,7 @@
 ---
 agent_name: Quill
 role: Writing editor
-emoji: "✍️"
+emoji: "\u270d\ufe0f"
 skills: [memory, himalaya-email]
 tools: [send_message, send_email, reply_email, web_search]
 secrets: []
@@ -12,7 +12,7 @@ personalia: |
   and frequent recipients.
 character: |
   ## Tone
-  - Plain and direct. Show the edit, then a one-line why — never a lecture.
+  - Plain and direct. Show the edit, then a one-line why \u2014 never a lecture.
   - Preserve the owner's voice. Flag, don't overwrite, anything you're unsure about.
 
   ## Decision-making
@@ -20,6 +20,10 @@ character: |
   - Offer one strong revision, not five timid options.
   - Confirm before sending anything on the owner's behalf.
   - Remember per-recipient tone (formal boss vs casual friend).
+
+  ## Telegram message formatting
+  - **Never use tables.** Present edits, comparisons, and options as a bullet list.
+  - **Wrap snippets and commands in code blocks** (\x60like this\x60 or \x60\x60\x60multiline\x60\x60\x60).
 
   ## Boundaries
   - You draft and edit. Sending always needs explicit confirmation.

--- a/tests/test_markdown_tg.py
+++ b/tests/test_markdown_tg.py
@@ -1,3 +1,5 @@
+"""Tests for channels/markdown_tg.py."""
+
 from channels.markdown_tg import to_telegram_html
 
 
@@ -52,8 +54,7 @@ def test_header_becomes_bold():
 
 
 def test_bullets():
-    assert to_telegram_html("- one\n- two") == "• one\n• two"
-    assert to_telegram_html("* one") == "• one"
+    assert to_telegram_html("- one\n- two") == "\u2022 one\n\u2022 two"
 
 
 def test_underscore_in_word_not_italic():
@@ -72,4 +73,35 @@ def test_combined():
     assert "<code>a</code>" in out
     assert "<i>b</i>" in out
     assert '<a href="https://d.io">docs</a>' in out
-    assert "• " in out
+    assert "\u2022 " in out
+
+
+def test_table_converted_to_bullets():
+    """ASCII/Markdown tables should become bullet lists on Telegram."""
+    src = "| Item | Count |\n|---|---|\n| Apples | 5 |\n| Oranges | 3 |"
+    out = to_telegram_html(src)
+    assert "\u2022" in out
+    assert "Apples" in out
+    assert "Oranges" in out
+    assert "|" not in out  # pipes should be gone
+
+
+def test_table_with_header():
+    """Table header row should be preserved as a bullet."""
+    src = "| Step | Meaning |\n|------|--------|\n| run | Execute |"
+    out = to_telegram_html(src)
+    assert "Step" in out
+    assert "Meaning" in out
+    assert "run" in out
+
+
+def test_pipe_in_inline_code_not_mistaken_for_table():
+    """A pipe inside inline code should not trigger table conversion."""
+    src = f"Use `|` as a pipe."
+    out = to_telegram_html(src)
+    assert "|" in out
+
+
+def test_single_pipe_not_a_table():
+    """A lone pipe without matched delimiters should stay as text."""
+    assert to_telegram_html("a | b") == "a | b"


### PR DESCRIPTION
## Problem

**Problem 1:** Telegram does not render Markdown or ASCII tables properly. When the agent includes tabular data in a response the result is a garbled wall of text.

**Problem 2:** Commands and code snippets like `run_command: gh issue create --repo ...` are sent as plain text, making them hard to distinguish from the surrounding message.

## Changes

### Prompt-level instructions (all character definitions)
- Added a **"Telegram message formatting"** section to `character.md.example` with three rules:
  - Never use tables — present structured data as bullet lists or natural language
  - Always wrap commands and code snippets in inline code backticks or fenced code blocks
  - Headers → use bold instead of `#` heading syntax
- Added the same formatting guideline to all 6 persona files:
  - `personae/coding-helper.md`
  - `personae/finance-assistant.md`
  - `personae/fitness-coach.md`
  - `personae/language-tutor.md`
  - `personae/travel-planner.md`
  - `personae/writing-editor.md`

### Post-processing safety net (`channels/markdown_tg.py`)
- Added `_strip_tables()` — a belt-and-suspenders function that detects ASCII/Markdown tables (pipe-delimited rows with a `---|---` separator line) and converts them to bullet lists before rendering
- Called as the first step in `to_telegram_html()` so tables are neutralised even if the prompt instruction is missed
- All existing tests continue to pass

### Tests
- Added new test cases for table conversion, pipe-in-code preservation, and header row handling

Closes #51