### PR TITLE
feat(telegram): group multi-agent rooms — turn-taking + loop guard + speaker tags (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Email** — Read, compose, and manage emails via [Himalaya](https://github.com/pimalaya/himalaya) CLI
 - **Calendar** — CalDAV integration (Google Calendar, iCloud, etc.)
 - **Contacts** — CardDAV providers via the built-in contacts CLI
-- **Personae** — Swappable agent identities (own character, skill/tool scope, voice). Bind one per chat — and, on Telegram, per forum topic — so several run concurrently, each with its own isolated context. Give a persona its own bot token and it becomes a separate Telegram contact (bot-per-persona)
+- **Personae** — Swappable agent identities (own character, skill/tool scope, voice). Bind one per chat — and, on Telegram, per forum topic — so several run concurrently, each with its own isolated context. Give a persona its own bot token and it becomes a separate Telegram contact (bot-per-persona); add several persona-bots to one Telegram group and they take turns — each replies only when addressed, ignores other bots so they never loop, and tags who said what in the shared history
 - **Reply decision** — In shared/group chats the agent decides per message whether to reply at all, staying quiet for messages aimed at another bot or caught in a bot-to-bot reaction loop, with a hard rate cap that guarantees runaway loops end (off by default)
 - **Memory** — Two-tier system: permanent long-term facts and expiring short-term context, both extracted automatically from conversations
 - **Scheduled tasks** — Cron-based jobs for morning briefings, email checks, contact sync, and custom tasks

--- a/api/admin.py
+++ b/api/admin.py
@@ -308,6 +308,18 @@ async def _channel_wizard_context(
         ctx["topics_enabled"] = (
             str(await config_store.get("channels.telegram.topics_enabled")).lower() == "true"
         )
+        # Group multi-agent rooms (#30). Absent keys fall back to the model
+        # defaults: enabled off, the two sub-options on.
+        g_enabled = await config_store.get("channels.telegram.group_chat.enabled")
+        g_addressed = await config_store.get(
+            "channels.telegram.group_chat.reply_when_addressed_only"
+        )
+        g_ignore = await config_store.get("channels.telegram.group_chat.ignore_bots")
+        ctx["group_chat_enabled"] = str(g_enabled).lower() == "true"  # default off
+        ctx["group_reply_addressed_only"] = (
+            g_addressed is None or str(g_addressed).lower() == "true"
+        )
+        ctx["group_ignore_bots"] = g_ignore is None or str(g_ignore).lower() == "true"
     if channel == "whatsapp":
         enabled_raw = await config_store.get("channels.whatsapp.enabled")
         enabled = str(enabled_raw).lower() != "false"
@@ -2254,6 +2266,10 @@ def create_admin_app(
         user_ids = str(body.get("user_ids", "")).strip()
         enabled = str(body.get("enabled", "true")).lower() == "true"
         topics_enabled = bool(body.get("topics_enabled", False))
+        # Group multi-agent rooms (#30). Sub-options default on; whole feature off.
+        group_enabled = bool(body.get("group_chat_enabled", False))
+        group_addressed = bool(body.get("group_reply_addressed_only", True))
+        group_ignore_bots = bool(body.get("group_ignore_bots", True))
         # When the token lives in the vault the editor submits an empty field —
         # treat the existing ${vault:} ref as "present" and leave it untouched.
         token_is_vaulted = _is_vault_ref(await config_store.get("channels.telegram.bot_token"))
@@ -2263,6 +2279,9 @@ def create_admin_app(
             "channels.telegram.enabled": str(enabled).lower(),
             "channels.telegram.allowed_user_ids": user_ids,
             "channels.telegram.topics_enabled": str(topics_enabled).lower(),
+            "channels.telegram.group_chat.enabled": str(group_enabled).lower(),
+            "channels.telegram.group_chat.reply_when_addressed_only": str(group_addressed).lower(),
+            "channels.telegram.group_chat.ignore_bots": str(group_ignore_bots).lower(),
         }
         if bot_token:  # only overwrite when a real new token was typed
             values["channels.telegram.bot_token"] = bot_token

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -349,7 +349,10 @@
     const groupAddressed = groupAddressedInput ? groupAddressedInput.checked : true;
     const groupIgnoreBotsInput = document.getElementById('ch-tg-group-ignorebots');
     const groupIgnoreBots = groupIgnoreBotsInput ? groupIgnoreBotsInput.checked : true;
-    if (!token) {
+    // A vault-managed token renders the field readonly+empty; the backend keeps
+    // the existing ${vault:} ref, so don't demand a typed token there (otherwise
+    // toggling topics/group rooms is impossible once the token is vaulted).
+    if (!token && !tokenInput.readOnly) {
       result.textContent = 'Bot token is required.';
       result.className = 'alert-error';
       return;

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -343,6 +343,12 @@
     const users = usersInput.value.trim();
     const topicsInput = document.getElementById('ch-tg-topics');
     const topics = topicsInput ? topicsInput.checked : false;
+    const groupInput = document.getElementById('ch-tg-group');
+    const group = groupInput ? groupInput.checked : false;
+    const groupAddressedInput = document.getElementById('ch-tg-group-addressed');
+    const groupAddressed = groupAddressedInput ? groupAddressedInput.checked : true;
+    const groupIgnoreBotsInput = document.getElementById('ch-tg-group-ignorebots');
+    const groupIgnoreBots = groupIgnoreBotsInput ? groupIgnoreBotsInput.checked : true;
     if (!token) {
       result.textContent = 'Bot token is required.';
       result.className = 'alert-error';
@@ -354,7 +360,11 @@
         'Content-Type': 'application/json',
         'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
       },
-      body: JSON.stringify({bot_token: token, user_ids: users, enabled: true, topics_enabled: topics})
+      body: JSON.stringify({
+        bot_token: token, user_ids: users, enabled: true, topics_enabled: topics,
+        group_chat_enabled: group, group_reply_addressed_only: groupAddressed,
+        group_ignore_bots: groupIgnoreBots
+      })
     })
       .then(r => r.text())
       .then(html => {

--- a/api/templates/partials/channel_wizard_telegram.html
+++ b/api/templates/partials/channel_wizard_telegram.html
@@ -31,6 +31,28 @@
     topic after a persona to auto-bind it; rebind any chat on the Chats tab.
   </div>
 
+  <label class="flex items-center gap-2 mt-3 text-sm">
+    <input type="checkbox" id="ch-tg-group" {% if group_chat_enabled %}checked{% endif %}>
+    Group multi-agent rooms
+  </label>
+  <div class="hint">
+    Let several persona-bots share one group: each replies only when addressed,
+    ignores other bots, and tags who said what. Requires each bot's Telegram
+    privacy mode to be <strong>off</strong> (@BotFather → /setprivacy) to see the
+    wider conversation. Inherited by per-persona bots.
+  </div>
+  <div class="ml-5 mt-1 space-y-1">
+    <label class="flex items-center gap-2 text-sm">
+      <input type="checkbox" id="ch-tg-group-addressed" {% if group_reply_addressed_only %}checked{% endif %}>
+      Reply only when addressed (@mention or reply-to)
+    </label>
+    <label class="flex items-center gap-2 text-sm">
+      <input type="checkbox" id="ch-tg-group-ignorebots" {% if group_ignore_bots %}checked{% endif %}>
+      Never reply to other bots (loop guard)
+    </label>
+    <div class="hint">These two apply only when group rooms are on.</div>
+  </div>
+
   {% include "partials/restart_note.html" %}
 
   <div class="flex items-center gap-2 mt-3">

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -214,10 +214,16 @@ class TelegramChannel:
 
         Telegram entity offsets/lengths are UTF-16 code units, so slicing the
         Python str by code point misaligns once a non-BMP char (emoji) precedes
-        the entity. Prefer python-telegram-bot's own ``parse_entity`` and fall
-        back to a code-point slice only for plain test doubles.
+        the entity. Prefer python-telegram-bot's own parser and fall back to a
+        code-point slice only for plain test doubles. A photo/document caption
+        has no ``.text``, and ``parse_entity`` raises there — use
+        ``parse_caption_entity`` for the entity that lives in the caption.
         """
-        parse = getattr(message, "parse_entity", None)
+        parse = (
+            getattr(message, "parse_caption_entity", None)
+            if not getattr(message, "text", None)
+            else getattr(message, "parse_entity", None)
+        )
         if callable(parse):
             try:
                 return parse(ent)

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -158,23 +158,38 @@ class TelegramChannel:
 
     # -- Group multi-agent rooms (#30) ---------------------------------------
 
-    def _is_group(self, chat) -> bool:
-        """True for a Telegram group/supergroup with group-room behaviour on."""
-        return (
-            bool(chat)
+    def _is_group(self, chat, message=None) -> bool:
+        """True for a Telegram group/supergroup with group-room behaviour on.
+
+        A genuine forum topic under ``topics_enabled`` is exempt: a topic is its
+        own persona-bound 1:1-style context (#14), so group turn-taking would
+        wrongly silence its bound persona. Group rooms (#30) apply to the rest of
+        the group/supergroup.
+        """
+        if not (
+            chat
             and getattr(chat, "type", "") in ("group", "supergroup")
             and self.config.group_chat.enabled
-        )
+        ):
+            return False
+        if (
+            self.config.topics_enabled
+            and message is not None
+            and getattr(message, "is_topic_message", False)
+        ):
+            return False
+        return True
 
-    def _convo_user_id(self, chat, sender_id: int) -> str:
+    def _convo_user_id(self, chat, sender_id: int, message=None) -> str:
         """The ``user_id`` key the agent stores history/bindings under.
 
         In a group room every participant shares one conversation per bot, so the
         group itself is the key — that is what lets a bot see other people's (and
-        other bots') messages as inbound turns. In a 1:1 DM it stays the sender
-        (where ``chat_id == user_id`` anyway), so the plain flow is unchanged.
+        other bots') messages as inbound turns. In a 1:1 DM (or an exempt forum
+        topic) it stays the sender (where ``chat_id == user_id`` anyway), so the
+        plain flow is unchanged.
         """
-        if self._is_group(chat):
+        if self._is_group(chat, message):
             return str(chat.id)
         return str(sender_id)
 
@@ -188,10 +203,27 @@ class TelegramChannel:
             uname = bot.username
             self._bot_username = uname.lower() if uname else None
         except RuntimeError, AttributeError:
-            # Bot info not populated yet — leave unset; reply-to detection still
-            # works, and the next update retries.
+            # Bot info not populated yet — leave unset; addressing checks return
+            # False this once and the next update retries once it is available.
             self._bot_id = None
             self._bot_username = None
+
+    @staticmethod
+    def _entity_text(message, text: str, ent) -> str:
+        """The substring an entity spans, UTF-16-safe.
+
+        Telegram entity offsets/lengths are UTF-16 code units, so slicing the
+        Python str by code point misaligns once a non-BMP char (emoji) precedes
+        the entity. Prefer python-telegram-bot's own ``parse_entity`` and fall
+        back to a code-point slice only for plain test doubles.
+        """
+        parse = getattr(message, "parse_entity", None)
+        if callable(parse):
+            try:
+                return parse(ent)
+            except Exception:
+                pass
+        return text[ent.offset : ent.offset + ent.length]
 
     @staticmethod
     def _speaker_name(user) -> str:
@@ -206,7 +238,15 @@ class TelegramChannel:
 
     def _addressed_to_me(self, message) -> bool:
         """True when this message is addressed to THIS bot: a reply to one of the
-        bot's own messages, or an @mention / text-mention of it."""
+        bot's own messages, an @mention, a text-mention, or a ``/cmd@bot`` command.
+
+        Addressing is decided by Telegram's own entities (exact handle match, not
+        a substring) so a sibling bot whose @username merely contains or extends
+        this one's — ``@coach`` vs ``@coachbot``, an email ``x@coachbot.com`` —
+        never makes the wrong bot reply, which would re-open the N×-reply storm
+        the respond-gate exists to close. A loose substring match is used only as
+        a last resort when Telegram supplied no entities at all.
+        """
         reply = getattr(message, "reply_to_message", None)
         if reply is not None:
             rf = getattr(reply, "from_user", None)
@@ -219,16 +259,22 @@ class TelegramChannel:
         handle = f"@{self._bot_username}" if self._bot_username else ""
         for ent in entities:
             etype = getattr(ent, "type", "")
-            if etype == "mention" and handle:
-                seg = text[ent.offset : ent.offset + ent.length]
-                if seg.lower() == handle:
+            if etype in ("mention", "bot_command") and handle:
+                seg = self._entity_text(message, text, ent).lower()
+                # "@coachbot" (mention) is an exact match; "/jobs@coachbot"
+                # (bot_command) ends with the handle.
+                if seg == handle or seg.endswith(handle):
                     return True
             elif etype == "text_mention":
                 u = getattr(ent, "user", None)
                 if u is not None and self._bot_id is not None and u.id == self._bot_id:
                     return True
-        # Fallback: covers "/cmd@bot" and a plain "@bot" when entities are absent.
-        return bool(handle) and handle in text.lower()
+        # Entity-less last resort (forwards / odd clients): when Telegram gave us
+        # entities we trust them — an absent match means not addressed. Require a
+        # boundary so "@coach" can't match inside "@coachbot".
+        if entities or not handle:
+            return False
+        return re.search(rf"(?<![\w@]){re.escape(handle)}(?![\w])", text.lower()) is not None
 
     def _turn_routing(self, update: Update, message, context) -> dict:
         """Decide how to handle an inbound message in a group room (#30).
@@ -242,7 +288,7 @@ class TelegramChannel:
         user = update.effective_user
         chat = update.effective_chat
         sender_id = user.id if user else 0
-        if not self._is_group(chat):
+        if not self._is_group(chat, message):
             return {"user_id": str(sender_id), "speaker_tag": "", "respond": True}
 
         self._ensure_bot_identity(context)
@@ -279,7 +325,11 @@ class TelegramChannel:
         routing = self._turn_routing(update, message, context)
         convo_user = routing["user_id"]
         self._remember_chat(convo_user, folded)
-        if not self._is_allowed(sender_id):
+        # The whitelist gates who can make the bot *reply/act*; a record-only turn
+        # (respond=False) writes to history but runs no inference and takes no
+        # action, so it bypasses the gate — that is what lets the loop guard
+        # record other bots and the shared history tag every speaker (#30).
+        if routing["respond"] and not self._is_allowed(sender_id):
             return
 
         chat_id = folded if folded is not None else sender_id
@@ -306,7 +356,11 @@ class TelegramChannel:
         routing = self._turn_routing(update, message, context)
         convo_user = routing["user_id"]
         self._remember_chat(convo_user, folded)
-        if not self._is_allowed(sender_id):
+        # The whitelist gates who can make the bot *reply/act*; a record-only turn
+        # (respond=False) writes to history but runs no inference and takes no
+        # action, so it bypasses the gate — that is what lets the loop guard
+        # record other bots and the shared history tag every speaker (#30).
+        if routing["respond"] and not self._is_allowed(sender_id):
             return
 
         chat_id = folded if folded is not None else sender_id
@@ -352,7 +406,11 @@ class TelegramChannel:
         routing = self._turn_routing(update, message, context)
         convo_user = routing["user_id"]
         self._remember_chat(convo_user, folded)
-        if not self._is_allowed(sender_id):
+        # The whitelist gates who can make the bot *reply/act*; a record-only turn
+        # (respond=False) writes to history but runs no inference and takes no
+        # action, so it bypasses the gate — that is what lets the loop guard
+        # record other bots and the shared history tag every speaker (#30).
+        if routing["respond"] and not self._is_allowed(sender_id):
             return
 
         chat_id = folded if folded is not None else sender_id
@@ -475,9 +533,11 @@ class TelegramChannel:
         if user_id is None or not self._is_allowed(user_id):
             return
         chat_id = f"{chat.id}:{thread}"
-        # Bind under the same conversational id messages resolve with, so a group
-        # room's shared history finds the topic binding (#30).
-        convo_user = self._convo_user_id(chat, user_id)
+        # Bind under the same conversational id messages resolve with. A forum
+        # topic under topics_enabled is exempt from group rooms (#30), so this
+        # resolves to the sender id — matching how messages in the topic key,
+        # keeping the per-topic persona binding intact.
+        convo_user = self._convo_user_id(chat, user_id, message)
         bound = await self.agent.bind_chat_persona_by_label(
             self.channel_name, convo_user, chat_id, name
         )

--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -61,6 +61,11 @@ class TelegramChannel:
         # Last chat a user wrote from, used to route approval prompts. Holds a
         # folded "<chat>:<thread>" string when the message came from a topic.
         self._last_chat_for_user: dict[int, int | str] = {}
+        # This bot's own identity, cached lazily from the first update (the Bot
+        # API has it only once polling is initialised). Used to detect @mentions
+        # and replies aimed at this bot in group rooms (#30).
+        self._bot_id: int | None = None
+        self._bot_username: str | None = None
         self.app = Application.builder().token(config.bot_token).concurrent_updates(8).build()
         # Commands are checked before the text handler so "/jobs" doesn't reach the
         # agent as an ordinary message. (Plain text — incl. /new, /clear — still
@@ -151,26 +156,142 @@ class TelegramChannel:
 
         return f"[reply_to]\n{author}: {text}\n[/reply_to]\n"
 
+    # -- Group multi-agent rooms (#30) ---------------------------------------
+
+    def _is_group(self, chat) -> bool:
+        """True for a Telegram group/supergroup with group-room behaviour on."""
+        return (
+            bool(chat)
+            and getattr(chat, "type", "") in ("group", "supergroup")
+            and self.config.group_chat.enabled
+        )
+
+    def _convo_user_id(self, chat, sender_id: int) -> str:
+        """The ``user_id`` key the agent stores history/bindings under.
+
+        In a group room every participant shares one conversation per bot, so the
+        group itself is the key — that is what lets a bot see other people's (and
+        other bots') messages as inbound turns. In a 1:1 DM it stays the sender
+        (where ``chat_id == user_id`` anyway), so the plain flow is unchanged.
+        """
+        if self._is_group(chat):
+            return str(chat.id)
+        return str(sender_id)
+
+    def _ensure_bot_identity(self, context) -> None:
+        """Cache this bot's id + username from the first update that needs them."""
+        if self._bot_id is not None:
+            return
+        bot = getattr(context, "bot", None) or self.app.bot
+        try:
+            self._bot_id = bot.id
+            uname = bot.username
+            self._bot_username = uname.lower() if uname else None
+        except RuntimeError, AttributeError:
+            # Bot info not populated yet — leave unset; reply-to detection still
+            # works, and the next update retries.
+            self._bot_id = None
+            self._bot_username = None
+
+    @staticmethod
+    def _speaker_name(user) -> str:
+        if user is None:
+            return "Unknown"
+        name = (
+            getattr(user, "full_name", None)
+            or getattr(user, "username", None)
+            or str(getattr(user, "id", ""))
+        )
+        return name or "Unknown"
+
+    def _addressed_to_me(self, message) -> bool:
+        """True when this message is addressed to THIS bot: a reply to one of the
+        bot's own messages, or an @mention / text-mention of it."""
+        reply = getattr(message, "reply_to_message", None)
+        if reply is not None:
+            rf = getattr(reply, "from_user", None)
+            if rf is not None and self._bot_id is not None and rf.id == self._bot_id:
+                return True
+        text = getattr(message, "text", None) or getattr(message, "caption", None) or ""
+        entities = list(getattr(message, "entities", None) or []) + list(
+            getattr(message, "caption_entities", None) or []
+        )
+        handle = f"@{self._bot_username}" if self._bot_username else ""
+        for ent in entities:
+            etype = getattr(ent, "type", "")
+            if etype == "mention" and handle:
+                seg = text[ent.offset : ent.offset + ent.length]
+                if seg.lower() == handle:
+                    return True
+            elif etype == "text_mention":
+                u = getattr(ent, "user", None)
+                if u is not None and self._bot_id is not None and u.id == self._bot_id:
+                    return True
+        # Fallback: covers "/cmd@bot" and a plain "@bot" when entities are absent.
+        return bool(handle) and handle in text.lower()
+
+    def _turn_routing(self, update: Update, message, context) -> dict:
+        """Decide how to handle an inbound message in a group room (#30).
+
+        Returns ``user_id`` (the shared conversation key — the group, or the
+        sender for a DM), the ``speaker_tag`` to prepend so the persona knows who
+        spoke, and ``respond`` (reply now, or just record for context). Outside a
+        group room every message gets ``respond=True`` and no tag, so 1:1 DMs are
+        untouched.
+        """
+        user = update.effective_user
+        chat = update.effective_chat
+        sender_id = user.id if user else 0
+        if not self._is_group(chat):
+            return {"user_id": str(sender_id), "speaker_tag": "", "respond": True}
+
+        self._ensure_bot_identity(context)
+        gc = self.config.group_chat
+        is_bot = bool(getattr(user, "is_bot", False))
+        marker = " (bot)" if is_bot else ""
+        speaker_tag = f"[from {self._speaker_name(user)}{marker}]\n"
+        if is_bot and gc.ignore_bots:
+            respond = False  # loop guard — record only, never reply to another bot
+        elif gc.reply_when_addressed_only and not self._addressed_to_me(message):
+            respond = False  # respond-gate — not addressed, stay silent but record
+        else:
+            respond = True
+        return {"user_id": str(chat.id), "speaker_tag": speaker_tag, "respond": respond}
+
+    def _remember_chat(self, convo_user: str, folded) -> None:
+        """Note the chat to route an approval prompt back to (keyed by the
+        conversational id, so a group's approval lands in the group)."""
+        if folded is None:
+            return
+        try:
+            self._last_chat_for_user[int(convo_user)] = folded
+        except TypeError, ValueError:
+            pass
+
     async def _on_text(self, update: Update, context) -> None:
         user = update.effective_user
         message = update.message
         chat = update.effective_chat
         if not user or not message:
             return
-        user_id = user.id
+        sender_id = user.id
         folded = self._fold(chat, message)
-        if folded is not None:
-            self._last_chat_for_user[user_id] = folded
-        if not self._is_allowed(user_id):
+        routing = self._turn_routing(update, message, context)
+        convo_user = routing["user_id"]
+        self._remember_chat(convo_user, folded)
+        if not self._is_allowed(sender_id):
             return
 
-        chat_id = folded if folded is not None else user_id
+        chat_id = folded if folded is not None else sender_id
         reply_context = self._reply_context(message)
         text = (message.text or "").strip()
-        payload = f"{reply_context}{text}" if reply_context else text
+        # Don't tag slash-commands — they're explicit and the tag would break the
+        # bare "/new" / "/clear" match (which already strips the @bot suffix).
+        tag = "" if text.startswith("/") else routing["speaker_tag"]
+        payload = f"{tag}{reply_context}{text}"
         asyncio.create_task(
-            self._handle_text(payload, user_id, chat_id),
-            name=f"tg-text-{user_id}",
+            self._handle_text(payload, convo_user, str(chat_id), routing["respond"]),
+            name=f"tg-text-{convo_user}",
         )
 
     async def _on_voice(self, update: Update, context) -> None:
@@ -180,14 +301,30 @@ class TelegramChannel:
         chat = update.effective_chat
         if not user or not message:
             return
-        user_id = user.id
+        sender_id = user.id
         folded = self._fold(chat, message)
-        if folded is not None:
-            self._last_chat_for_user[user_id] = folded
-        if not self._is_allowed(user_id):
+        routing = self._turn_routing(update, message, context)
+        convo_user = routing["user_id"]
+        self._remember_chat(convo_user, folded)
+        if not self._is_allowed(sender_id):
             return
 
-        chat_id = folded if folded is not None else user_id
+        chat_id = folded if folded is not None else sender_id
+        reply_context = self._reply_context(message)
+        prefix = f"{routing['speaker_tag']}{reply_context}"
+        # Respond-gate: a voice message we're staying silent on is recorded as a
+        # cheap placeholder — no point downloading/transcribing audio we won't
+        # answer (#30).
+        if not routing["respond"]:
+            await self.agent.process(
+                message=f"{prefix}(voice message)",
+                channel=self.channel_name,
+                user_id=str(convo_user),
+                chat_id=str(chat_id),
+                respond=False,
+            )
+            return
+
         if not self.voice:
             await self.send(
                 chat_id, "Voice messages are not supported (voice pipeline not configured)."
@@ -198,10 +335,9 @@ class TelegramChannel:
         voice_msg = message.voice or message.audio
         if not voice_msg:
             return
-        reply_context = self._reply_context(message)
         asyncio.create_task(
-            self._handle_voice(voice_msg.file_id, user_id, chat_id, reply_context),
-            name=f"tg-voice-{user_id}",
+            self._handle_voice(voice_msg.file_id, convo_user, str(chat_id), prefix),
+            name=f"tg-voice-{convo_user}",
         )
 
     async def _on_photo(self, update: Update, context) -> None:
@@ -211,15 +347,30 @@ class TelegramChannel:
         chat = update.effective_chat
         if not user or not message:
             return
-        user_id = user.id
+        sender_id = user.id
         folded = self._fold(chat, message)
-        if folded is not None:
-            self._last_chat_for_user[user_id] = folded
-        if not self._is_allowed(user_id):
+        routing = self._turn_routing(update, message, context)
+        convo_user = routing["user_id"]
+        self._remember_chat(convo_user, folded)
+        if not self._is_allowed(sender_id):
             return
 
-        chat_id = folded if folded is not None else user_id
+        chat_id = folded if folded is not None else sender_id
         caption = message.caption or ""
+        reply_context = self._reply_context(message)
+        prefix = f"{routing['speaker_tag']}{reply_context}"
+        # Respond-gate: record a placeholder for an image we're staying silent
+        # on instead of downloading it (#30).
+        if not routing["respond"]:
+            label = f"{caption} (image)" if caption else "(image)"
+            await self.agent.process(
+                message=f"{prefix}{label}",
+                channel=self.channel_name,
+                user_id=str(convo_user),
+                chat_id=str(chat_id),
+                respond=False,
+            )
+            return
 
         # Collect file IDs to download.
         # Photos: Telegram sends multiple sizes; pick the largest (last).
@@ -234,10 +385,9 @@ class TelegramChannel:
         if not file_ids:
             return
 
-        reply_context = self._reply_context(message)
         asyncio.create_task(
-            self._handle_photo(file_ids, caption, reply_context, user_id, chat_id),
-            name=f"tg-photo-{user_id}",
+            self._handle_photo(file_ids, caption, prefix, convo_user, str(chat_id)),
+            name=f"tg-photo-{convo_user}",
         )
 
     async def _on_jobs_command(self, update: Update, context) -> None:
@@ -325,8 +475,11 @@ class TelegramChannel:
         if user_id is None or not self._is_allowed(user_id):
             return
         chat_id = f"{chat.id}:{thread}"
+        # Bind under the same conversational id messages resolve with, so a group
+        # room's shared history finds the topic binding (#30).
+        convo_user = self._convo_user_id(chat, user_id)
         bound = await self.agent.bind_chat_persona_by_label(
-            self.channel_name, str(user_id), chat_id, name
+            self.channel_name, convo_user, chat_id, name
         )
         if bound:
             await self.send(chat_id, f"Bound this topic to {bound}.")
@@ -522,7 +675,20 @@ class TelegramChannel:
             return False
         return True
 
-    async def _handle_text(self, text: str, user_id: int, chat_id: int | str) -> None:
+    async def _handle_text(
+        self, text: str, user_id: str, chat_id: int | str, respond: bool = True
+    ) -> None:
+        # Respond-gate silent path (#30): record the turn for context, no typing
+        # indicator, no reply.
+        if not respond:
+            await self.agent.process(
+                message=text,
+                channel=self.channel_name,
+                user_id=str(user_id),
+                chat_id=str(chat_id),
+                respond=False,
+            )
+            return
         async with self._typing(chat_id), self._progress(chat_id):
             response = await self.agent.process(
                 message=text,
@@ -533,7 +699,7 @@ class TelegramChannel:
         await self._send_response(chat_id, response)
 
     async def _handle_voice(
-        self, file_id: str, user_id: int, chat_id: int | str, reply_context: str
+        self, file_id: str, user_id: str, chat_id: int | str, prefix: str
     ) -> None:
         async with self._typing(chat_id), self._progress(chat_id):
             file = await self.app.bot.get_file(file_id)
@@ -558,8 +724,8 @@ class TelegramChannel:
             log.info("Transcript: %s", transcript[:200])
 
             content = f"[voice] {transcript}"
-            if reply_context:
-                content = f"{reply_context}{content}"
+            if prefix:
+                content = f"{prefix}{content}"
             response = await self.agent.process(
                 message=content,
                 channel=self.channel_name,
@@ -572,8 +738,8 @@ class TelegramChannel:
         self,
         file_ids: list[tuple[str, str | None]],
         caption: str,
-        reply_context: str,
-        user_id: int,
+        prefix: str,
+        user_id: str,
         chat_id: int | str,
     ) -> None:
         from core.models import IMAGE_MIME_TYPES, Attachment
@@ -603,8 +769,8 @@ class TelegramChannel:
                 return
 
             content = caption.strip()
-            if reply_context:
-                content = f"{reply_context}{content}" if content else reply_context
+            if prefix:
+                content = f"{prefix}{content}" if content else prefix
             response = await self.agent.process(
                 message=content,
                 channel=self.channel_name,

--- a/config.yml.example
+++ b/config.yml.example
@@ -24,6 +24,18 @@ channels:
     allowed_user_ids: "${TELEGRAM_ALLOWED_USER_IDS}"
     # Opt-in: treat each forum topic as its own persona-bound context (#14).
     topics_enabled: false
+    # Multi-agent group rooms (#30) — turn-taking + loop guard + speaker tags.
+    # Lets several persona-bots share one group without all answering every
+    # message or looping replies at each other. Inherited by per-persona bots.
+    # NOTE: a bot only receives *unaddressed* group messages (the shared context)
+    # when its Telegram privacy mode is OFF (set via @BotFather → /setprivacy).
+    group_chat:
+      enabled: true
+      # Reply only when addressed (@mentioned or replying to this bot). Set false
+      # to reply to every human message in the group.
+      reply_when_addressed_only: true
+      # Never reply to another bot's messages (still recorded for context).
+      ignore_bots: true
   whatsapp:
     enabled: false
     bridge_url: "local-wacli"

--- a/config.yml.example
+++ b/config.yml.example
@@ -27,10 +27,13 @@ channels:
     # Multi-agent group rooms (#30) — turn-taking + loop guard + speaker tags.
     # Lets several persona-bots share one group without all answering every
     # message or looping replies at each other. Inherited by per-persona bots.
+    # Opt-in (off by default): enabling it makes a bot reply only when addressed
+    # and re-keys group history from per-sender to per-group (no migration; prior
+    # group history is not carried forward).
     # NOTE: a bot only receives *unaddressed* group messages (the shared context)
     # when its Telegram privacy mode is OFF (set via @BotFather → /setprivacy).
     group_chat:
-      enabled: true
+      enabled: false
       # Reply only when addressed (@mentioned or replying to this bot). Set false
       # to reply to every human message in the group.
       reply_when_addressed_only: true

--- a/core/agent.py
+++ b/core/agent.py
@@ -2488,7 +2488,11 @@ class AgentCore:
             return
         text = self._history_message_text(message, attachments)
         # Cap a single folded run so a high-traffic, never-addressed group can't
-        # grow one turn without bound; a fresh turn then ages out via windowing.
+        # grow one turn without bound. A fresh turn then ages out via windowing in
+        # injection mode; in session mode it persists until the next reply triggers
+        # _maybe_compact, so a sustained never-addressed flood can bloat the session
+        # — acceptable behind the opt-in group_chat flag. ponytail: add a per-chat
+        # record budget only if a real room ever shows write abuse.
         cap = _SILENT_FOLD_MAX_CHARS
         try:
             if self.history_mode == "session":

--- a/core/agent.py
+++ b/core/agent.py
@@ -62,6 +62,17 @@ def _shell_quote(s: str) -> str:
     return shlex.quote(s)
 
 
+def _strip_command_suffix(message: str) -> str:
+    """Normalise a slash command for matching: lower-cased and with any
+    ``@botname`` suffix removed (Telegram appends it to group commands, e.g.
+    ``/new@coach``). Non-commands are returned lower-cased and stripped, so a
+    normal message is matched verbatim by the caller."""
+    text = message.strip()
+    if text.startswith("/"):
+        text = text.split("@", 1)[0]
+    return text.lower()
+
+
 # -- Tool definitions the LLM can call --
 
 TOOLS = [
@@ -646,6 +657,7 @@ class AgentCore:
         attachments: list[Attachment] | None = None,
         chat_id: str = "",
         persona_name: str | None = None,
+        respond: bool = True,
     ) -> AgentResponse:
         """Process an incoming message through the LLM with tool-use loop.
 
@@ -658,10 +670,24 @@ class AgentCore:
         channel/binding ladder — used by the scheduler so a ``telegram:<persona>``
         job is generated *as* that persona while keeping the ``system`` execution
         mode (auto-approved writes, no memory/reflection) (#29).
+
+        ``respond=False`` records the message into history for context but
+        generates no reply — the respond-gate for group rooms (#30): a bot stays
+        silent for messages not addressed to it (and for other bots' messages),
+        yet still sees them as inbound turns when it is later addressed. No
+        persona, preamble, or LLM call runs on this path.
         """
 
-        # Handle /new (alias /clear) command — clear conversational context.
-        if message.strip().lower() in ("/new", "/clear"):
+        # Respond-gate (#30): record the turn for context, but do not reply. Runs
+        # before everything else so a suppressed message costs only a DB write.
+        if not respond:
+            await self._record_inbound(channel, user_id, chat_id, message, attachments)
+            return AgentResponse(text="")
+
+        # Handle /new (alias /clear) command — clear conversational context. In a
+        # group the command arrives as "/new@botname"; strip the @-suffix so the
+        # addressed bot still honours it.
+        if _strip_command_suffix(message) in ("/new", "/clear"):
             if self.history_mode == "session":
                 await self.history.clear_session(channel, user_id, chat_id)
             else:
@@ -2426,6 +2452,44 @@ class AgentCore:
                     await self.history.add_turn(channel, user_id, "assistant", framed, chat_id)
         except Exception:
             log.exception("Failed to record subagent context (chat=%s)", chat_id)
+
+    async def _record_inbound(
+        self,
+        channel: str,
+        user_id: str,
+        chat_id: str,
+        message: str,
+        attachments: list[Attachment] | None = None,
+    ) -> None:
+        """Record an inbound message as a user turn without generating a reply —
+        the respond-gate's silent path for group rooms (#30).
+
+        Folds into the trailing user turn (mirroring ``_record_subagent_context``)
+        so a run of un-answered group messages stays a single turn and the
+        replayed history keeps strict user/assistant alternation. ``message``
+        already carries its ``[from <author>]`` speaker tag, so the bot sees who
+        said what when it is later addressed.
+        """
+        if channel == "system":
+            return
+        text = self._history_message_text(message, attachments)
+        try:
+            if self.history_mode == "session":
+                merged = await self.history.append_to_last_session_message(
+                    channel, user_id, f"\n\n{text}", chat_id, role="user"
+                )
+                if not merged:
+                    await self.history.append_session_message(
+                        channel, user_id, {"role": "user", "content": text}, chat_id
+                    )
+            else:
+                merged = await self.history.append_to_last_turn(
+                    channel, user_id, "user", f"\n\n{text}", chat_id
+                )
+                if not merged:
+                    await self.history.add_turn(channel, user_id, "user", text, chat_id)
+        except Exception:
+            log.exception("Failed to record silent inbound turn (chat=%s)", chat_id)
 
     @staticmethod
     def _usage_total(usage: dict | None) -> int:

--- a/core/agent.py
+++ b/core/agent.py
@@ -56,6 +56,12 @@ log = logging.getLogger(__name__)
 # hash so repeated identical images don't re-hit the vision model.
 _VISION_CACHE_MAX = 256
 
+# Max characters a single folded run of silent group turns (#30) may reach
+# before a fresh turn is started, so a busy never-addressed room can't grow one
+# history row without bound. ponytail: generous char cap; raise if one
+# un-addressed run legitimately needs more context than this.
+_SILENT_FOLD_MAX_CHARS = 16000
+
 
 def _shell_quote(s: str) -> str:
     """Quote a string for safe shell interpolation."""
@@ -2468,15 +2474,32 @@ class AgentCore:
         so a run of un-answered group messages stays a single turn and the
         replayed history keeps strict user/assistant alternation. ``message``
         already carries its ``[from <author>]`` speaker tag, so the bot sees who
-        said what when it is later addressed.
+        said what when it is later addressed. A refused fold (trailing turn is an
+        assistant reply, a structured tool turn, or the cap below is hit) just
+        starts a fresh user turn — ``_coalesce_user_messages`` merges the run back
+        into one before the next LLM call, so alternation always holds.
+
+        ponytail: the fold is a non-locked read-modify-write, so two silent
+        records racing in one busy group can drop a line of ambient context (never
+        a reply). Add a per-(channel,user,chat) asyncio.Lock around process() if a
+        room ever shows missing turns.
         """
         if channel == "system":
             return
         text = self._history_message_text(message, attachments)
+        # Cap a single folded run so a high-traffic, never-addressed group can't
+        # grow one turn without bound; a fresh turn then ages out via windowing.
+        cap = _SILENT_FOLD_MAX_CHARS
         try:
             if self.history_mode == "session":
                 merged = await self.history.append_to_last_session_message(
-                    channel, user_id, f"\n\n{text}", chat_id, role="user"
+                    channel,
+                    user_id,
+                    f"\n\n{text}",
+                    chat_id,
+                    role="user",
+                    text_only=True,
+                    max_len=cap,
                 )
                 if not merged:
                     await self.history.append_session_message(
@@ -2484,7 +2507,7 @@ class AgentCore:
                     )
             else:
                 merged = await self.history.append_to_last_turn(
-                    channel, user_id, "user", f"\n\n{text}", chat_id
+                    channel, user_id, "user", f"\n\n{text}", chat_id, max_len=cap
                 )
                 if not merged:
                     await self.history.add_turn(channel, user_id, "user", text, chat_id)

--- a/core/config.py
+++ b/core/config.py
@@ -89,6 +89,36 @@ class AgentConfig(BaseModel):
     personalia: str = ""
 
 
+class GroupChatConfig(BaseModel):
+    """Multi-agent group rooms — turn-taking + loop guard + speaker tags (#30).
+
+    Lets several persona-bots share one Telegram group without the raw misbehaviour
+    (every bot answering every message; bots looping replies at each other). In a
+    group/supergroup a bot:
+
+    - replies only when **addressed** — @mentioned or replying to one of its own
+      messages (``reply_when_addressed_only``); otherwise it stays silent but still
+      records the turn for context,
+    - **ignores other bots** so two assistants never loop replying to each other
+      (``ignore_bots``); their messages are still recorded for context,
+    - records every message it sees with a ``[from <author>]`` speaker tag, so a
+      persona is never confused about who said what in the shared history.
+
+    Receiving the unaddressed messages that feed the shared context requires the
+    bot's Telegram **privacy mode to be OFF** (set via BotFather). With privacy
+    mode on (the default) a bot only receives messages addressed to it, so the
+    gate is moot and no shared context accumulates. Telegram-only: WhatsApp uses a
+    single number, so multi-bot rooms don't apply there.
+    """
+
+    enabled: bool = True
+    # Respond-gate: only reply when addressed. False = reply to every human message
+    # in the group (still ignoring bots / tagging speakers).
+    reply_when_addressed_only: bool = True
+    # Loop guard: never reply to a message authored by another bot (record only).
+    ignore_bots: bool = True
+
+
 class TelegramConfig(BaseModel):
     enabled: bool = False
     bot_token: str = ""
@@ -96,6 +126,8 @@ class TelegramConfig(BaseModel):
     # Opt-in: fold forum topics into separate contexts (one persona per topic).
     # Off by default so the plain 1:1 DM flow is unchanged.
     topics_enabled: bool = False
+    # Group multi-agent room behaviour (#30); inherited by per-persona bots.
+    group_chat: GroupChatConfig = Field(default_factory=GroupChatConfig)
 
     @field_validator("allowed_user_ids", mode="before")
     @classmethod

--- a/core/config.py
+++ b/core/config.py
@@ -109,9 +109,14 @@ class GroupChatConfig(BaseModel):
     mode on (the default) a bot only receives messages addressed to it, so the
     gate is moot and no shared context accumulates. Telegram-only: WhatsApp uses a
     single number, so multi-bot rooms don't apply there.
+
+    Off by default (like ``topics_enabled``) so existing single-bot group flows
+    are unchanged on upgrade: enabling it makes a bot reply only when addressed
+    and re-keys a group's history from per-sender to per-group (no migration —
+    prior group history is simply not carried forward).
     """
 
-    enabled: bool = True
+    enabled: bool = False
     # Respond-gate: only reply when addressed. False = reply to every human message
     # in the group (still ignoring bots / tagging speakers).
     reply_when_addressed_only: bool = True

--- a/core/history.py
+++ b/core/history.py
@@ -282,7 +282,13 @@ class ConversationHistory:
             await db.commit()
 
     async def append_to_last_turn(
-        self, channel: str, user_id: str, role: str, suffix: str, chat_id: str = ""
+        self,
+        channel: str,
+        user_id: str,
+        role: str,
+        suffix: str,
+        chat_id: str = "",
+        max_len: int | None = None,
     ) -> bool:
         """Append ``suffix`` to the most recent turn iff it has ``role`` and text
         content. Returns False when there is no such turn (caller adds a fresh one).
@@ -290,6 +296,10 @@ class ConversationHistory:
         Used to fold an out-of-band assistant message (a background subagent's
         result) into the trailing assistant turn so the replayed history keeps
         strict user/assistant alternation. (injection mode)
+
+        ``max_len`` refuses the fold (returns False) once the turn would exceed
+        that many characters, so a long run of folded turns can't grow one row
+        without bound — the caller then starts a fresh turn (#30).
         """
         await self._ensure_schema()
         async with aiosqlite.connect(self.db_path) as db:
@@ -305,6 +315,8 @@ class ConversationHistory:
             content = json.loads(row["content"])
             if not isinstance(content, str):
                 return False
+            if max_len is not None and len(content) + len(suffix) > max_len:
+                return False
             await db.execute(
                 "UPDATE conversation_turns SET content = ? WHERE id = ?",
                 (json.dumps(content + suffix), row["id"]),
@@ -313,10 +325,23 @@ class ConversationHistory:
         return True
 
     async def append_to_last_session_message(
-        self, channel: str, user_id: str, suffix: str, chat_id: str = "", role: str = "assistant"
+        self,
+        channel: str,
+        user_id: str,
+        suffix: str,
+        chat_id: str = "",
+        role: str = "assistant",
+        text_only: bool = False,
+        max_len: int | None = None,
     ) -> bool:
         """Session-mode counterpart of :meth:`append_to_last_turn`: fold ``suffix``
-        into the last session message iff it has ``role``. Returns False otherwise."""
+        into the last session message iff it has ``role``. Returns False otherwise.
+
+        ``text_only`` refuses to fold into a non-string (list) content — used by
+        the silent group-record path so it never mutates a structured message such
+        as an in-flight Anthropic ``tool_result`` turn (#30). ``max_len`` bounds
+        the folded turn's growth like :meth:`append_to_last_turn`.
+        """
         await self._ensure_schema()
         key = (channel, user_id, chat_id)
         if key not in self._sessions:
@@ -327,8 +352,12 @@ class ConversationHistory:
         msg = session[-1]
         content = msg.get("content")
         if isinstance(content, str):
+            if max_len is not None and len(content) + len(suffix) > max_len:
+                return False
             msg["content"] = content + suffix
         elif isinstance(content, list):
+            if text_only:
+                return False
             content.append({"type": "text", "text": suffix})
         else:
             return False

--- a/core/llm.py
+++ b/core/llm.py
@@ -131,6 +131,40 @@ def _openai_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return converted
 
 
+def _as_content_blocks(content: Any) -> list[dict[str, Any]]:
+    """Normalise a message ``content`` to a list of content-part blocks."""
+    if isinstance(content, list):
+        return content
+    return [{"type": "text", "text": content if isinstance(content, str) else str(content)}]
+
+
+def _coalesce_user_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge consecutive ``user`` messages into one, so a run of user turns is
+    sent as a single turn.
+
+    Group multi-agent rooms (#30) record every message they see — including ones
+    the bot stays silent on — so the replayed history can hold several user turns
+    in a row before the bot's reply. Anthropic requires strict user/assistant
+    alternation, so this normalises the array right before the API call instead of
+    making every caller track it. String contents join with a blank line; anything
+    multimodal falls back to concatenated content-part blocks (valid for both
+    Anthropic and the OpenAI-compatible providers). Assistant/tool messages are
+    left untouched — only plain user turns are ever produced back-to-back.
+    """
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        if out and out[-1].get("role") == "user" and msg.get("role") == "user":
+            prev, cur = out[-1].get("content"), msg.get("content")
+            if isinstance(prev, str) and isinstance(cur, str):
+                merged: Any = f"{prev}\n\n{cur}"
+            else:
+                merged = _as_content_blocks(prev) + _as_content_blocks(cur)
+            out[-1] = {**out[-1], "content": merged}
+        else:
+            out.append(dict(msg))
+    return out
+
+
 def _normalize_provider(provider: str) -> str:
     value = (provider or "").strip().lower()
     return value or "anthropic"
@@ -229,6 +263,9 @@ class LLMClient:
         max_tokens: int = 4096,
     ) -> LLMResponse:
         resolved_model = _normalize_model(self.provider, model)
+        # Collapse any run of consecutive user turns (group rooms record silent
+        # turns between replies, #30) so the array honours strict alternation.
+        messages = _coalesce_user_messages(messages)
         if self.provider == "anthropic":
             client_any = cast(Any, self._client)
             messages_client = cast(Any, getattr(client_any, "messages"))  # type: ignore[attr-defined]

--- a/core/main.py
+++ b/core/main.py
@@ -124,6 +124,7 @@ async def _start_agent(config_store: ConfigStore):
                 bot_token=token,
                 allowed_user_ids=persona.allowed_user_ids or tg_global.allowed_user_ids,
                 topics_enabled=tg_global.topics_enabled,
+                group_chat=tg_global.group_chat,  # inherit group-room behaviour (#30)
             )
             await _start_tg(pconf, f"telegram:{persona.name}", f"telegram:{persona.name}")
 

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -25,8 +25,8 @@ channels:
     bot_token: "${TELEGRAM_BOT_TOKEN}"
     allowed_user_ids: "${TELEGRAM_ALLOWED_USER_IDS}"
     topics_enabled: false   # opt-in: one persona-bound context per forum topic
-    group_chat:             # multi-agent group rooms (turn-taking + loop guard)
-      enabled: true
+    group_chat:             # opt-in: multi-agent group rooms (turn-taking + loop guard)
+      enabled: false
       reply_when_addressed_only: true
       ignore_bots: true
 ```
@@ -60,12 +60,14 @@ would loop replying to each other forever. The `group_chat` block fixes the turn
 channels:
   telegram:
     group_chat:
-      enabled: true                    # group-room behaviour (default on)
+      enabled: false                   # opt-in; off by default
       reply_when_addressed_only: true  # reply only when @mentioned or replied-to
       ignore_bots: true                # never reply to another bot (loop guard)
 ```
 
-In a group or supergroup each bot:
+Group rooms are **off by default** (like `topics_enabled`), so existing single-bot
+groups are unchanged on upgrade. Turn it on for a group where you've added several
+persona-bots. In a group or supergroup each bot then:
 
 - **replies only when addressed** — @mentioned, or you reply to one of its messages.
   Otherwise it stays silent but still records the message, so it has the full
@@ -86,6 +88,17 @@ In a group or supergroup each bot:
 > [@BotFather](https://t.me/BotFather): `/setprivacy` → pick the bot → **Disable**.
 > With privacy mode on, the gate still works — each bot simply only ever sees the
 > messages aimed at it.
+
+A few details worth knowing:
+
+- **Clearing context** — in a group, clear a specific bot with `/new@botname` (a bare
+  `/new` is not addressed to any one bot, so it's recorded as context, not a clear).
+- **Forum topics** — if you also use `topics_enabled`, genuine forum-topic messages keep
+  their per-topic 1:1 behaviour (the bound persona replies without an @mention); group
+  turn-taking applies to the rest of the group.
+- **Upgrade note** — enabling group rooms re-keys a group's history from per-sender to
+  per-group, so a previously-active group starts fresh (old per-sender history is left in
+  place, just not carried forward).
 
 The autonomous "bots debate each other" loop is intentionally out of scope — start
 with human-addressed turns. Group rooms are Telegram-only (WhatsApp uses a single

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -25,6 +25,10 @@ channels:
     bot_token: "${TELEGRAM_BOT_TOKEN}"
     allowed_user_ids: "${TELEGRAM_ALLOWED_USER_IDS}"
     topics_enabled: false   # opt-in: one persona-bound context per forum topic
+    group_chat:             # multi-agent group rooms (turn-taking + loop guard)
+      enabled: true
+      reply_when_addressed_only: true
+      ignore_bots: true
 ```
 
 ### Features
@@ -35,6 +39,7 @@ channels:
 - **User ID whitelist** — only allowed users can interact with the bot
 - **Forum topics** (opt-in) — with `topics_enabled`, each topic in a group becomes its own context with its own bound persona; see [Per-chat personae](/docs/personae#per-chat-personae)
 - **Bot-per-persona** (opt-in) — give a persona its own bot token and it becomes a separate Telegram contact, running alongside the default bot in the same process; see below
+- **Group rooms** — several persona-bots share one group sanely: each replies only when addressed, ignores other bots, and tags who said what; see below
 
 ### Bot-per-persona
 
@@ -44,6 +49,47 @@ contact. Each persona-bot registers as the channel `telegram:<persona>`, isolati
 history, approvals, and scheduled jobs from the default bot and from every other persona.
 Configure it on the persona and restart the agent — see
 [Bot-per-persona](/docs/personae#bot-per-persona).
+
+### Group rooms (multi-agent turn-taking)
+
+Once each persona is its own bot, adding several to one Telegram group is natural —
+but the raw behaviour is wrong: every bot would answer every message, and two bots
+would loop replying to each other forever. The `group_chat` block fixes the turn-taking:
+
+```yaml
+channels:
+  telegram:
+    group_chat:
+      enabled: true                    # group-room behaviour (default on)
+      reply_when_addressed_only: true  # reply only when @mentioned or replied-to
+      ignore_bots: true                # never reply to another bot (loop guard)
+```
+
+In a group or supergroup each bot:
+
+- **replies only when addressed** — @mentioned, or you reply to one of its messages.
+  Otherwise it stays silent but still records the message, so it has the full
+  conversation in context the next time it *is* addressed. This is also the cost
+  control: a group message naively hits every bot = N× LLM calls; the gate means
+  only the addressed bot runs inference. Set `reply_when_addressed_only: false` to
+  have a bot reply to every human message instead.
+- **ignores other bots** — another bot's messages are recorded for context but never
+  trigger a reply, so two assistants can't loop. Set `ignore_bots: false` to allow it.
+- **tags every speaker** — each message a bot sees is recorded with a `[from <author>]`
+  prefix (`(bot)` for bots), so a persona is never confused about who said what in the
+  shared history. All participants share one conversation per bot (keyed by the group,
+  not the sender).
+
+> **Privacy mode.** A Telegram bot only receives messages **addressed to it** unless
+> its **privacy mode is OFF**. To let bots see the wider conversation (the shared
+> context that makes tagging and silent recording useful), disable privacy mode in
+> [@BotFather](https://t.me/BotFather): `/setprivacy` → pick the bot → **Disable**.
+> With privacy mode on, the gate still works — each bot simply only ever sees the
+> messages aimed at it.
+
+The autonomous "bots debate each other" loop is intentionally out of scope — start
+with human-addressed turns. Group rooms are Telegram-only (WhatsApp uses a single
+number, so multi-bot rooms don't apply).
 
 ### Permission approvals
 

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -241,6 +241,32 @@ class TestPartialRoutes:
         assert "ch-tg-group-addressed" in resp.text
         assert "ch-tg-group-ignorebots" in resp.text
 
+    def test_save_telegram_vaulted_token_allows_group_chat(self):
+        """A vault-managed token (empty readonly field) must not block saving the
+        group_chat / topics toggles (#30)."""
+        store = _ConfigStoreStub(setup_complete=True)
+        store._data["channels.telegram.bot_token"] = "${vault:TELEGRAM_BOT_TOKEN}"
+        agent_state = AgentState(agent=cast(Any, _AgentStub()))
+        app, _ = create_admin_app(agent_state, cast(ConfigStore, store))
+        client = TestClient(app, follow_redirects=False)
+        resp = client.post(
+            "/channels/telegram",
+            headers=AUTH,
+            json={
+                "bot_token": "",  # vaulted → field is empty
+                "user_ids": "1",
+                "enabled": True,
+                "group_chat_enabled": True,
+                "group_reply_addressed_only": False,
+                "group_ignore_bots": True,
+            },
+        )
+        assert resp.status_code == 200  # not 400, despite the empty token
+        assert store._data["channels.telegram.group_chat.enabled"] == "true"
+        assert store._data["channels.telegram.group_chat.reply_when_addressed_only"] == "false"
+        # The vault ref is left untouched (not overwritten with an empty token).
+        assert store._data["channels.telegram.bot_token"] == "${vault:TELEGRAM_BOT_TOKEN}"
+
     def test_logs_partial(self):
         client = _client(setup_complete=True)
         resp = client.get("/partials/logs", headers=AUTH)

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -231,6 +231,16 @@ class TestPartialRoutes:
         assert "reply_decision.enabled" in resp.text
         assert "reply_decision.max_replies_per_window" in resp.text
 
+    def test_telegram_wizard_has_group_chat(self):
+        client = _client(setup_complete=True)
+        resp = client.get("/channels/wizard?channel=telegram", headers=AUTH)
+        assert resp.status_code == 200
+        assert "Group multi-agent rooms" in resp.text
+        # All three toggles are wired so the save can POST them.
+        assert "ch-tg-group" in resp.text
+        assert "ch-tg-group-addressed" in resp.text
+        assert "ch-tg-group-ignorebots" in resp.text
+
     def test_logs_partial(self):
         client = _client(setup_complete=True)
         resp = client.get("/partials/logs", headers=AUTH)

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -55,6 +55,24 @@ async def test_embedding_config_roundtrips_to_nested_model(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_group_chat_config_roundtrips_to_nested_model(tmp_path) -> None:
+    """UI-saved flat channels.telegram.group_chat.* keys reconstruct GroupChatConfig (#30)."""
+    store = ConfigStore(db_path=str(tmp_path / "config.db"))
+    await store.set_many(
+        {
+            "channels.telegram.group_chat.enabled": "true",
+            "channels.telegram.group_chat.reply_when_addressed_only": "false",
+            "channels.telegram.group_chat.ignore_bots": "true",
+        }
+    )
+    config = await store.export_to_config()
+    gc = config.channels.telegram.group_chat
+    assert gc.enabled is True
+    assert gc.reply_when_addressed_only is False
+    assert gc.ignore_bots is True
+
+
+@pytest.mark.asyncio
 async def test_set_get_delete(tmp_path) -> None:
     store = ConfigStore(db_path=str(tmp_path / "config.db"))
 

--- a/tests/test_group_chat.py
+++ b/tests/test_group_chat.py
@@ -1,0 +1,357 @@
+"""Group multi-agent rooms — turn-taking, loop guard, speaker tags (#30).
+
+Covers the three required behaviours from the issue:
+- respond-gate (reply only when addressed; otherwise record the turn silently),
+- loop guard (never reply to another bot, but still record it),
+- speaker tagging (each inbound turn carries a [from <author>] tag),
+plus the alternation-safety net (consecutive user turns are coalesced before the
+LLM call) and the /new@bot command normalisation.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.agent import AgentCore, _strip_command_suffix
+from core.config import GroupChatConfig, TelegramConfig
+from core.history import ConversationHistory
+from core.llm import _coalesce_user_messages
+
+# ---------------------------------------------------------------------------
+# _coalesce_user_messages — the alternation safety net
+# ---------------------------------------------------------------------------
+
+
+def test_coalesce_merges_consecutive_user_strings() -> None:
+    out = _coalesce_user_messages(
+        [{"role": "user", "content": "a"}, {"role": "user", "content": "b"}]
+    )
+    assert out == [{"role": "user", "content": "a\n\nb"}]
+
+
+def test_coalesce_leaves_alternating_untouched() -> None:
+    msgs = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "x"},
+        {"role": "user", "content": "b"},
+    ]
+    assert _coalesce_user_messages(msgs) == msgs
+
+
+def test_coalesce_does_not_merge_assistant_or_tool() -> None:
+    msgs = [
+        {"role": "assistant", "content": "x"},
+        {"role": "assistant", "content": "y"},  # would never happen, must stay split
+        {"role": "user", "content": "a"},
+        {"role": "tool", "content": "t"},
+    ]
+    assert _coalesce_user_messages(msgs) == msgs
+
+
+def test_coalesce_runs_of_three() -> None:
+    out = _coalesce_user_messages(
+        [
+            {"role": "user", "content": "1"},
+            {"role": "user", "content": "2"},
+            {"role": "user", "content": "3"},
+        ]
+    )
+    assert out == [{"role": "user", "content": "1\n\n2\n\n3"}]
+
+
+def test_coalesce_mixed_string_and_blocks_falls_back_to_blocks() -> None:
+    out = _coalesce_user_messages(
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "user", "content": [{"type": "text", "text": "world"}, {"type": "image"}]},
+        ]
+    )
+    assert out == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hello"},
+                {"type": "text", "text": "world"},
+                {"type": "image"},
+            ],
+        }
+    ]
+
+
+def test_coalesce_does_not_mutate_input() -> None:
+    msgs = [{"role": "user", "content": "a"}, {"role": "user", "content": "b"}]
+    _coalesce_user_messages(msgs)
+    assert msgs == [{"role": "user", "content": "a"}, {"role": "user", "content": "b"}]
+
+
+def test_coalesce_empty() -> None:
+    assert _coalesce_user_messages([]) == []
+
+
+# ---------------------------------------------------------------------------
+# _strip_command_suffix — /new@bot normalisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("/new", "/new"),
+        ("/new@coachbot", "/new"),
+        ("  /Clear  ", "/clear"),
+        ("/CLEAR@Bot", "/clear"),
+        ("hello there", "hello there"),
+        ("email bob@example.com", "email bob@example.com"),  # not a command, no @-split
+    ],
+)
+def test_strip_command_suffix(raw: str, expected: str) -> None:
+    assert _strip_command_suffix(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# AgentCore.process(respond=False) — the silent record path
+# ---------------------------------------------------------------------------
+
+
+def _bare_agent(tmp_path, mode: str) -> AgentCore:
+    config = MagicMock()
+    config.history.db_path = str(tmp_path / "agent.db")
+    config.history.max_turns = 10
+    config.history.mode = mode
+    agent = object.__new__(AgentCore)
+    agent.config = config
+    agent.history = ConversationHistory(db_path=config.history.db_path, max_turns=10)
+    agent.history_mode = mode
+    return agent
+
+
+async def _silent(agent: AgentCore, message: str):
+    return await agent.process(
+        message, channel="telegram", user_id="g1", chat_id="g1", respond=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_silent_record_injection_returns_empty_and_stores(tmp_path) -> None:
+    agent = _bare_agent(tmp_path, "injection")
+    resp = await _silent(agent, "[from Bob]\nhi all")
+    assert resp.text == ""
+    msgs = await agent.history.get_messages("telegram", "g1", "g1")
+    assert len(msgs) == 1
+    assert msgs[0]["role"] == "user"
+    assert msgs[0]["content"] == "[from Bob]\nhi all"
+
+
+@pytest.mark.asyncio
+async def test_silent_records_fold_into_one_user_turn(tmp_path) -> None:
+    """Several un-answered group messages stay a single user turn (alternation)."""
+    agent = _bare_agent(tmp_path, "injection")
+    await _silent(agent, "[from Bob]\none")
+    await _silent(agent, "[from Cy]\ntwo")
+    msgs = await agent.history.get_messages("telegram", "g1", "g1")
+    assert len(msgs) == 1
+    assert msgs[0]["role"] == "user"
+    assert msgs[0]["content"] == "[from Bob]\none\n\n[from Cy]\ntwo"
+
+
+@pytest.mark.asyncio
+async def test_silent_record_session_mode(tmp_path) -> None:
+    agent = _bare_agent(tmp_path, "session")
+    await _silent(agent, "[from Bob]\none")
+    await _silent(agent, "[from Cy]\ntwo")
+    session = await agent.history.get_session("telegram", "g1", "g1")
+    assert len(session) == 1
+    assert session[0]["role"] == "user"
+    assert session[0]["content"] == "[from Bob]\none\n\n[from Cy]\ntwo"
+
+
+@pytest.mark.asyncio
+async def test_silent_record_does_not_clear_on_new(tmp_path) -> None:
+    """A silent /new (unaddressed) is recorded, never honoured as a clear."""
+    agent = _bare_agent(tmp_path, "injection")
+    await agent.history.add_turn("telegram", "g1", "user", "hello", "g1")
+    await agent.history.add_turn("telegram", "g1", "assistant", "hi", "g1")
+    resp = await _silent(agent, "/new")
+    assert resp.text == ""
+    msgs = await agent.history.get_messages("telegram", "g1", "g1")
+    # The prior exchange survives (a clear would have wiped it); /new is a turn.
+    assert [m["content"] for m in msgs] == ["hello", "hi", "/new"]
+
+
+@pytest.mark.asyncio
+async def test_addressed_new_with_bot_suffix_clears(tmp_path) -> None:
+    """An addressed "/new@bot" still clears, despite the @-suffix."""
+    agent = _bare_agent(tmp_path, "injection")
+    await agent.history.add_turn("telegram", "g1", "user", "hello", "g1")
+    await agent.history.add_turn("telegram", "g1", "assistant", "hi", "g1")
+    resp = await agent.process("/new@coachbot", channel="telegram", user_id="g1", chat_id="g1")
+    assert resp.text == "Conversation cleared."
+    assert await agent.history.get_messages("telegram", "g1", "g1") == []
+
+
+# ---------------------------------------------------------------------------
+# Telegram channel routing — respond-gate, loop guard, speaker tags
+# ---------------------------------------------------------------------------
+
+
+def _channel(group_chat: GroupChatConfig | None = None, channel_name: str = "telegram"):
+    cfg = TelegramConfig(
+        enabled=True, bot_token="123456:TESTTOKEN", group_chat=group_chat or GroupChatConfig()
+    )
+    from channels.telegram import TelegramChannel
+
+    ch = TelegramChannel(cfg, MagicMock(), channel_name=channel_name)
+    ch._bot_id = 999
+    ch._bot_username = "coachbot"
+    return ch
+
+
+def _msg(text="", *, entities=None, reply_to=None, caption=None, caption_entities=None):
+    return SimpleNamespace(
+        text=text,
+        caption=caption,
+        entities=entities or [],
+        caption_entities=caption_entities or [],
+        reply_to_message=reply_to,
+    )
+
+
+def _user(uid=1, name="Alice", is_bot=False, username=None):
+    return SimpleNamespace(id=uid, full_name=name, username=username, is_bot=is_bot)
+
+
+GROUP = SimpleNamespace(id=-100, type="supergroup")
+PRIVATE = SimpleNamespace(id=1, type="private")
+
+
+def test_is_group_and_convo_user_id() -> None:
+    ch = _channel()
+    assert ch._is_group(GROUP) is True
+    assert ch._is_group(PRIVATE) is False
+    assert ch._convo_user_id(GROUP, 1) == "-100"  # shared across senders
+    assert ch._convo_user_id(PRIVATE, 7) == "7"
+
+
+def test_is_group_off_when_disabled() -> None:
+    ch = _channel(GroupChatConfig(enabled=False))
+    assert ch._is_group(GROUP) is False
+    assert ch._convo_user_id(GROUP, 1) == "1"  # falls back to per-sender
+
+
+def test_speaker_name_fallbacks() -> None:
+    ch = _channel()
+    assert ch._speaker_name(_user(name="Alice")) == "Alice"
+    assert ch._speaker_name(SimpleNamespace(id=5, full_name="", username="al")) == "al"
+    assert ch._speaker_name(SimpleNamespace(id=5, full_name="", username="")) == "5"
+    assert ch._speaker_name(None) == "Unknown"
+
+
+def test_addressed_via_mention_entity() -> None:
+    ch = _channel()
+    ent = SimpleNamespace(type="mention", offset=0, length=len("@coachbot"))
+    assert ch._addressed_to_me(_msg("@coachbot help me", entities=[ent])) is True
+
+
+def test_addressed_via_reply_to_bot() -> None:
+    ch = _channel()
+    reply = SimpleNamespace(from_user=SimpleNamespace(id=999))
+    assert ch._addressed_to_me(_msg("thanks", reply_to=reply)) is True
+
+
+def test_addressed_via_text_mention() -> None:
+    ch = _channel()
+    ent = SimpleNamespace(type="text_mention", user=SimpleNamespace(id=999))
+    assert ch._addressed_to_me(_msg("hey you", entities=[ent])) is True
+
+
+def test_not_addressed_to_another_bot() -> None:
+    ch = _channel()
+    ent = SimpleNamespace(type="mention", offset=0, length=len("@chefbot"))
+    assert ch._addressed_to_me(_msg("@chefbot hi", entities=[ent])) is False
+    reply = SimpleNamespace(from_user=SimpleNamespace(id=12345))  # someone else's msg
+    assert ch._addressed_to_me(_msg("ok", reply_to=reply)) is False
+
+
+def test_addressed_substring_fallback_for_command() -> None:
+    ch = _channel()
+    # No entities (e.g. forwarded/edge) but the handle appears verbatim.
+    assert ch._addressed_to_me(_msg("/jobs@coachbot")) is True
+
+
+def _route(ch, *, chat=GROUP, user=None, message=None):
+    user = user or _user()
+    message = message if message is not None else _msg("hello")
+    upd = SimpleNamespace(effective_user=user, effective_chat=chat, message=message)
+    ctx = SimpleNamespace(bot=SimpleNamespace(id=999, username="coachbot"))
+    return ch._turn_routing(upd, message, ctx)
+
+
+def test_routing_private_chat_is_untouched() -> None:
+    ch = _channel()
+    r = _route(ch, chat=PRIVATE, user=_user(uid=7))
+    assert r == {"user_id": "7", "speaker_tag": "", "respond": True}
+
+
+def test_routing_group_unaddressed_human_records_silently() -> None:
+    ch = _channel()
+    r = _route(ch, user=_user(name="Bob"), message=_msg("just chatting"))
+    assert r["respond"] is False
+    assert r["user_id"] == "-100"
+    assert r["speaker_tag"] == "[from Bob]\n"
+
+
+def test_routing_group_addressed_human_replies() -> None:
+    ch = _channel()
+    ent = SimpleNamespace(type="mention", offset=0, length=len("@coachbot"))
+    r = _route(ch, user=_user(name="Alice"), message=_msg("@coachbot hi", entities=[ent]))
+    assert r["respond"] is True
+    assert r["speaker_tag"] == "[from Alice]\n"
+
+
+def test_routing_loop_guard_ignores_bots_even_if_addressed() -> None:
+    ch = _channel()
+    ent = SimpleNamespace(type="mention", offset=0, length=len("@coachbot"))
+    r = _route(
+        ch,
+        user=_user(name="Chef", is_bot=True),
+        message=_msg("@coachbot hello fellow bot", entities=[ent]),
+    )
+    assert r["respond"] is False  # never reply to another bot
+    assert r["speaker_tag"] == "[from Chef (bot)]\n"  # but tagged + recorded
+
+
+def test_routing_reply_to_all_humans_when_gate_disabled() -> None:
+    ch = _channel(GroupChatConfig(reply_when_addressed_only=False))
+    r = _route(ch, user=_user(name="Bob"), message=_msg("anything"))
+    assert r["respond"] is True
+    # bots still ignored even with the address-gate off
+    r2 = _route(ch, user=_user(name="Chef", is_bot=True), message=_msg("loop?"))
+    assert r2["respond"] is False
+
+
+def test_routing_keep_bots_when_ignore_disabled() -> None:
+    ch = _channel(GroupChatConfig(ignore_bots=False))
+    ent = SimpleNamespace(type="mention", offset=0, length=len("@coachbot"))
+    chef = _user(name="Chef", is_bot=True)
+    r = _route(ch, user=chef, message=_msg("@coachbot hi", entities=[ent]))
+    assert r["respond"] is True  # addressed bot reply allowed when ignore_bots off
+
+
+# ---------------------------------------------------------------------------
+# _handle_text wiring — silent path skips typing + passes respond through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_text_silent_calls_process_respond_false() -> None:
+    ch = _channel()
+    ch.agent.process = AsyncMock()
+    await ch._handle_text("[from Bob]\nhi", "-100", "-100", respond=False)
+    ch.agent.process.assert_awaited_once()
+    kwargs = ch.agent.process.await_args.kwargs
+    assert kwargs["respond"] is False
+    assert kwargs["user_id"] == "-100"
+    assert kwargs["message"] == "[from Bob]\nhi"

--- a/tests/test_group_chat.py
+++ b/tests/test_group_chat.py
@@ -221,10 +221,10 @@ def _channel(
     return ch
 
 
-def _ent(type_, text="", *, user=None):
-    """A MessageEntity-ish double; offset/length span the LAST occurrence of
-    ``text`` so a single mention is found wherever it sits in the message."""
-    return SimpleNamespace(type=type_, offset=0, length=len(text), user=user, _seg=text)
+def _ent(type_, text="", *, user=None, offset=0):
+    """A MessageEntity-ish double. ``_seg`` is what PTB's UTF-16-safe parser
+    returns; ``offset/length`` drive the raw code-point slice fallback."""
+    return SimpleNamespace(type=type_, offset=offset, length=len(text), user=user, _seg=text)
 
 
 def _msg(
@@ -236,7 +236,13 @@ def _msg(
     caption_entities=None,
     is_topic_message=False,
 ):
-    # parse_entity returns the stashed segment, mirroring PTB's UTF-16-safe helper.
+    # Mirror PTB: parse_entity raises on a caption-only message (no .text); the
+    # caption entity must be read via parse_caption_entity instead.
+    def _parse_entity(ent):
+        if not text:
+            raise RuntimeError("This Message has no 'text'.")
+        return getattr(ent, "_seg", "")
+
     return SimpleNamespace(
         text=text,
         caption=caption,
@@ -244,7 +250,8 @@ def _msg(
         caption_entities=caption_entities or [],
         reply_to_message=reply_to,
         is_topic_message=is_topic_message,
-        parse_entity=lambda ent: getattr(ent, "_seg", ""),
+        parse_entity=_parse_entity,
+        parse_caption_entity=lambda ent: getattr(ent, "_seg", ""),
     )
 
 
@@ -287,6 +294,18 @@ def test_addressed_via_mention_entity() -> None:
 def test_addressed_via_command_entity() -> None:
     ch = _channel()
     msg = _msg("/jobs@coachbot", entities=[_ent("bot_command", "/jobs@coachbot")])
+    assert ch._addressed_to_me(msg) is True
+
+
+def test_addressed_via_photo_caption_mention() -> None:
+    """A photo caption @mention must be read via parse_caption_entity (a caption
+    message has no .text, where parse_entity raises) — and stay UTF-16-safe so an
+    emoji before the mention doesn't misalign the slice."""
+    ch = _channel()
+    # Emoji prefix: a raw code-point slice at the UTF-16 offset would be wrong;
+    # only parse_caption_entity yields the correct "@coachbot".
+    ent = _ent("mention", "@coachbot", offset=3)
+    msg = _msg(text="", caption="😀 @coachbot hi", caption_entities=[ent])
     assert ch._addressed_to_me(msg) is True
 
 

--- a/tests/test_group_chat.py
+++ b/tests/test_group_chat.py
@@ -10,6 +10,7 @@ LLM call) and the /new@bot command normalisation.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -197,9 +198,20 @@ async def test_addressed_new_with_bot_suffix_clears(tmp_path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _channel(group_chat: GroupChatConfig | None = None, channel_name: str = "telegram"):
+def _channel(
+    group_chat: GroupChatConfig | None = None,
+    channel_name: str = "telegram",
+    *,
+    topics_enabled: bool = False,
+    allowed_user_ids=None,
+):
+    # group_chat defaults OFF (opt-in); the tests want it ON to exercise the path.
     cfg = TelegramConfig(
-        enabled=True, bot_token="123456:TESTTOKEN", group_chat=group_chat or GroupChatConfig()
+        enabled=True,
+        bot_token="123456:TESTTOKEN",
+        topics_enabled=topics_enabled,
+        allowed_user_ids=allowed_user_ids or [],
+        group_chat=group_chat or GroupChatConfig(enabled=True),
     )
     from channels.telegram import TelegramChannel
 
@@ -209,13 +221,30 @@ def _channel(group_chat: GroupChatConfig | None = None, channel_name: str = "tel
     return ch
 
 
-def _msg(text="", *, entities=None, reply_to=None, caption=None, caption_entities=None):
+def _ent(type_, text="", *, user=None):
+    """A MessageEntity-ish double; offset/length span the LAST occurrence of
+    ``text`` so a single mention is found wherever it sits in the message."""
+    return SimpleNamespace(type=type_, offset=0, length=len(text), user=user, _seg=text)
+
+
+def _msg(
+    text="",
+    *,
+    entities=None,
+    reply_to=None,
+    caption=None,
+    caption_entities=None,
+    is_topic_message=False,
+):
+    # parse_entity returns the stashed segment, mirroring PTB's UTF-16-safe helper.
     return SimpleNamespace(
         text=text,
         caption=caption,
         entities=entities or [],
         caption_entities=caption_entities or [],
         reply_to_message=reply_to,
+        is_topic_message=is_topic_message,
+        parse_entity=lambda ent: getattr(ent, "_seg", ""),
     )
 
 
@@ -251,8 +280,14 @@ def test_speaker_name_fallbacks() -> None:
 
 def test_addressed_via_mention_entity() -> None:
     ch = _channel()
-    ent = SimpleNamespace(type="mention", offset=0, length=len("@coachbot"))
-    assert ch._addressed_to_me(_msg("@coachbot help me", entities=[ent])) is True
+    msg = _msg("@coachbot help me", entities=[_ent("mention", "@coachbot")])
+    assert ch._addressed_to_me(msg) is True
+
+
+def test_addressed_via_command_entity() -> None:
+    ch = _channel()
+    msg = _msg("/jobs@coachbot", entities=[_ent("bot_command", "/jobs@coachbot")])
+    assert ch._addressed_to_me(msg) is True
 
 
 def test_addressed_via_reply_to_bot() -> None:
@@ -263,22 +298,45 @@ def test_addressed_via_reply_to_bot() -> None:
 
 def test_addressed_via_text_mention() -> None:
     ch = _channel()
-    ent = SimpleNamespace(type="text_mention", user=SimpleNamespace(id=999))
+    ent = _ent("text_mention", user=SimpleNamespace(id=999))
     assert ch._addressed_to_me(_msg("hey you", entities=[ent])) is True
 
 
 def test_not_addressed_to_another_bot() -> None:
     ch = _channel()
-    ent = SimpleNamespace(type="mention", offset=0, length=len("@chefbot"))
-    assert ch._addressed_to_me(_msg("@chefbot hi", entities=[ent])) is False
+    assert ch._addressed_to_me(_msg("@chefbot hi", entities=[_ent("mention", "@chefbot")])) is False
     reply = SimpleNamespace(from_user=SimpleNamespace(id=12345))  # someone else's msg
     assert ch._addressed_to_me(_msg("ok", reply_to=reply)) is False
 
 
-def test_addressed_substring_fallback_for_command() -> None:
+def test_not_addressed_when_handle_is_prefix_of_another_bot() -> None:
+    """@coachbot must NOT consider itself addressed by a mention of @coachbotpro."""
     ch = _channel()
-    # No entities (e.g. forwarded/edge) but the handle appears verbatim.
-    assert ch._addressed_to_me(_msg("/jobs@coachbot")) is True
+    msg = _msg("@coachbotpro do X", entities=[_ent("mention", "@coachbotpro")])
+    assert ch._addressed_to_me(msg) is False
+
+
+def test_not_addressed_when_shorter_handle_is_prefix() -> None:
+    """A bot named @coach must NOT match a mention of the longer @coachbot."""
+    ch = _channel()
+    ch._bot_username = "coach"
+    msg = _msg("@coachbot hi", entities=[_ent("mention", "@coachbot")])
+    assert ch._addressed_to_me(msg) is False
+
+
+def test_not_addressed_by_email_substring() -> None:
+    """An email containing the handle (its own entity) must not address the bot."""
+    ch = _channel()
+    msg = _msg("mail me at admin@coachbot.com", entities=[_ent("email", "admin@coachbot.com")])
+    assert ch._addressed_to_me(msg) is False
+
+
+def test_entity_less_fallback_matches_with_boundary() -> None:
+    ch = _channel()
+    # No entities at all (forwarded / odd client): a bare handle still addresses.
+    assert ch._addressed_to_me(_msg("@coachbot help")) is True
+    # ...but a longer handle as a bare substring does not.
+    assert ch._addressed_to_me(_msg("@coachbotpro help")) is False
 
 
 def _route(ch, *, chat=GROUP, user=None, message=None):
@@ -305,26 +363,22 @@ def test_routing_group_unaddressed_human_records_silently() -> None:
 
 def test_routing_group_addressed_human_replies() -> None:
     ch = _channel()
-    ent = SimpleNamespace(type="mention", offset=0, length=len("@coachbot"))
-    r = _route(ch, user=_user(name="Alice"), message=_msg("@coachbot hi", entities=[ent]))
+    msg = _msg("@coachbot hi", entities=[_ent("mention", "@coachbot")])
+    r = _route(ch, user=_user(name="Alice"), message=msg)
     assert r["respond"] is True
     assert r["speaker_tag"] == "[from Alice]\n"
 
 
 def test_routing_loop_guard_ignores_bots_even_if_addressed() -> None:
     ch = _channel()
-    ent = SimpleNamespace(type="mention", offset=0, length=len("@coachbot"))
-    r = _route(
-        ch,
-        user=_user(name="Chef", is_bot=True),
-        message=_msg("@coachbot hello fellow bot", entities=[ent]),
-    )
+    msg = _msg("@coachbot hello fellow bot", entities=[_ent("mention", "@coachbot")])
+    r = _route(ch, user=_user(name="Chef", is_bot=True), message=msg)
     assert r["respond"] is False  # never reply to another bot
     assert r["speaker_tag"] == "[from Chef (bot)]\n"  # but tagged + recorded
 
 
 def test_routing_reply_to_all_humans_when_gate_disabled() -> None:
-    ch = _channel(GroupChatConfig(reply_when_addressed_only=False))
+    ch = _channel(GroupChatConfig(enabled=True, reply_when_addressed_only=False))
     r = _route(ch, user=_user(name="Bob"), message=_msg("anything"))
     assert r["respond"] is True
     # bots still ignored even with the address-gate off
@@ -333,11 +387,24 @@ def test_routing_reply_to_all_humans_when_gate_disabled() -> None:
 
 
 def test_routing_keep_bots_when_ignore_disabled() -> None:
-    ch = _channel(GroupChatConfig(ignore_bots=False))
-    ent = SimpleNamespace(type="mention", offset=0, length=len("@coachbot"))
+    ch = _channel(GroupChatConfig(enabled=True, ignore_bots=False))
     chef = _user(name="Chef", is_bot=True)
-    r = _route(ch, user=chef, message=_msg("@coachbot hi", entities=[ent]))
+    msg = _msg("@coachbot hi", entities=[_ent("mention", "@coachbot")])
+    r = _route(ch, user=chef, message=msg)
     assert r["respond"] is True  # addressed bot reply allowed when ignore_bots off
+
+
+def test_routing_forum_topic_exempt_from_group_gate() -> None:
+    """A genuine forum-topic message under topics_enabled keeps 1:1 behaviour."""
+    ch = _channel(topics_enabled=True)
+    msg = _msg("just chatting", is_topic_message=True)
+    r = _route(ch, user=_user(uid=7, name="Bob"), message=msg)
+    # No group gate: replies, no speaker tag, keyed by the sender (per-topic).
+    assert r == {"user_id": "7", "speaker_tag": "", "respond": True}
+    # A non-topic message in the same supergroup still gets group treatment.
+    r2 = _route(ch, user=_user(name="Bob"), message=_msg("hi"))
+    assert r2["respond"] is False
+    assert r2["user_id"] == "-100"
 
 
 # ---------------------------------------------------------------------------
@@ -355,3 +422,109 @@ async def test_handle_text_silent_calls_process_respond_false() -> None:
     assert kwargs["respond"] is False
     assert kwargs["user_id"] == "-100"
     assert kwargs["message"] == "[from Bob]\nhi"
+
+
+# ---------------------------------------------------------------------------
+# _on_text gate — whitelist applies to replies, not to record-only turns
+# ---------------------------------------------------------------------------
+
+
+async def _drive_on_text(ch, user, message, chat=GROUP):
+    upd = SimpleNamespace(effective_user=user, effective_chat=chat, message=message)
+    ctx = SimpleNamespace(bot=SimpleNamespace(id=999, username="coachbot"))
+    before = set(asyncio.all_tasks())
+    await ch._on_text(upd, ctx)
+    spawned = [t for t in asyncio.all_tasks() if t not in before]
+    if spawned:
+        await asyncio.gather(*spawned)
+
+
+@pytest.mark.asyncio
+async def test_whitelist_still_records_other_bots_for_context() -> None:
+    """A whitelist gates replies, but a bot's message (respond=False) is still
+    recorded — otherwise the loop guard + cross-bot speaker tags would be dead."""
+    ch = _channel(allowed_user_ids=[1])  # only human id 1 may drive the bot
+    ch.agent.process = AsyncMock()
+    chef = _user(uid=555, name="Chef", is_bot=True)
+    await _drive_on_text(ch, chef, _msg("hello fellow bot"))
+    ch.agent.process.assert_awaited_once()
+    kwargs = ch.agent.process.await_args.kwargs
+    assert kwargs["respond"] is False
+    assert kwargs["message"] == "[from Chef (bot)]\nhello fellow bot"
+
+
+@pytest.mark.asyncio
+async def test_whitelist_blocks_non_allowed_human_reply() -> None:
+    """A non-whitelisted human addressing the bot is still blocked from replies."""
+    ch = _channel(allowed_user_ids=[1])
+    ch.agent.process = AsyncMock()
+    intruder = _user(uid=2, name="Mallory")
+    msg = _msg("@coachbot do X", entities=[_ent("mention", "@coachbot")])
+    await _drive_on_text(ch, intruder, msg)
+    ch.agent.process.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_allowed_human_reply_still_works(tmp_path) -> None:
+    ch = _channel(allowed_user_ids=[1])
+    ch.agent.process = AsyncMock(
+        return_value=SimpleNamespace(voice=None, text="", system_notice=None)
+    )
+    msg = _msg("@coachbot hi", entities=[_ent("mention", "@coachbot")])
+    await _drive_on_text(ch, _user(uid=1, name="Owner"), msg)
+    ch.agent.process.assert_awaited_once()
+    # The reply path omits the respond kwarg (defaults True).
+    assert ch.agent.process.await_args.kwargs.get("respond", True) is True
+
+
+# ---------------------------------------------------------------------------
+# History safety — session tool_result fold guard + fold cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_fold_refuses_tool_result_message(tmp_path) -> None:
+    """A silent user record must not be spliced into an in-flight tool_result
+    (a role=user message whose content is a list)."""
+    hist = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    tool_result = {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "tu1"}]}
+    await hist.append_session_message("telegram", "g1", tool_result, "g1")
+    merged = await hist.append_to_last_session_message(
+        "telegram", "g1", "\n\n[from Bob]\nchatter", "g1", role="user", text_only=True
+    )
+    assert merged is False
+    session = await hist.get_session("telegram", "g1", "g1")
+    # The tool_result block list is untouched (no stray text block appended).
+    assert session[0]["content"] == [{"type": "tool_result", "tool_use_id": "tu1"}]
+
+
+@pytest.mark.asyncio
+async def test_fold_cap_refuses_when_oversized(tmp_path) -> None:
+    hist = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    await hist.add_turn("telegram", "g1", "user", "x" * 100, "g1")
+    refused = await hist.append_to_last_turn("telegram", "g1", "user", "y" * 50, "g1", max_len=120)
+    assert refused is False  # 100 + 50 > 120
+    ok = await hist.append_to_last_turn("telegram", "g1", "user", "z" * 5, "g1", max_len=120)
+    assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: silent records then a reply stay alternation-safe via coalesce
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_silent_then_reply_array_is_alternation_safe(tmp_path) -> None:
+    agent = _bare_agent(tmp_path, "injection")
+    await _silent(agent, "[from Bob]\none")
+    await _silent(agent, "[from Cy]\ntwo")
+    # Build the message array the way _process_injection does for the reply turn:
+    history = await agent.history.get_messages("telegram", "g1", "g1")
+    messages = [{"role": t["role"], "content": t["content"]} for t in history]
+    messages.append({"role": "user", "content": "preamble\n\n[from Alice]\n@coachbot help"})
+    # The raw array has a consecutive user/user pair (the silent run + the reply)...
+    raw = [m["role"] for m in messages]
+    assert any(raw[i] == raw[i + 1] == "user" for i in range(len(raw) - 1))
+    # ...which the coalescer (called inside llm.generate) collapses before the API.
+    collapsed = [m["role"] for m in _coalesce_user_messages(messages)]
+    assert all(not (collapsed[i] == collapsed[i + 1] == "user") for i in range(len(collapsed) - 1))

--- a/tests/test_markdown_tg.py
+++ b/tests/test_markdown_tg.py
@@ -97,7 +97,7 @@ def test_table_with_header():
 
 def test_pipe_in_inline_code_not_mistaken_for_table():
     """A pipe inside inline code should not trigger table conversion."""
-    src = f"Use `|` as a pipe."
+    src = "Use `|` as a pipe."
     out = to_telegram_html(src)
     assert "|" in out
 


### PR DESCRIPTION
Closes #30. Depends on #29 (bot-per-persona), already merged.

## What

Lets several persona-bots share one Telegram group without the raw misbehaviour the issue calls out: every bot answering every message, and bots looping replies at each other. The infrastructure already exists (#29 runs each persona-bot as its own polling channel; all receive the group's messages) — this PR adds only the *behaviour* layer.

The three required behaviours from the issue:

- **Respond-gate** — in a group a bot replies only when **addressed**: @mentioned, a `/cmd@bot` command, a text-mention, or a reply to one of its own messages. Otherwise it stays silent but still **records the turn** for context, so it sees the full conversation the next time it *is* addressed. No persona/preamble/LLM runs on the silent path, so this is also the cost control (a group message no longer fans out to N inferences).
- **Loop guard** — a bot never replies to a message authored by another bot (`ignore_bots`); the message is still recorded (tagged) for context, so two assistants can't loop.
- **Speaker tagging** — every recorded message carries a `[from <author>]` prefix (`(bot)` for bots). All participants share one conversation per bot, keyed by the group rather than the sender, so a persona is never confused about who said what. The existing `[reply_to]` prefix was the seed.

## How

- `channels/telegram.py` — group detected via `chat.type`; addressing decided from Telegram **entities** (exact handle / `bot_command` suffix / text-mention / reply-to), with a boundary-anchored substring match only as an entity-less last resort. Entity text is read UTF-16-safely via `parse_entity`. The `allowed_user_ids` whitelist gates the **reply/act** path only — record-only turns (no inference, no action) are still recorded, so the loop guard and cross-speaker tags work under a whitelist. For groups the conversation is keyed by the group id; the real sender drives the whitelist check and the speaker tag.
- `core/agent.py` — `process(respond=False)` records the inbound message (folded into the trailing user turn) and returns empty, running no LLM. The folded run is length-capped so a busy never-addressed group can't grow one history row without bound.
- `core/llm.py` — `generate()` coalesces consecutive same-role user turns right before the API call (both providers). Silent recording can produce consecutive user turns and Anthropic requires strict alternation; this is the one-place safety net.
- `core/config.py` — `GroupChatConfig` (`enabled` / `reply_when_addressed_only` / `ignore_bots`) nested under `TelegramConfig.group_chat`, inherited by per-persona bots.

## Scope / decisions

- **Opt-in (off by default)**, matching `topics_enabled`, so existing single-bot groups are unchanged on upgrade. Enabling it re-keys a group's history from per-sender to per-group (no migration; prior group history is left in place, not carried forward).
- A genuine **forum topic** under `topics_enabled` is exempt from the group gate — a bound per-topic persona still replies without an @mention.
- Telegram-only (WhatsApp uses a single number, so multi-bot rooms don't apply). The autonomous "bots debate each other" loop is out of scope, per the issue.
- Requires the bots' Telegram **privacy mode OFF** (via BotFather) to receive the unaddressed messages that feed the shared context — documented.

## Relationship to #36 / PR #53

#30 and #36 overlap. PR #53 (`feat/reply-decision`, open) adds the **optional LLM relevance gate + per-chat rate cap** for #36. This PR implements the **deterministic** addressing gate + loop guard + speaker tagging on `main`. They're complementary (the issue lists the relevance check as the optional rung of the same respond-gate), but both touch group-reply behaviour, so they'll want a small reconciliation when both land. Flagging for the manual review.

## Review

Built and verified through a multi-lens adversarial review; the confirmed findings are folded into the second commit (addressing precision against prefix-overlapping bot names, the whitelist-vs-recording fix, the opt-in default + topics exemption, and the session/`tool_result` fold guard).

## Tests

`tests/test_group_chat.py` (new) covers the coalescer, the silent-record fold (both history modes), addressing precision (mention / command / text-mention / reply / prefix-overlap both directions / email / entity-less boundary), routing (respond-gate, loop guard, gate-disabled, topic-exempt), the whitelist-bypass record path, the session `tool_result` fold guard, the fold cap, and the silent-then-reply alternation safety net. Full suite green (`uv run pytest` — 576 passed).

Docs: README bullet, `docs/.../channels.mdx` "Group rooms" section (with privacy-mode + upgrade + topics + `/new@bot` notes), `config.yml.example`.