### PR TITLE
feat(vault): enable secret removal from vaults (#56)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -3203,7 +3203,9 @@ def create_admin_app(
         if secret_store is None:
             return _no_vault_partial()
         form = await request.form()
-        await secret_store.delete_secret(str(form.get("name", "")).strip())
+        name = str(form.get("name", "")).strip()
+        if await secret_store.delete_secret(name):
+            log.info("Persona secret %r deleted via admin", name)
         return _render_partial("partials/secrets.html", **(await _secrets_ctx()))
 
     @app.post("/admin/secrets/grant", response_class=HTMLResponse, dependencies=[Depends(auth)])
@@ -3236,6 +3238,18 @@ def create_admin_app(
         await secret_store.set_infra_secret(
             name, str(form.get("value", "")), str(form.get("description", ""))
         )
+        return _render_partial("partials/secrets.html", **(await _secrets_ctx()))
+
+    @app.post(
+        "/admin/secrets/infra/delete", response_class=HTMLResponse, dependencies=[Depends(auth)]
+    )
+    async def delete_infra_secret(request: Request) -> HTMLResponse:
+        if secret_store is None:
+            return _no_vault_partial()
+        form = await request.form()
+        name = str(form.get("name", "")).strip()
+        if await secret_store.delete_infra_secret(name):
+            log.info("Infra secret %r deleted via admin", name)
         return _render_partial("partials/secrets.html", **(await _secrets_ctx()))
 
     # -- Secure-link credential fill flow --

--- a/api/templates/partials/secrets.html
+++ b/api/templates/partials/secrets.html
@@ -155,8 +155,16 @@
     </div>
 
     {% if infra %}
-    <ul class="text-xs font-mono mb-3">
-      {% for i in infra %}<li>{{ i.name }} <span class="text-muted">— {{ i.description }}</span></li>{% endfor %}
+    <ul class="text-xs font-mono mb-3 space-y-1">
+      {% for i in infra %}
+      <li class="flex items-center justify-between gap-2">
+        <span>{{ i.name }} <span class="text-muted">— {{ i.description }}</span></span>
+        <button class="btn-danger btn-sm"
+                hx-post="/admin/secrets/infra/delete" hx-target="#tab-content" hx-swap="innerHTML"
+                hx-confirm="Delete infra secret '{{ i.name }}'? Config referencing ${% raw %}{vault:{% endraw %}{{ i.name }}} will fall back to .env."
+                hx-vals='{"name":"{{ i.name }}"}'>Delete</button>
+      </li>
+      {% endfor %}
     </ul>
     {% endif %}
     <form hx-post="/admin/secrets/infra" hx-target="#tab-content" hx-swap="innerHTML" class="space-y-2">

--- a/docs/content/docs/secrets.mdx
+++ b/docs/content/docs/secrets.mdx
@@ -120,6 +120,12 @@ Bitwarden import, and the infra-secrets section — including the one-click **mi
 scattered credentials into the vault** action described above. It is responsive at phone
 width.
 
+Both kinds of secret can be removed: **Revoke** drops a persona secret, **Delete** drops an
+infra secret (config that still references `${vault:NAME}` then falls back to `.env`). Both
+ask for confirmation first and are logged. Deletion only removes the stored ciphertext —
+there is no recovery, so rotate by re-adding rather than delete-then-add if you need
+continuity.
+
 Over Telegram you can ask the agent to list secret names and who holds them, but **values
 are never entered or shown over chat** — sensitive entry is deep-linked to the web UI.
 

--- a/tests/test_secrets_vault.py
+++ b/tests/test_secrets_vault.py
@@ -360,6 +360,30 @@ async def test_add_and_list_secret_via_admin(admin_client) -> None:
     assert await s.get_secret("STRIPE") == "sk_live"
 
 
+async def test_delete_secret_via_admin(admin_client) -> None:
+    client, s, _cs = admin_client
+    await s.set_secret("DOOMED", "v", shared=True)
+    resp = client.post("/admin/secrets/delete", data={"name": "DOOMED"}, headers=_auth())
+    assert resp.status_code == 200 and "DOOMED" not in resp.text
+    assert await s.get_secret("DOOMED") is None
+
+
+async def test_delete_infra_secret_via_admin(tmp_path) -> None:
+    db = str(tmp_path / "config.db")
+    cs = ConfigStore(db_path=db)
+    await cs.set_setup_step("done")
+    await cs.set_admin_password("testpw")
+    s = SecretStore(db_path=db, infra_vault=InfraVault("test-machine-key"))
+    app, _ = create_admin_app(AgentState(), cs, secret_store=s)
+    client = TestClient(app)
+    await s.set_infra_secret("OPENAI_API_KEY", "sk-old")
+    resp = client.post(
+        "/admin/secrets/infra/delete", data={"name": "OPENAI_API_KEY"}, headers=_auth()
+    )
+    assert resp.status_code == 200 and "OPENAI_API_KEY" not in resp.text
+    assert await s.get_infra_secret("OPENAI_API_KEY") is None
+
+
 async def test_vault_fill_flow(admin_client) -> None:
     client, s, _cs = admin_client
     token = await s.create_request("NEWKEY", persona="", reason="need")


### PR DESCRIPTION
Closes #56.

## Problem
Secrets could be added to the vaults but only **persona** secrets could be removed (the Revoke button). **Infrastructure** secrets could be added and migrated but never deleted from the UI — `delete_infra_secret()` existed in `SecretStore` but had no route and no button, so a rotated/stale infra key was stuck forever.

## Change
- **New route** `POST /admin/secrets/infra/delete` — calls the existing `delete_infra_secret()`.
- **Delete button** per infra secret on the Secrets tab, with an `hx-confirm` prompt that warns config referencing `${vault:NAME}` falls back to `.env`.
- **Audit logging** — both persona and infra deletions now `log.info(...)` (the issue asked for an audit trail; previously deletions were silent).
- Docs: Secrets page now documents Revoke (persona) vs Delete (infra), confirmation, logging, and the no-recovery caveat.

The issue's "confirmation before deletion" was already present for persona secrets and is now matched for infra; deletion stays immediate (no soft-delete) — consistent with the existing persona Revoke.

## Tests
- `test_delete_secret_via_admin` — persona delete through the route.
- `test_delete_infra_secret_via_admin` — infra delete through the new route (machine-key store).
- Full suite: `39 passed`. Lint + format clean.