### PR TITLE
Auto-dismiss permission approval messages after user interaction

### DIFF
--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -498,17 +498,17 @@ class TelegramChannel:
         if data.startswith(_APPROVE_PREFIX):
             request_id = data[len(_APPROVE_PREFIX) :]
             resolved = self.agent.permissions.resolve_approval(request_id, True)
-            await self._finalize_approval_response(query, resolved, "Approved")
+            await self._finalize_approval_response(query, resolved, "✅ Approved")
 
         elif data.startswith(_DENY_PREFIX):
             request_id = data[len(_DENY_PREFIX) :]
             resolved = self.agent.permissions.resolve_approval(request_id, False)
-            await self._finalize_approval_response(query, resolved, "Denied")
+            await self._finalize_approval_response(query, resolved, "❌ Denied")
 
         elif data.startswith(_ALWAYS_PREFIX):
             request_id = data[len(_ALWAYS_PREFIX) :]
             resolved = self.agent.permissions.resolve_approval(request_id, True, always_allow=True)
-            await self._finalize_approval_response(query, resolved, "Always allowed")
+            await self._finalize_approval_response(query, resolved, "♾️ Always allowed")
 
         elif data.startswith(_SUB_CANCEL_PREFIX):
             run_id = data[len(_SUB_CANCEL_PREFIX) :]
@@ -872,12 +872,17 @@ class TelegramChannel:
         if not resolved:
             await query.edit_message_text("(approval request expired or already handled)")
             return
-        message = query.message
         try:
-            text = getattr(message, "text", None) if message else None
-            if text:
-                await query.edit_message_text(text + f"\n\n--- {label}")
-            else:
-                await self.app.bot.send_message(query.from_user.id, f"{label}.")
+            await query.edit_message_text(f"{label}.")
+            asyncio.create_task(self._delete_after_delay(query))
         except Exception:
             log.exception("Failed to update approval message")
+
+    async def _delete_after_delay(self, query: CallbackQuery, delay: int = 30) -> None:
+        """Delete message after a delay to keep chat clean (issue #62)."""
+        await asyncio.sleep(delay)
+        try:
+            await query.message.delete()
+        except Exception:
+            pass
+


### PR DESCRIPTION
## Problem

When the user clicks Approve/Deny/Always allow on a permission prompt, the message is edited to append `--- Approved` (or similar) but stays in the chat forever, cluttering the conversation. See #62.

## Changes

### `channels/telegram.py`

1. **Emoji labels** — Changed the approval labels to include emoji for quick visual scanning:
   - `"Approved"` → `"✅  Approved"`
   - `"Denied"` → `"❌  Denied"`
   - `"Always allowed"` → `"♾️  Always allowed"`

2. **`_finalize_approval_response`** — Instead of appending `--- {label}` to the original permission text, the message is now edited to just `{label}.` (a clean, minimal status). Then it schedules deletion via `asyncio.create_task`.

3. **`_delete_after_delay`** — New helper that waits 30 seconds, then deletes the approval message. Errors are silently caught (message already deleted, permissions changed, etc.).

### No changes to `core/permissions.py` or the agent loop

The model's context (what was approved/denied) lives in `PermissionEngine._pending` and is **unaffected** by deleting the chat message. This is purely a UI cleanup.

## How it looks

1. User sends a message that requires permission → bot posts "Permission request:\n\n..." with Approve/Deny/Always allow buttons
2. User clicks a button → message edits to "✅  Approved." (or "❌  Denied." / "♾️  Always allowed.")
3. After 30 seconds → message is silently deleted