### PR TITLE
feat(voice): advertise voice reply as a base capability

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -71,6 +71,17 @@ def _shell_quote(s: str) -> str:
     return shlex.quote(s)
 
 
+# Control marker the LLM appends to request a spoken reply (see the <voice> prompt
+# block). It is internal signalling and must never reach the user, whether or not
+# synthesis ran.
+VOICE_MARKER = "[respond_with_voice]"
+
+
+def strip_voice_marker(text: str) -> str:
+    """Remove the voice control marker so it never leaks into a user-visible reply."""
+    return text.replace(VOICE_MARKER, "").strip()
+
+
 def _strip_command_suffix(message: str) -> str:
     """Normalise a slash command for matching: lower-cased and with any
     ``@botname`` suffix removed (Telegram appends it to group commands, e.g.
@@ -1355,8 +1366,9 @@ class AgentCore:
         voice_bytes = await self._maybe_synthesize_voice(
             final_text, voice=persona.voice if persona else None
         )
-        if voice_bytes:
-            final_text = final_text.replace("[respond_with_voice]", "").strip()
+        # Strip the control marker unconditionally — it must never reach the user,
+        # even when synthesis was skipped or failed (voice_bytes is None).
+        final_text = strip_voice_marker(final_text)
 
         # Persist the turn (user message + final assistant text only)
         history_message = self._history_message_text(message, attachments)
@@ -1484,8 +1496,9 @@ class AgentCore:
         voice_bytes = await self._maybe_synthesize_voice(
             final_text, voice=persona.voice if persona else None
         )
-        if voice_bytes:
-            final_text = final_text.replace("[respond_with_voice]", "").strip()
+        # Strip the control marker unconditionally — it must never reach the user,
+        # even when synthesis was skipped or failed (voice_bytes is None).
+        final_text = strip_voice_marker(final_text)
 
         # Automatic memory extraction
         if channel != "system":
@@ -1522,8 +1535,8 @@ class AgentCore:
     async def _maybe_synthesize_voice(self, text: str, voice: str | None = None) -> bytes | None:
         """Synthesize voice if requested by the LLM, using the persona's voice
         when one is set (else the configured default)."""
-        if "[respond_with_voice]" in text and self.voice:
-            clean_text = text.replace("[respond_with_voice]", "").strip()
+        if VOICE_MARKER in text and self.voice:
+            clean_text = strip_voice_marker(text)
             try:
                 return await self.voice.synthesize(clean_text, voice=voice)
             except Exception:

--- a/core/prompt_builder.py
+++ b/core/prompt_builder.py
@@ -64,6 +64,7 @@ class PromptSections:
     tool_usage: str
     tools: str
     secrets: str
+    voice: str
     memory_instruction: str
     history_handling: str
     memories: str
@@ -84,6 +85,8 @@ class PromptSections:
             parts.append(self.tools)
         if self.secrets:
             parts.append(self.secrets)
+        if self.voice:
+            parts.append(self.voice)
         parts.append(self.memory_instruction)
         if self.history_handling:
             parts.append(self.history_handling)
@@ -106,6 +109,7 @@ class PromptSections:
             "tool_usage": self.tool_usage,
             "tools": self.tools,
             "secrets": self.secrets,
+            "voice": self.voice,
             "memory_instruction": self.memory_instruction,
             "history_handling": self.history_handling,
             "memories": self.memories,
@@ -191,6 +195,24 @@ def build_prompt_sections(
             "output — substitution happens only inside `run_command`.\n"
             "</secrets>"
         )
+    # Voice is a base capability, not a skill or a function-tool: when TTS is on
+    # (same flag that brings up the pipeline in main.py) every agent — default or
+    # persona, 1:1 or group room — is told it can speak. Without this the only
+    # documentation of the [respond_with_voice] marker lived inside the `voice`
+    # skill, so a model that hadn't loaded it would deny having any voice tool.
+    voice_section = ""
+    if config.voice.tts_enabled:
+        voice_section = (
+            "<voice>\n"
+            "You can reply with a voice message instead of text: end your response with "
+            "the marker [respond_with_voice] and the whole reply is synthesized to speech "
+            "(it is NOT a tool call — just append the marker). Use it when the user sent a "
+            "voice message (mirror the medium), explicitly asks for voice, or the reply is "
+            "short and conversational. Do NOT use it for code, links, or long/structured "
+            "answers. A voice reply must be plain, speakable text end to end. For the full "
+            "guidance, load the `voice` skill.\n"
+            "</voice>"
+        )
     memory_instruction = (
         "You can store and recall memories using the sqlite3 CLI (see the memory skill).\n"
         "Proactively remember important facts about the user and their contacts.\n"
@@ -236,6 +258,7 @@ def build_prompt_sections(
         tool_usage=tool_usage,
         tools=tools_section,
         secrets=secrets_section,
+        voice=voice_section,
         memory_instruction=memory_instruction,
         history_handling=history_handling,
         memories=memory_section,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -124,6 +124,16 @@ def test_voice_capability_hidden_when_tts_disabled() -> None:
     assert "[respond_with_voice]" not in sections.full_prompt
 
 
+def test_strip_voice_marker_removes_marker_unconditionally() -> None:
+    # The marker is internal signalling: it must be removed from the reply text
+    # whether or not synthesis ran, so it can never leak to the user.
+    from core.agent import strip_voice_marker
+
+    assert strip_voice_marker("Hi there [respond_with_voice]") == "Hi there"
+    assert strip_voice_marker("[respond_with_voice]") == ""
+    assert strip_voice_marker("plain reply") == "plain reply"
+
+
 # ---------------------------------------------------------------------------
 # Session system snapshot
 # ---------------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -105,6 +105,25 @@ def test_tools_section_only_when_enabled() -> None:
     assert sections.tools in sections.full_prompt
 
 
+def test_voice_capability_advertised_when_tts_enabled() -> None:
+    # TTS is on by default → every agent's base prompt must teach the
+    # [respond_with_voice] marker, so it never denies having a voice capability.
+    cfg = Config()
+    assert cfg.voice.tts_enabled
+    sections = _sections(cfg)
+    assert "<voice>" in sections.voice
+    assert "[respond_with_voice]" in sections.voice
+    assert sections.voice in sections.full_prompt
+
+
+def test_voice_capability_hidden_when_tts_disabled() -> None:
+    cfg = Config()
+    cfg.voice.tts_enabled = False
+    sections = _sections(cfg)
+    assert sections.voice == ""
+    assert "[respond_with_voice]" not in sections.full_prompt
+
+
 # ---------------------------------------------------------------------------
 # Session system snapshot
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

In a group room, both agents refused a "send a voice message" request, saying they had no voice tool — even though TTS was enabled.

Root cause: **sending a voice reply is not a function-tool and was never in the base prompt.** It is a hidden text marker `[respond_with_voice]` whose only documentation lived inside the `voice` skill (`skills/voice.md`). An agent learns it can speak only after calling `load_skill voice`. So:

- The **default agent** sees only a one-line "Voice Interaction" summary in the skills index; on a tangential ask it scans its tools, finds none, and denies the capability.
- A **persona** with a non-empty `skills` allowlist that omits `voice` can't see the skill at all → guaranteed refusal.
- The persona `tools` allowlist (the admin "tools" toggles / `GATEABLE_TOOLS`) does nothing for voice — voice isn't a tool — so "I enabled the voice tool" enabled nothing the model could see.

## Fix

Treat voice as a **base capability**, not a skill or tool. Add a `<voice>` block to the base system prompt (`build_prompt_sections`), gated on `config.voice.tts_enabled` — the *same* flag that brings up the `VoicePipeline` in `core/main.py`. So the prompt advertises voice exactly when the pipeline is actually available.

Now every agent — default or persona, 1:1 or group room — knows it can append `[respond_with_voice]`, with no skill load and untouched by persona skill/tool allowlists. The block is self-sufficient (marker + the speakable-text rules) and points to the `voice` skill for full guidance.

## Also fixed: marker leak on TTS failure

`core/agent.py` stripped the `[respond_with_voice]` marker **only on synthesis success** (`if voice_bytes:`). If `synthesize()` raised (caught) or the pipeline was None, the literal `[respond_with_voice]` leaked into the text reply. Advertising voice to every agent widens how often that path is hit, so this fixes the root: the marker is internal signalling and is now stripped **unconditionally**. The strip (3 copies) and the literal (4 sites) are deduped behind a single `VOICE_MARKER` constant + `strip_voice_marker()` helper.

## Tests

- `test_voice_capability_advertised_when_tts_enabled` — block + marker present in the base prompt by default.
- `test_voice_capability_hidden_when_tts_disabled` — block absent when TTS off.
- `test_strip_voice_marker_removes_marker_unconditionally` — marker never survives, with or without synthesis.

Green: `test_tools.py`, `test_personae.py`, `test_group_chat.py`, `test_per_chat_persona.py`, `test_voice_clean.py`, `test_subagents.py`.
