### PR TITLE
feat: allow editing persona slug (#69)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import sys
 import urllib.parse
@@ -50,6 +51,10 @@ if TYPE_CHECKING:
     from core.skills import SkillsStore
 
 log = logging.getLogger(__name__)
+
+# A persona slug becomes part of a channel name (``telegram:<slug>``) and a URL
+# path (``/admin/personae/<slug>``), so it must avoid ':' , '/' and whitespace.
+_VALID_SLUG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 
 # ---------------------------------------------------------------------------
 # Google OAuth 2.0 constants (for CalDAV calendar access)
@@ -2592,6 +2597,52 @@ def create_admin_app(
         agent = agent_state.agent
         if agent:
             agent.config.agent.active_persona = name
+
+    @app.post("/personae/rename", dependencies=[Depends(auth)])
+    async def rename_persona(request: Request) -> HTMLResponse:
+        """Change a persona's slug, cascading it to every store that keys off it.
+
+        The slug is a foreign key without a DB constraint: per-chat bindings,
+        private memory scope, scheduled jobs, the active-persona selection and the
+        ``telegram:<slug>`` bot channel all reference it by value, so each is
+        repointed here (#69). A persona with its own bot needs an agent restart for
+        the bot to re-register under the new slug.
+        """
+        content_type = request.headers.get("content-type", "")
+        if "application/x-www-form-urlencoded" in content_type:
+            body = await request.form()
+        else:
+            body = await request.json()
+        old = str(body.get("old", "")).strip()
+        new = str(body.get("new", "")).strip()
+        if not old or not new:
+            raise HTTPException(400, "Missing 'old' or 'new' in request body")
+        if old == new:
+            return await _personae_partial()  # no-op
+        if not _VALID_SLUG.match(new):
+            raise HTTPException(
+                400, "Slug may contain only letters, digits, '-' and '_' (no spaces or ':')."
+            )
+        store = await _persona_store_from_config(config_store)
+        try:
+            renamed = await store.rename(old, new)
+        except ValueError as exc:
+            raise HTTPException(409, str(exc))
+        if not renamed:
+            raise HTTPException(404, f"Persona not found: {old}")
+        # ponytail: best-effort cascade across the separate SQLite DBs — there is
+        # no cross-DB transaction; a missed ref just falls back to the default
+        # identity at runtime, never corrupts data.
+        history = await _history_from_config(config_store)
+        await history.rename_persona(old, new)
+        from core.memory import MemoryStore
+
+        memory_db = await config_store.get("memory.db_path") or "data/memory.db"
+        await MemoryStore(db_path=memory_db).rename_scope(old, new)
+        await _get_job_store().rename_persona(old, new)
+        if (await config_store.get("agent.active_persona") or "").strip() == old:
+            await _set_active_persona(new)
+        return await _personae_partial()
 
     @app.post("/personae/activate", dependencies=[Depends(auth)])
     async def activate_persona(request: Request) -> HTMLResponse:

--- a/api/admin.py
+++ b/api/admin.py
@@ -54,7 +54,9 @@ log = logging.getLogger(__name__)
 
 # A persona slug becomes part of a channel name (``telegram:<slug>``) and a URL
 # path (``/admin/personae/<slug>``), so it must avoid ':' , '/' and whitespace.
-_VALID_SLUG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+# Capped at 64 chars so it can't bloat every channel string it is embedded in.
+_VALID_SLUG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+_SLUG_ERROR = "Slug must be 1-64 chars: letters, digits, '-' and '_' only (no spaces or ':')."
 
 # ---------------------------------------------------------------------------
 # Google OAuth 2.0 constants (for CalDAV calendar access)
@@ -2551,6 +2553,8 @@ def create_admin_app(
         name = body.name.strip()
         if not name:
             raise HTTPException(400, "Persona name is required")
+        if not _VALID_SLUG.match(name):
+            raise HTTPException(400, _SLUG_ERROR)
         # Raw markdown (power-user mode) wins over the structured fields.
         if body.raw.strip():
             persona = parse_markdown(body.raw, name=name)
@@ -2620,19 +2624,18 @@ def create_admin_app(
         if old == new:
             return await _personae_partial()  # no-op
         if not _VALID_SLUG.match(new):
-            raise HTTPException(
-                400, "Slug may contain only letters, digits, '-' and '_' (no spaces or ':')."
-            )
+            raise HTTPException(400, _SLUG_ERROR)
         store = await _persona_store_from_config(config_store)
-        try:
-            renamed = await store.rename(old, new)
-        except ValueError as exc:
-            raise HTTPException(409, str(exc))
-        if not renamed:
+        if await store.get(old) is None:
             raise HTTPException(404, f"Persona not found: {old}")
-        # ponytail: best-effort cascade across the separate SQLite DBs — there is
-        # no cross-DB transaction; a missed ref just falls back to the default
-        # identity at runtime, never corrupts data.
+        if await store.get(new) is not None:
+            raise HTTPException(409, f"A persona named '{new}' already exists")
+        # ponytail: best-effort cascade across the separate SQLite DBs — no cross-DB
+        # transaction. The references are repointed first and the personae PK row is
+        # renamed LAST, so if any step fails the old slug still fully resolves and the
+        # whole rename is safe to retry (the ref updates are idempotent no-ops once
+        # moved). A missed ref only ever falls back to the default identity, never
+        # corrupts data.
         history = await _history_from_config(config_store)
         await history.rename_persona(old, new)
         from core.memory import MemoryStore
@@ -2640,8 +2643,15 @@ def create_admin_app(
         memory_db = await config_store.get("memory.db_path") or "data/memory.db"
         await MemoryStore(db_path=memory_db).rename_scope(old, new)
         await _get_job_store().rename_persona(old, new)
+        await store.rename(old, new)
         if (await config_store.get("agent.active_persona") or "").strip() == old:
             await _set_active_persona(new)
+        # Re-register live scheduler jobs so a renamed persona's cron/once jobs fire
+        # under the new slug + channel immediately, not only after a restart. Bot
+        # channels still need a restart (they are created at startup).
+        agent = agent_state.agent
+        if agent is not None:
+            await agent.scheduler.load_jobs()
         return await _personae_partial()
 
     @app.post("/personae/activate", dependencies=[Depends(auth)])

--- a/api/templates/persona_editor.html
+++ b/api/templates/persona_editor.html
@@ -24,7 +24,10 @@
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
           <div class="sm:col-span-2">
             <label class="label">Name (slug)</label>
-            <input class="input-sm" x-model="name" {% if not is_new %}readonly{% endif %} placeholder="fitness-coach">
+            <input class="input-sm" x-model="name" placeholder="fitness-coach">
+            {% if not is_new %}
+            <p class="hint" x-show="name.trim() !== originalName">Renaming moves this persona's chat bindings, private memories and scheduled jobs to the new slug. A persona with its own bot needs an agent restart afterwards.</p>
+            {% endif %}
           </div>
           <div>
             <label class="label">Emoji</label>
@@ -135,6 +138,8 @@
   function personaEditor() {
     return {
       mode: 'guided',
+      isNew: {{ is_new|tojson }},
+      originalName: {{ persona.name|tojson }},
       name: {{ persona.name|tojson }},
       agent_name: {{ persona.agent_name|tojson }},
       role: {{ persona.role|tojson }},
@@ -173,9 +178,14 @@
           '---\n';
       },
 
-      save() {
-        const name = (this.name || '').trim();
-        if (!name) { this.ok = false; this.result = 'Name is required.'; return; }
+      _headers() {
+        return {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || ''),
+        };
+      },
+
+      _upsert(name) {
         const body = this.mode === 'raw'
           ? { name: name, raw: this.raw }
           : {
@@ -186,20 +196,36 @@
               secrets: this.secretsText.split('\n').map(s => s.trim()).filter(Boolean),
               bot_token: this.bot_token, allowed_user_ids: this.allowedUserIds,
             };
-        fetch('/personae', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || ''),
-          },
-          body: JSON.stringify(body),
-        })
-        .then(r => { this.ok = r.ok; return r.text().then(t => ({ ok: r.ok, t })); })
-        .then(({ ok, t }) => {
-          this.result = ok ? 'Saved.' : ('Error: ' + t.slice(0, 200));
-          if (ok && window.showToast) window.showToast('Persona saved');
-        })
-        .catch(e => { this.ok = false; this.result = e.message; });
+        fetch('/personae', { method: 'POST', headers: this._headers(), body: JSON.stringify(body) })
+          .then(r => { this.ok = r.ok; return r.text().then(t => ({ ok: r.ok, t })); })
+          .then(({ ok, t }) => {
+            this.result = ok ? 'Saved.' : ('Error: ' + t.slice(0, 200));
+            if (ok && window.showToast) window.showToast('Persona saved');
+          })
+          .catch(e => { this.ok = false; this.result = e.message; });
+      },
+
+      save() {
+        const name = (this.name || '').trim();
+        if (!name) { this.ok = false; this.result = 'Name is required.'; return; }
+        // Existing persona whose slug changed: rename first (cascades bindings,
+        // memories, jobs), then save the rest of the fields under the new slug.
+        if (!this.isNew && this.originalName && name !== this.originalName) {
+          fetch('/personae/rename', {
+            method: 'POST',
+            headers: this._headers(),
+            body: JSON.stringify({ old: this.originalName, new: name }),
+          })
+          .then(r => r.text().then(t => ({ ok: r.ok, t })))
+          .then(({ ok, t }) => {
+            if (!ok) { this.ok = false; this.result = 'Rename failed: ' + t.slice(0, 200); return; }
+            this.originalName = name;
+            this._upsert(name);
+          })
+          .catch(e => { this.ok = false; this.result = e.message; });
+          return;
+        }
+        this._upsert(name);
       },
     };
   }

--- a/core/history.py
+++ b/core/history.py
@@ -513,6 +513,26 @@ class ConversationHistory:
             await self.clear_chat_persona(channel, user_id, chat_id)
         await self.clear_session_system(channel, user_id, chat_id)
 
+    async def rename_persona(self, old: str, new: str) -> None:
+        """Repoint everything keyed by a persona slug after it is renamed (#69).
+
+        Two kinds of reference move: the ``chat_persona.persona`` binding value,
+        and the ``telegram:<slug>`` channel that a per-persona bot's turns,
+        session, and binding rows are stored under (#29).
+        """
+        old_ch, new_ch = f"telegram:{old}", f"telegram:{new}"
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("UPDATE chat_persona SET persona = ? WHERE persona = ?", (new, old))
+            tables = ("conversation_turns", "session_messages", "session_system", "chat_persona")
+            for table in tables:
+                await db.execute(
+                    f"UPDATE {table} SET channel = ? WHERE channel = ?",  # noqa: S608
+                    (new_ch, old_ch),
+                )
+            await db.commit()
+        # The per-persona bot channel only carries traffic after a restart, so the
+        # in-memory _session_system cache (keyed by the old channel) is moot here.
+
     async def list_chats(self) -> list[dict[str, str]]:
         """List every known (channel, user_id, chat_id) with its bound persona.
 

--- a/core/job_store.py
+++ b/core/job_store.py
@@ -281,6 +281,18 @@ class JobStore:
             await db.commit()
             return cursor.rowcount > 0
 
+    async def rename_persona(self, old: str, new: str) -> None:
+        """Repoint jobs from a renamed persona slug (#69): the ``persona`` column
+        and the ``telegram:<slug>`` channel a per-persona-bot job delivers to."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("UPDATE jobs SET persona = ? WHERE persona = ?", (new, old))
+            await db.execute(
+                "UPDATE jobs SET channel = ? WHERE channel = ?",
+                (f"telegram:{new}", f"telegram:{old}"),
+            )
+            await db.commit()
+
     async def seed_from_config(self, jobs: list[dict]) -> int:
         """Seed jobs from config (on first boot). Only inserts, never overwrites.
 

--- a/core/memory.py
+++ b/core/memory.py
@@ -565,6 +565,15 @@ class MemoryStore:
         await db.execute("CREATE INDEX IF NOT EXISTS idx_st_scope ON short_term(scope)")
         await db.commit()
 
+    async def rename_scope(self, old: str, new: str) -> None:
+        """Move a persona's private memories to a new scope key after the persona
+        slug is renamed (#69). A persona's scope key is its slug (see #42)."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("UPDATE long_term SET scope = ? WHERE scope = ?", (new, old))
+            await db.execute("UPDATE short_term SET scope = ? WHERE scope = ?", (new, old))
+            await db.commit()
+
     async def get_long_term(self, scope: str | None = None) -> list[dict]:
         """Retrieve recent (non-archived) long-term memories for injection.
 

--- a/core/personae.py
+++ b/core/personae.py
@@ -278,6 +278,27 @@ class PersonaStore:
             await db.commit()
             return cursor.rowcount > 0
 
+    async def rename(self, old: str, new: str) -> bool:
+        """Change a persona's slug (its PRIMARY KEY). Returns False if ``old`` is
+        missing; raises ``ValueError`` if ``new`` already names another persona.
+
+        This only moves the personae row. The slug is referenced from other
+        stores (per-chat bindings, memory scope, jobs, the active-persona config,
+        and the ``telegram:<slug>`` bot channel) — the admin rename route cascades
+        the new slug to those so nothing is orphaned.
+        """
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute("SELECT 1 FROM personae WHERE name = ?", (new,))
+            if await cursor.fetchone():
+                raise ValueError(f"A persona named '{new}' already exists")
+            cursor = await db.execute(
+                "UPDATE personae SET name = ?, updated_at = datetime('now') WHERE name = ?",
+                (new, old),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
 
 if __name__ == "__main__":
     # ponytail: one runnable check covering the parse/serialise round-trip + scopes.

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -81,6 +81,12 @@ Six ready-made personae ship seeded and ready to use or customise: fitness coach
 assistant, travel planner, coding helper, writing editor, and language tutor. They are normal
 rows — edit them in place, or activate one as-is.
 
+Seeding is by file stem: a gallery slug is (re)seeded whenever no row by that name exists. So
+**renaming or deleting a starter persona leaves its original slug to be re-seeded** — the
+renamed copy lives under the new slug, and the pristine starter reappears. Personae you create
+yourself have no seed file, so renaming them is clean. To retire a starter for good, also remove
+its `personae/<slug>.md` file.
+
 ## Setup wizard
 
 The setup wizard has a skippable **persona** step (after *identity*): pick a starter persona to

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -67,6 +67,10 @@ the active one. From there you can:
 - **Use** a persona (activates it; applies live to new turns) or revert to **Default**;
 - **edit** a persona in the editor — a **guided form** (identity, voice, skill + tool
   checkboxes, secret scope) with a **raw markdown** toggle for power users;
+- **rename** a persona's slug in the editor — the new slug is cascaded to everything that
+  references it (per-chat bindings, private memories, scheduled jobs, the active selection,
+  and the `telegram:<slug>` bot channel), so no association is lost. A persona with its own
+  bot needs an agent restart afterwards so the bot re-registers under the new slug;
 - **create** or **delete** personae.
 
 The page is responsive and touch-friendly: cards reflow to a single column at phone width.

--- a/tests/test_memory_tiers.py
+++ b/tests/test_memory_tiers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import re
+import zlib
 
 import aiosqlite
 import numpy as np
@@ -27,7 +28,11 @@ class _HashEmbedder:
     async def embed_one(self, text: str) -> list[float]:
         vec = [0.0] * self.DIM
         for tok in re.findall(r"[a-z0-9]+", text.lower()):
-            vec[hash(tok) % self.DIM] += 1.0
+            # crc32, not the builtin hash(): str hashing is salted per process
+            # (PYTHONHASHSEED), which made the bucketing — and the ranking tests
+            # below — flaky across runs. crc32 is stable, keeping this honestly
+            # deterministic.
+            vec[zlib.crc32(tok.encode()) % self.DIM] += 1.0
         return vec
 
     async def embed(self, texts: list[str]) -> list[list[float]]:

--- a/tests/test_personae.py
+++ b/tests/test_personae.py
@@ -156,3 +156,26 @@ async def test_store_crud(tmp_path) -> None:
 
     assert await store.delete("coach") is True
     assert await store.get("coach") is None
+
+
+@pytest.mark.asyncio
+async def test_store_rename(tmp_path) -> None:
+    store = PersonaStore(db_path=str(tmp_path / "p.db"), seed_dir=tmp_path / "missing")
+    await store.upsert(Persona(name="coach", role="Coach", skills=["memory"]))
+
+    # Happy path: the row moves to the new slug, fields intact.
+    assert await store.rename("coach", "trainer") is True
+    assert await store.get("coach") is None
+    moved = await store.get("trainer")
+    assert moved is not None and moved.role == "Coach" and moved.skills == ["memory"]
+
+    # Renaming a missing slug is a no-op (False), not an error.
+    assert await store.rename("ghost", "whoever") is False
+
+    # Collision with an existing slug is rejected.
+    await store.upsert(Persona(name="writer", role="Writer"))
+    with pytest.raises(ValueError):
+        await store.rename("trainer", "writer")
+    # Both survive the rejected rename.
+    assert (await store.get("trainer")).role == "Coach"
+    assert (await store.get("writer")).role == "Writer"

--- a/tests/test_personae.py
+++ b/tests/test_personae.py
@@ -179,3 +179,20 @@ async def test_store_rename(tmp_path) -> None:
     # Both survive the rejected rename.
     assert (await store.get("trainer")).role == "Coach"
     assert (await store.get("writer")).role == "Writer"
+
+
+@pytest.mark.asyncio
+async def test_rename_seeded_persona_reseeds_old_slug(tmp_path) -> None:
+    """Characterise (not endorse) the gallery seam: seeding keys off the file
+    stem, so renaming a *seeded* persona leaves the old slug to be re-seeded on
+    the next list. User-created personae have no seed file, so they rename clean.
+    """
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "fitness-coach.md").write_text("---\nrole: Fitness coach\n---\n")
+    store = PersonaStore(db_path=str(tmp_path / "p.db"), seed_dir=seed)
+    assert [p.name for p in await store.list_personae()] == ["fitness-coach"]
+
+    await store.rename("fitness-coach", "my-coach")
+    # list_personae re-seeds the now-missing gallery stem alongside the renamed row.
+    assert {p.name for p in await store.list_personae()} == {"fitness-coach", "my-coach"}

--- a/tests/test_personae_admin.py
+++ b/tests/test_personae_admin.py
@@ -44,11 +44,20 @@ class _Store:
         return {}
 
 
+class _SchedulerSpy:
+    def __init__(self):
+        self.reloads = 0
+
+    async def load_jobs(self):
+        self.reloads += 1
+
+
 class _AgentStub:
     def __init__(self):
         self.config = Config()
         self.channels = {}
         self.job_store = None  # rename route reaches _get_job_store(); set per-test
+        self.scheduler = _SchedulerSpy()
 
 
 def _client(tmp_path):
@@ -194,6 +203,7 @@ def test_persona_rename_cascades(tmp_path) -> None:
     assert client.get("/personae/coach", headers=AUTH).status_code == 404
     assert client.get("/personae/trainer", headers=AUTH).status_code == 200
     assert agent.config.agent.active_persona == "trainer"
+    assert agent.scheduler.reloads == 1  # live scheduler re-registered the renamed job
 
     async def check() -> None:
         h = ConversationHistory(db_path=history_db)
@@ -208,6 +218,15 @@ def test_persona_rename_cascades(tmp_path) -> None:
         assert job["persona"] == "trainer" and job["channel"] == "telegram:trainer"
 
     asyncio.run(check())
+
+
+def test_persona_create_rejects_bad_slug(tmp_path) -> None:
+    # The slug guard applies to the create path too, so a malformed slug can't be
+    # introduced and then break channel/URL routing (#69).
+    client, _ = _client(tmp_path)
+    for bad in ("te:am", "my persona", "has/slash", ""):
+        r = client.post("/personae", json={"name": bad, "role": "X"}, headers=AUTH)
+        assert r.status_code == 400, bad
 
 
 def test_persona_rename_validation(tmp_path) -> None:

--- a/tests/test_personae_admin.py
+++ b/tests/test_personae_admin.py
@@ -20,6 +20,8 @@ class _Store:
         self._data = {
             "agent.personae_db_path": str(tmp_path / "personae.db"),
             "agent.personae_dir": str(tmp_path / "seed"),  # missing = no gallery
+            "history.db_path": str(tmp_path / "history.db"),
+            "memory.db_path": str(tmp_path / "memory.db"),
         }
 
     async def is_setup_complete(self) -> bool:
@@ -46,6 +48,7 @@ class _AgentStub:
     def __init__(self):
         self.config = Config()
         self.channels = {}
+        self.job_store = None  # rename route reaches _get_job_store(); set per-test
 
 
 def _client(tmp_path):
@@ -143,3 +146,98 @@ def test_partial_personae_renders(tmp_path) -> None:
     r = client.get("/partials/personae", headers=AUTH)
     assert r.status_code == 200
     assert "Active persona" in r.text
+
+
+def test_persona_rename_cascades(tmp_path) -> None:
+    """Renaming a slug repoints the persona row, the active selection, per-chat
+    bindings, the per-persona bot channel, private memory scope and jobs (#69)."""
+    import asyncio
+
+    import aiosqlite
+
+    from core.history import ConversationHistory
+    from core.job_store import JobStore
+    from core.memory import MemoryStore
+
+    client, agent = _client(tmp_path)
+    history_db = str(tmp_path / "history.db")
+    memory_db = str(tmp_path / "memory.db")
+    agent.job_store = JobStore(db_path=str(tmp_path / "jobs.db"))
+
+    assert (
+        client.post("/personae", json={"name": "coach", "role": "Coach"}, headers=AUTH).status_code
+        == 200
+    )
+    assert (
+        client.post("/personae/activate", json={"name": "coach"}, headers=AUTH).status_code == 200
+    )
+    assert agent.config.agent.active_persona == "coach"
+
+    async def seed() -> None:
+        h = ConversationHistory(db_path=history_db)
+        await h.set_chat_persona("telegram", "u1", "coach", "")  # default-bot binding
+        await h.add_turn("telegram:coach", "u1", "user", "hi")  # the bot's own channel
+        m = MemoryStore(db_path=memory_db)
+        await m._ensure_schema()
+        async with aiosqlite.connect(memory_db) as db:
+            await db.execute(
+                "INSERT INTO long_term (category, subject, content, scope) "
+                "VALUES ('pref','s','c','coach')"
+            )
+            await db.commit()
+        await agent.job_store.upsert_job("j1", task="t", channel="telegram:coach", persona="coach")
+
+    asyncio.run(seed())
+
+    r = client.post("/personae/rename", json={"old": "coach", "new": "trainer"}, headers=AUTH)
+    assert r.status_code == 200
+    assert client.get("/personae/coach", headers=AUTH).status_code == 404
+    assert client.get("/personae/trainer", headers=AUTH).status_code == 200
+    assert agent.config.agent.active_persona == "trainer"
+
+    async def check() -> None:
+        h = ConversationHistory(db_path=history_db)
+        assert await h.get_chat_persona("telegram", "u1", "") == "trainer"
+        async with aiosqlite.connect(history_db) as db:
+            cur = await db.execute("SELECT channel FROM conversation_turns WHERE user_id='u1'")
+            assert [row[0] for row in await cur.fetchall()] == ["telegram:trainer"]
+        async with aiosqlite.connect(memory_db) as db:
+            cur = await db.execute("SELECT scope FROM long_term")
+            assert [row[0] for row in await cur.fetchall()] == ["trainer"]
+        job = await agent.job_store.get_job("j1")
+        assert job["persona"] == "trainer" and job["channel"] == "telegram:trainer"
+
+    asyncio.run(check())
+
+
+def test_persona_rename_validation(tmp_path) -> None:
+    client, _ = _client(tmp_path)
+    client.post("/personae", json={"name": "coach", "role": "C"}, headers=AUTH)
+    client.post("/personae", json={"name": "writer", "role": "W"}, headers=AUTH)
+
+    # Collision with an existing slug → 409.
+    assert (
+        client.post(
+            "/personae/rename", json={"old": "coach", "new": "writer"}, headers=AUTH
+        ).status_code
+        == 409
+    )
+    # Illegal characters (the ':' would break channel routing) → 400.
+    assert (
+        client.post(
+            "/personae/rename", json={"old": "coach", "new": "te:am"}, headers=AUTH
+        ).status_code
+        == 400
+    )
+    # Unknown source slug → 404.
+    assert (
+        client.post("/personae/rename", json={"old": "ghost", "new": "x"}, headers=AUTH).status_code
+        == 404
+    )
+    # Renaming to the same slug is a harmless no-op.
+    assert (
+        client.post(
+            "/personae/rename", json={"old": "coach", "new": "coach"}, headers=AUTH
+        ).status_code
+        == 200
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -928,7 +928,7 @@ wheels = [
 
 [[package]]
 name = "mpa"
-version = "0.12.0"
+version = "0.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## What

Closes #69. You can now **rename a persona's slug** instead of deleting it and re-adding it under a new name.

The slug (`personae.name`, the PK) is a foreign key without a DB constraint — referenced *by value* from several places. A rename cascades the new slug to all of them so no association is lost:

- per-chat persona bindings (`chat_persona.persona`)
- the `telegram:<slug>` per-persona-bot channel (turns, session, bindings)
- private memory scope (`long_term.scope` / `short_term.scope`)
- scheduled jobs (`jobs.persona` + their `telegram:<slug>` channel) — and the **live APScheduler** is reloaded so jobs fire under the new identity immediately
- the active-persona selection (`agent.active_persona`)

## How

- `PersonaStore.rename(old, new)` — moves the personae row; rejects a collision, `False` for unknown.
- `ConversationHistory.rename_persona`, `JobStore.rename_persona`, `MemoryStore.rename_scope` — small repoint helpers on each owning store.
- `POST /personae/rename` — validates the new slug (1–64 chars, `[A-Za-z0-9_-]`, no `:`/`/`/space), checks existence/collision up front (clean 404/409), repoints references, then moves the PK **last** so a mid-cascade failure leaves the old slug fully resolvable and the rename safe to retry. Reloads the live scheduler at the end.
- The same slug guard now also covers the create path, closing a bypass that let a malformed slug reach channel/URL routing.
- Persona editor: the slug is editable on an existing persona; saving a changed slug renames first, then upserts the rest under the new slug. A hint explains the cascade and that a persona **with its own bot** needs an agent restart (the bot is created at startup).

## Review hardening (post adversarial review)

- live scheduler reload on rename (APScheduler bakes persona/channel in at load time)
- references-first / PK-last ordering for retryable, non-corrupting failures
- slug validation hoisted to the create path + length cap

## Known limitation

Seeding is by file stem, so **renaming or deleting a starter-gallery persona leaves its original slug to be re-seeded** (same as the existing delete behavior). Personae you create yourself have no seed file and rename clean. Documented, and pinned with a characterization test. A seed "tombstone" would fix both delete and rename — out of scope here.

## Out of scope

Persona-scoped vault secrets use a name *convention* (`persona:<slug>:*`), not a structural FK; the stored allowlist and the secret names both keep their literal text after a rename, so they stay mutually consistent (and rewriting them would need an unsealed vault).

## Testing

- `PersonaStore.rename`: success / unknown / collision; gallery re-seed characterization.
- Admin route: full cascade (binding, bot channel, memory scope, job, active selection, live scheduler reload) + validation (409 collision, 400 bad chars/length, 404 unknown, same-slug no-op) + create-path slug rejection.
- Full suite: 637 passed; ruff clean; CI green.

## Drive-by

Fixed a pre-existing flaky test (`test_semantic_match_ranks_first`): the "deterministic" test embedder bucketed tokens with the builtin `hash()`, which is salted per process (`PYTHONHASHSEED`), so it failed intermittently on CI (every recent `main` run was red on it). Switched to `zlib.crc32`.
