### PR TITLE
feat(jobs): hide completed jobs from main list behind a 'Show completed' toggle

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1508,10 +1508,14 @@ def create_admin_app(
 
         return JobStore(db_path="data/jobs.db")
 
-    def _get_jobs_list() -> list[dict]:
-        """Build a list of job dicts from the JobStore + APScheduler next_run times."""
+    def _get_jobs_list(include_done: bool = False) -> list[dict]:
+        """Build a list of job dicts from the JobStore + APScheduler next_run times.
+
+        By default only live jobs (active/paused) are returned; pass
+        ``include_done=True`` to also include completed/cancelled jobs.
+        """
         store = _get_job_store()
-        db_jobs = store.list_jobs_sync(include_done=False)
+        db_jobs = store.list_jobs_sync(include_done=include_done)
         agent = agent_state.agent
 
         # Build a map of APScheduler next_run times
@@ -1549,11 +1553,16 @@ def create_admin_app(
         return jobs
 
     @app.get("/partials/jobs", dependencies=[Depends(auth)])
-    async def partial_jobs() -> HTMLResponse:
-        """Jobs tab partial."""
-        jobs = _get_jobs_list()
+    async def partial_jobs(show_completed: bool = False) -> HTMLResponse:
+        """Jobs tab partial. ``show_completed`` reveals done/cancelled jobs."""
+        jobs = _get_jobs_list(include_done=show_completed)
         agent_running = agent_state.agent is not None
-        return _render_partial("partials/jobs.html", jobs=jobs, agent_running=agent_running)
+        return _render_partial(
+            "partials/jobs.html",
+            jobs=jobs,
+            agent_running=agent_running,
+            show_completed=show_completed,
+        )
 
     @app.post("/jobs", dependencies=[Depends(auth)])
     async def upsert_job(request: Request) -> HTMLResponse:

--- a/api/admin.py
+++ b/api/admin.py
@@ -1638,9 +1638,15 @@ def create_admin_app(
 
         log.info("Job %r upserted via admin: %s (%s)", job_id, cron, job_type)
 
-        jobs = _get_jobs_list()
+        show_completed = str(body.get("show_completed", "")).strip().lower() in ("true", "on", "1")
+        jobs = _get_jobs_list(include_done=show_completed)
         agent_running = agent is not None
-        resp = _render_partial("partials/jobs.html", jobs=jobs, agent_running=agent_running)
+        resp = _render_partial(
+            "partials/jobs.html",
+            jobs=jobs,
+            agent_running=agent_running,
+            show_completed=show_completed,
+        )
         resp.headers["HX-Trigger"] = json.dumps({"showToast": f'Job "{job_id}" saved'})
         return resp
 
@@ -1669,9 +1675,15 @@ def create_admin_app(
 
         log.info("Job %r deleted via admin", job_id)
 
-        jobs = _get_jobs_list()
+        show_completed = str(body.get("show_completed", "")).strip().lower() in ("true", "on", "1")
+        jobs = _get_jobs_list(include_done=show_completed)
         agent_running = agent is not None
-        resp = _render_partial("partials/jobs.html", jobs=jobs, agent_running=agent_running)
+        resp = _render_partial(
+            "partials/jobs.html",
+            jobs=jobs,
+            agent_running=agent_running,
+            show_completed=show_completed,
+        )
         resp.headers["HX-Trigger"] = json.dumps({"showToast": f'Job "{job_id}" deleted'})
         return resp
 

--- a/api/templates/partials/jobs.html
+++ b/api/templates/partials/jobs.html
@@ -80,6 +80,7 @@
             </button>
             <button class="btn-danger btn-sm ml-0.5"
                     hx-post="/jobs/delete" hx-target="#tab-content" hx-swap="innerHTML"
+                    hx-include="#jobs-show-completed"
                     hx-vals='{"job_id": {{ job.id|tojson }} }'
                     hx-confirm="Delete job &quot;{{ job.id }}&quot;?">
               x
@@ -99,7 +100,8 @@
 
   {# Add / edit job form #}
   <h3 class="text-xs text-muted uppercase tracking-wider mt-5 mb-2" x-text="editing ? 'Edit job' : 'Add new job'">Add new job</h3>
-  <form hx-post="/jobs" hx-target="#tab-content" hx-swap="innerHTML">
+  <form hx-post="/jobs" hx-target="#tab-content" hx-swap="innerHTML"
+        hx-include="#jobs-show-completed">
     <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
       <div>
         <label class="label">Job ID</label>

--- a/api/templates/partials/jobs.html
+++ b/api/templates/partials/jobs.html
@@ -1,13 +1,20 @@
 {# Jobs tab partial #}
 <div x-data="jobsTab()">
   <div class="flex items-center gap-2 mb-4 flex-wrap">
-    <button class="btn btn-sm" hx-get="/partials/jobs" hx-target="#tab-content" hx-swap="innerHTML">
+    <button class="btn btn-sm" hx-get="/partials/jobs" hx-target="#tab-content" hx-swap="innerHTML"
+            hx-include="#jobs-show-completed">
       Refresh
     </button>
     <span class="text-muted text-xs">{{ jobs|length }} job{{ 's' if jobs|length != 1 else '' }}</span>
     {% if not agent_running %}
     <span class="badge-off text-[0.65rem]">agent stopped — jobs won't run</span>
     {% endif %}
+    <label class="flex items-center gap-1.5 text-xs text-muted cursor-pointer ml-auto" title="Show completed, cancelled, and past one-time jobs">
+      <input id="jobs-show-completed" type="checkbox" name="show_completed" value="true"
+             hx-get="/partials/jobs" hx-target="#tab-content" hx-swap="innerHTML" hx-include="this"
+             {% if show_completed %}checked{% endif %}>
+      Show completed
+    </label>
   </div>
 
   {# Subagent runs (issue #15) — live status, polled every 3s #}

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -259,7 +259,8 @@ class AgentScheduler:
         """Parse a one-shot job's ``run_at`` into a tz-aware datetime.
 
         Returns ``None`` when absent or unparseable. Naive datetimes are
-        assumed to be in the configured timezone.
+        assumed to be in the configured timezone (e.g. a naive
+        ``2026-02-20T18:00:00`` is read in the agent's timezone, not UTC).
         """
         run_at_str = job.get("run_at")
         if not run_at_str:

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -243,10 +243,45 @@ class AgentScheduler:
         self.scheduler = AsyncIOScheduler(timezone=self.tz)
 
     async def load_jobs(self) -> None:
-        """Load all active jobs from JobStore into APScheduler."""
+        """Load all active jobs from JobStore into APScheduler.
+
+        Past one-shots (whose ``run_at`` has already elapsed, e.g. while the
+        agent was down) are retired to ``done`` rather than registered, so they
+        drop out of the active jobs list instead of lingering forever.
+        """
         jobs = await self.job_store.list_jobs(status="active")
         for job in jobs:
+            if await self._retire_if_past(job):
+                continue
             self._register_job(job)
+
+    def _resolve_run_at(self, job: dict) -> datetime | None:
+        """Parse a one-shot job's ``run_at`` into a tz-aware datetime.
+
+        Returns ``None`` when absent or unparseable. Naive datetimes are
+        assumed to be in the configured timezone.
+        """
+        run_at_str = job.get("run_at")
+        if not run_at_str:
+            return None
+        try:
+            run_at = datetime.fromisoformat(run_at_str)
+        except ValueError:
+            return None
+        if run_at.tzinfo is None:
+            run_at = run_at.replace(tzinfo=self.tz)
+        return run_at
+
+    async def _retire_if_past(self, job: dict) -> bool:
+        """Mark an active, past one-shot job as ``done``. Returns True if retired."""
+        if job.get("schedule") != "once" or job.get("status") != "active":
+            return False
+        run_at = self._resolve_run_at(job)
+        if run_at is not None and run_at < datetime.now(self.tz):
+            await self.job_store.update_status(job["id"], "done")
+            log.info("One-shot job %r is in the past; marked done", job["id"])
+            return True
+        return False
 
     def _register_job(self, job: dict) -> None:
         """Register a single job dict into APScheduler."""
@@ -260,24 +295,13 @@ class AgentScheduler:
 
         try:
             if schedule == "once":
-                run_at_str = job.get("run_at")
-                if not run_at_str:
-                    log.warning("One-shot job %r has no run_at; skipping", job_id)
+                run_at = self._resolve_run_at(job)
+                if run_at is None:
+                    log.warning("One-shot job %r has no/invalid run_at; skipping", job_id)
                     return
-                try:
-                    run_at = datetime.fromisoformat(run_at_str)
-                except ValueError:
-                    log.warning(
-                        "One-shot job %r has invalid run_at %r; skipping", job_id, run_at_str
-                    )
-                    return
-                # Treat naive datetimes as being in the configured timezone
-                if run_at.tzinfo is None:
-                    run_at = run_at.replace(tzinfo=self.tz)
-                # Skip one-shots in the past
+                # Skip one-shots in the past (retired to done by _retire_if_past)
                 if run_at < datetime.now(self.tz):
-                    log.info("One-shot job %r is in the past; marking done", job_id)
-                    # Can't await here, but we'll handle it in load_jobs
+                    log.info("One-shot job %r is in the past; skipping", job_id)
                     return
 
                 if job_type == "system":
@@ -399,6 +423,8 @@ class AgentScheduler:
         # If the job is still active, re-register it
         job = await self.job_store.get_job(job_id)
         if job and job["status"] == "active":
+            if await self._retire_if_past(job):
+                return
             self._register_job(job)
         elif job:
             log.info("Job %r has status %r; removed from scheduler", job_id, job["status"])

--- a/docs/content/docs/scheduler.mdx
+++ b/docs/content/docs/scheduler.mdx
@@ -135,6 +135,8 @@ Edit `config.yml` and restart the agent.
 
 Navigate to Jobs in the admin UI to view, create, edit, pause, and delete scheduled jobs.
 
+By default the list shows only live jobs (`active` and `paused`). Completed and cancelled jobs — including one-time jobs whose time has already passed — are hidden to keep the view clean. Flip the **Show completed** switch to reveal them.
+
 ### Via chat
 
 Ask the agent to schedule tasks:

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 from fastapi.testclient import TestClient
 
 from api.admin import AgentState, create_admin_app
 from core.config_store import ConfigStore
+from core.job_store import JobStore
 
 
 class _ConfigStoreStub:
@@ -116,6 +119,70 @@ def test_agent_status_reports_channels_and_jobs() -> None:
         "channels": ["telegram"],
         "scheduler_jobs": 2,
     }
+
+
+class _JobsAgentStub:
+    def __init__(self, job_store):
+        self.channels = {"telegram": object()}
+        self.job_store = job_store
+        self.scheduler = SimpleNamespace(
+            scheduler=SimpleNamespace(get_jobs=lambda: []),
+            sync_job=AsyncMock(),
+        )
+
+
+def _toggle_checked(html: str) -> bool:
+    m = re.search(r'<input id="jobs-show-completed"[^>]*>', html)
+    assert m, "show-completed toggle not rendered"
+    return "checked" in m.group(0)
+
+
+def _jobs_client(tmp_path):
+    store = JobStore(db_path=str(tmp_path / "jobs.db"))
+    store.upsert_job_sync("alpha-live", cron="0 7 * * *", task="t", status="active")
+    store.upsert_job_sync("omega-done", cron="0 7 * * *", task="t", status="done")
+    store.upsert_job_sync("victim-live", cron="0 7 * * *", task="t", status="active")
+    cfg = _ConfigStoreStub(setup_complete=True)
+    agent_state = AgentState(agent=cast(Any, _JobsAgentStub(store)))
+    app, _auth = create_admin_app(agent_state, cast(ConfigStore, cfg))
+    return TestClient(app)
+
+
+def test_partial_jobs_hides_completed_by_default(tmp_path) -> None:
+    client = _jobs_client(tmp_path)
+    headers = {"Authorization": "Bearer secret"}
+
+    resp = client.get("/partials/jobs", headers=headers)
+    assert resp.status_code == 200
+    assert "alpha-live" in resp.text
+    assert "omega-done" not in resp.text  # completed hidden by default
+    assert _toggle_checked(resp.text) is False
+
+
+def test_partial_jobs_show_completed_reveals_done(tmp_path) -> None:
+    client = _jobs_client(tmp_path)
+    headers = {"Authorization": "Bearer secret"}
+
+    resp = client.get("/partials/jobs?show_completed=true", headers=headers)
+    assert resp.status_code == 200
+    assert "omega-done" in resp.text  # completed revealed
+    assert _toggle_checked(resp.text) is True
+
+
+def test_delete_job_preserves_show_completed_toggle(tmp_path) -> None:
+    """Deleting a job while 'Show completed' is on keeps the toggle and completed jobs (#68)."""
+    client = _jobs_client(tmp_path)
+    headers = {"Authorization": "Bearer secret"}
+
+    resp = client.post(
+        "/jobs/delete",
+        data={"job_id": "victim-live", "show_completed": "true"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert "victim-live" not in resp.text  # deleted
+    assert "omega-done" in resp.text  # completed still shown
+    assert _toggle_checked(resp.text) is True  # toggle preserved
 
 
 def test_install_log_buffer_routes_reasoning_to_buffer_not_console() -> None:

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -1,0 +1,26 @@
+"""Tests for JobStore status filtering — the contract behind the jobs UI toggle."""
+
+from __future__ import annotations
+
+from core.job_store import JobStore
+
+
+def test_list_jobs_sync_filters_by_status(tmp_path) -> None:
+    """Default lists only live jobs; include_done reveals done/cancelled (issue #68)."""
+    store = JobStore(db_path=str(tmp_path / "jobs.db"))
+    for jid, status in (
+        ("a", "active"),
+        ("p", "paused"),
+        ("d", "done"),
+        ("c", "cancelled"),
+    ):
+        store.upsert_job_sync(jid, cron="0 7 * * *", task="t", status=status)
+
+    live = {j["id"] for j in store.list_jobs_sync()}
+    assert live == {"a", "p"}
+
+    everything = {j["id"] for j in store.list_jobs_sync(include_done=True)}
+    assert everything == {"a", "p", "d", "c"}
+
+    only_done = {j["id"] for j in store.list_jobs_sync(status="done")}
+    assert only_done == {"d"}

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2,18 +2,31 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
 
 import pytest
 
 from core.scheduler import (
+    AgentScheduler,
     _parse_cron,
     run_agent_task,
     run_memory_consolidation,
     run_system_command,
     set_agent_context,
 )
+
+
+def _make_scheduler(job_store) -> AgentScheduler:
+    """Build an AgentScheduler with a stub agent (UTC tz) and the given job store."""
+    agent = SimpleNamespace(config=SimpleNamespace(agent=SimpleNamespace(timezone="UTC")))
+    return AgentScheduler(agent, job_store)
+
+
+def _iso(offset_minutes: int) -> str:
+    return (datetime.now(ZoneInfo("UTC")) + timedelta(minutes=offset_minutes)).isoformat()
 
 
 def test_parse_cron_valid_expression() -> None:
@@ -179,3 +192,85 @@ async def test_run_agent_task_no_channel() -> None:
     # Should not raise
     await run_agent_task("do thing", channel="telegram")
     agent.process.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_retire_if_past_marks_done() -> None:
+    """An active one-shot whose run_at has elapsed is retired to 'done'."""
+    job_store = AsyncMock()
+    sched = _make_scheduler(job_store)
+    retired = await sched._retire_if_past(
+        {"id": "old", "schedule": "once", "status": "active", "run_at": _iso(-60)}
+    )
+    assert retired is True
+    job_store.update_status.assert_awaited_once_with("old", "done")
+
+
+@pytest.mark.asyncio
+async def test_retire_if_past_keeps_future_oneshot() -> None:
+    """A future one-shot is left alone."""
+    job_store = AsyncMock()
+    sched = _make_scheduler(job_store)
+    retired = await sched._retire_if_past(
+        {"id": "soon", "schedule": "once", "status": "active", "run_at": _iso(60)}
+    )
+    assert retired is False
+    job_store.update_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retire_if_past_ignores_cron() -> None:
+    """Cron jobs are never retired regardless of timing."""
+    job_store = AsyncMock()
+    sched = _make_scheduler(job_store)
+    retired = await sched._retire_if_past(
+        {"id": "daily", "schedule": "cron", "status": "active", "cron": "0 7 * * *"}
+    )
+    assert retired is False
+    job_store.update_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_load_jobs_retires_past_oneshot_and_skips_registration() -> None:
+    """load_jobs marks a past one-shot done and does not register it in APScheduler."""
+    job_store = AsyncMock()
+    job_store.list_jobs = AsyncMock(
+        return_value=[
+            {
+                "id": "stale",
+                "type": "agent",
+                "schedule": "once",
+                "status": "active",
+                "run_at": _iso(-120),
+                "task": "x",
+                "channel": "telegram",
+            }
+        ]
+    )
+    sched = _make_scheduler(job_store)
+    await sched.load_jobs()
+    job_store.update_status.assert_awaited_once_with("stale", "done")
+    assert sched.scheduler.get_job("stale") is None
+
+
+@pytest.mark.asyncio
+async def test_load_jobs_registers_future_oneshot() -> None:
+    """A future one-shot is registered, not retired."""
+    job_store = AsyncMock()
+    job_store.list_jobs = AsyncMock(
+        return_value=[
+            {
+                "id": "future",
+                "type": "agent",
+                "schedule": "once",
+                "status": "active",
+                "run_at": _iso(120),
+                "task": "x",
+                "channel": "telegram",
+            }
+        ]
+    )
+    sched = _make_scheduler(job_store)
+    await sched.load_jobs()
+    job_store.update_status.assert_not_awaited()
+    assert sched.scheduler.get_job("future") is not None


### PR DESCRIPTION
Closes #68.

## What

Completed/past jobs cluttered the main jobs list. Now the list shows only **live** jobs (`active`/`paused`) by default, and a **Show completed** toggle reveals the rest (`done`/`cancelled` + past one-time jobs).

## Changes

- **Root-cause fix (`core/scheduler.py`):** past one-shot jobs (whose `run_at` elapsed while the agent was down) were logged as "marking done" but never actually updated — they lingered as `active` forever. `load_jobs` and `sync_job` now retire them to `done`. Extracted a shared `_resolve_run_at` helper; added `_retire_if_past`.
- **UI (`api/admin.py` + `partials/jobs.html`):** `GET /partials/jobs?show_completed=…` threads through to `_get_jobs_list(include_done=…)`. A "Show completed" checkbox drives the reload; its state is preserved across **Refresh, add, edit, and delete** via `hx-include` so cleaning up old completed jobs no longer snaps the view back to live-only.
- **Docs:** documented the toggle in `scheduler.mdx`.

## Tests

- `tests/test_job_store.py` — status filtering contract behind the toggle.
- `tests/test_scheduler.py` — past one-shot retirement (retire / keep-future / ignore-cron / load_jobs interaction).
- `tests/test_admin_api.py` — partial hides completed by default, reveals on toggle, and preserves the toggle through delete.

Full suite: 642 passed.

## Review

Ran an adversarial multi-agent review (correctness / issue-fit / UI / over-engineering dimensions, each finding independently verified). It surfaced one real defect — the toggle state was lost after add/edit/delete — which is fixed in this PR and covered by a regression test.
