### PR TITLE
fix(scheduler): run scheduled jobs in the originating agent/chat (#71)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1701,10 +1701,24 @@ def create_admin_app(
         task = job.get("task", "")
         channel_name = job.get("channel", "telegram")
 
+        # Restore the originating persona + chat (issue #71) so a manual run
+        # behaves exactly like the scheduled one (empty for pre-#71/admin jobs).
+        persona = job.get("persona", "")
+        origin_user_id = job.get("origin_user_id", "")
+        origin_chat_id = job.get("origin_chat_id", "")
+
         if job_type in ("agent", "agent_silent"):
             silent = job_type == "agent_silent"
             asyncio.create_task(
-                run_agent_task(task=task, channel=channel_name, job_id=job_id, silent=silent)
+                run_agent_task(
+                    task=task,
+                    channel=channel_name,
+                    job_id=job_id,
+                    silent=silent,
+                    persona=persona,
+                    origin_user_id=origin_user_id,
+                    origin_chat_id=origin_chat_id,
+                )
             )
         elif job_type == "system":
             asyncio.create_task(run_system_command(command=task))
@@ -1713,10 +1727,12 @@ def create_admin_app(
         elif job_type == "subagent":
             asyncio.create_task(
                 run_subagent_task(
-                    persona=job.get("persona", ""),
+                    persona=persona,
                     task=task,
                     channel=channel_name,
                     job_id=job_id,
+                    origin_user_id=origin_user_id,
+                    origin_chat_id=origin_chat_id,
                 )
             )
         else:

--- a/core/agent.py
+++ b/core/agent.py
@@ -1773,7 +1773,7 @@ class AgentCore:
 
         if name == "manage_jobs":
             log.info("Tool call: manage_jobs — %s", params.get("action", ""))
-            result = await self._tool_manage_jobs(params)
+            result = await self._tool_manage_jobs(params, request_state)
             if is_write_action and self._is_tool_success(result):
                 executed_writes.add(write_sig)
             return result
@@ -2066,8 +2066,14 @@ class AgentCore:
 
         return await self.executor.run_command(" ".join(cmd_parts))
 
-    async def _tool_manage_jobs(self, params: dict) -> dict:
-        """Create, list, or cancel scheduled jobs via the JobStore."""
+    async def _tool_manage_jobs(self, params: dict, request_state: dict | None = None) -> dict:
+        """Create, list, or cancel scheduled jobs via the JobStore.
+
+        A created job captures its origin (the persona that scheduled it and the
+        chat it was scheduled in) from ``request_state`` so the scheduler later
+        runs it as that persona and delivers it back to the same chat — not the
+        default identity in the owner's 1:1 DM (issue #71).
+        """
         action = params.get("action", "")
 
         if action == "list":
@@ -2128,6 +2134,20 @@ class AgentCore:
             cron_expr = params.get("cron")
             run_at_str = params.get("run_at")
 
+            # Capture the originating context (issue #71): the persona that
+            # scheduled this and the chat it was scheduled in, so the scheduler
+            # runs it as that persona and delivers back to the same chat. Deliver
+            # from the same bot that received the request (a persona bot answers
+            # as itself); non-telegram origins (e.g. the scheduler itself) keep
+            # the explicit/default delivery channel.
+            origin = (request_state or {}).get("origin") or {}
+            origin_persona = (request_state or {}).get("persona_name") or ""
+            origin_channel = origin.get("channel") or ""
+            if origin_channel == "telegram" or origin_channel.startswith("telegram:"):
+                channel = origin_channel
+            origin_user_id = str(origin.get("user_id") or "")
+            origin_chat_id = str(origin.get("chat_id") or "")
+
             if cron_expr:
                 # Recurring cron job
                 from core.scheduler import _parse_cron
@@ -2145,8 +2165,11 @@ class AgentCore:
                     task=task,
                     channel=channel,
                     status="active",
-                    created_by="agent",
+                    created_by=origin_persona or "agent",
                     description=description,
+                    persona=origin_persona,
+                    origin_user_id=origin_user_id,
+                    origin_chat_id=origin_chat_id,
                 )
                 await self.scheduler.sync_job(job_id)
                 return {
@@ -2178,8 +2201,11 @@ class AgentCore:
                     task=task,
                     channel=channel,
                     status="active",
-                    created_by="agent",
+                    created_by=origin_persona or "agent",
                     description=description,
+                    persona=origin_persona,
+                    origin_user_id=origin_user_id,
+                    origin_chat_id=origin_chat_id,
                 )
                 await self.scheduler.sync_job(job_id)
                 return {

--- a/core/job_store.py
+++ b/core/job_store.py
@@ -155,9 +155,14 @@ class JobStore:
                        channel = excluded.channel,
                        status = excluded.status,
                        description = excluded.description,
-                       persona = excluded.persona,
-                       origin_user_id = excluded.origin_user_id,
-                       origin_chat_id = excluded.origin_chat_id,
+                       -- Identity/origin are sticky (#71): a re-upsert that omits
+                       -- them (admin "edit", CLI edit/cancel) must not wipe what
+                       -- job creation captured. A non-empty new value still wins.
+                       persona = COALESCE(NULLIF(excluded.persona, ''), persona),
+                       origin_user_id =
+                           COALESCE(NULLIF(excluded.origin_user_id, ''), origin_user_id),
+                       origin_chat_id =
+                           COALESCE(NULLIF(excluded.origin_chat_id, ''), origin_chat_id),
                        updated_at = datetime('now')
                 """,
                 (
@@ -254,9 +259,14 @@ class JobStore:
                        channel = excluded.channel,
                        status = excluded.status,
                        description = excluded.description,
-                       persona = excluded.persona,
-                       origin_user_id = excluded.origin_user_id,
-                       origin_chat_id = excluded.origin_chat_id,
+                       -- Identity/origin are sticky (#71): a re-upsert that omits
+                       -- them (admin "edit", CLI edit/cancel) must not wipe what
+                       -- job creation captured. A non-empty new value still wins.
+                       persona = COALESCE(NULLIF(excluded.persona, ''), persona),
+                       origin_user_id =
+                           COALESCE(NULLIF(excluded.origin_user_id, ''), origin_user_id),
+                       origin_chat_id =
+                           COALESCE(NULLIF(excluded.origin_chat_id, ''), origin_chat_id),
                        updated_at = datetime('now')
                 """,
                 (

--- a/core/job_store.py
+++ b/core/job_store.py
@@ -31,6 +31,8 @@ CREATE TABLE IF NOT EXISTS jobs (
     created_by  TEXT NOT NULL DEFAULT 'admin',
     description TEXT NOT NULL DEFAULT '',
     persona     TEXT NOT NULL DEFAULT '',
+    origin_user_id TEXT NOT NULL DEFAULT '',
+    origin_chat_id TEXT NOT NULL DEFAULT '',
     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -40,6 +42,8 @@ CREATE TABLE IF NOT EXISTS jobs (
 # name → ALTER statement; applied only when the column is missing.
 _MIGRATIONS = {
     "persona": "ALTER TABLE jobs ADD COLUMN persona TEXT NOT NULL DEFAULT ''",
+    "origin_user_id": "ALTER TABLE jobs ADD COLUMN origin_user_id TEXT NOT NULL DEFAULT ''",
+    "origin_chat_id": "ALTER TABLE jobs ADD COLUMN origin_chat_id TEXT NOT NULL DEFAULT ''",
 }
 
 # Valid values. "subagent" runs the spawn_subagent primitive under ``persona``.
@@ -130,6 +134,8 @@ class JobStore:
         created_by: str = "admin",
         description: str = "",
         persona: str = "",
+        origin_user_id: str = "",
+        origin_chat_id: str = "",
     ) -> dict:
         """Synchronous upsert for CLI/admin use."""
         self._ensure_schema_sync()
@@ -137,8 +143,9 @@ class JobStore:
             db.row_factory = sqlite3.Row
             db.execute(
                 """INSERT INTO jobs (id, type, schedule, cron, run_at, task, channel,
-                                     status, created_by, description, persona, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                                     status, created_by, description, persona,
+                                     origin_user_id, origin_chat_id, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
                    ON CONFLICT(id) DO UPDATE SET
                        type = excluded.type,
                        schedule = excluded.schedule,
@@ -149,6 +156,8 @@ class JobStore:
                        status = excluded.status,
                        description = excluded.description,
                        persona = excluded.persona,
+                       origin_user_id = excluded.origin_user_id,
+                       origin_chat_id = excluded.origin_chat_id,
                        updated_at = datetime('now')
                 """,
                 (
@@ -163,6 +172,8 @@ class JobStore:
                     created_by,
                     description,
                     persona,
+                    origin_user_id,
+                    origin_chat_id,
                 ),
             )
             db.commit()
@@ -222,6 +233,8 @@ class JobStore:
         created_by: str = "admin",
         description: str = "",
         persona: str = "",
+        origin_user_id: str = "",
+        origin_chat_id: str = "",
     ) -> dict:
         """Insert or update a job. Returns the job dict."""
         await self._ensure_schema()
@@ -229,8 +242,9 @@ class JobStore:
             db.row_factory = aiosqlite.Row
             await db.execute(
                 """INSERT INTO jobs (id, type, schedule, cron, run_at, task, channel,
-                                     status, created_by, description, persona, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                                     status, created_by, description, persona,
+                                     origin_user_id, origin_chat_id, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
                    ON CONFLICT(id) DO UPDATE SET
                        type = excluded.type,
                        schedule = excluded.schedule,
@@ -241,6 +255,8 @@ class JobStore:
                        status = excluded.status,
                        description = excluded.description,
                        persona = excluded.persona,
+                       origin_user_id = excluded.origin_user_id,
+                       origin_chat_id = excluded.origin_chat_id,
                        updated_at = datetime('now')
                 """,
                 (
@@ -255,6 +271,8 @@ class JobStore:
                     created_by,
                     description,
                     persona,
+                    origin_user_id,
+                    origin_chat_id,
                 ),
             )
             await db.commit()

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -45,8 +45,18 @@ async def run_agent_task(
     channel: str = "telegram",
     job_id: str | None = None,
     silent: bool = False,
+    persona: str = "",
+    origin_user_id: str = "",
+    origin_chat_id: str = "",
 ) -> None:
-    """Execute a natural-language task through the agent and deliver the result."""
+    """Execute a natural-language task through the agent and deliver the result.
+
+    ``persona`` / ``origin_chat_id`` carry the originating context (issue #71):
+    the job runs as the persona that scheduled it and is delivered back to the
+    chat it was scheduled in. Both fall back to the legacy behaviour (persona
+    derived from a ``telegram:<persona>`` channel suffix; delivery to the owner
+    DM) when empty, so jobs created before #71 are unaffected.
+    """
     agent = _get_agent_context()
     if agent is None:
         log.error("Scheduler agent task dropped; agent not initialized")
@@ -75,7 +85,7 @@ async def run_agent_task(
             channel="system",
             user_id="scheduler",
             chat_id="scheduler",
-            persona_name=gen_persona,
+            persona_name=persona or gen_persona,
         )
 
         # Deliver the response to the target channel
@@ -85,8 +95,10 @@ async def run_agent_task(
             if silent_mode and not text:
                 log.info("Scheduler silent task produced no updates; skipping send")
                 return
-            # For Telegram, send to the first allowed user (the owner)
-            chat_id = _get_owner_chat_id(agent, channel)
+            # Deliver to the chat the job was scheduled in (#71); fall back to
+            # the owner's chat for jobs with no captured origin (pre-#71, CLI,
+            # config-seeded).
+            chat_id = origin_chat_id or _get_owner_chat_id(agent, channel)
             if chat_id:
                 await ch.send(chat_id, text or response.text)
             else:
@@ -109,31 +121,38 @@ async def run_subagent_task(
     task: str,
     channel: str = "telegram",
     job_id: str | None = None,
+    origin_user_id: str = "",
+    origin_chat_id: str = "",
 ) -> None:
-    """Fire a scheduled subagent run and deliver its result to the channel."""
+    """Fire a scheduled subagent run and deliver its result to the channel.
+
+    Delivers to the chat the job was scheduled in (#71), falling back to the
+    owner's chat when no origin was captured (pre-#71, CLI, config-seeded).
+    """
     agent = _get_agent_context()
     if agent is None:
         log.error("Scheduler subagent task dropped; agent not initialized")
         return
 
     owner = _get_owner_chat_id(agent, channel)
+    target = origin_chat_id or owner
     log.info("Scheduler running subagent (persona=%s): %s", persona or "default", task[:100])
     try:
         result = await agent.run_subagent(
             task=task,
             persona_name=persona or "",
             origin_channel=channel,
-            origin_user_id=str(owner or "scheduler"),
-            origin_chat_id=str(owner or ""),
+            origin_user_id=str(origin_user_id or owner or "scheduler"),
+            origin_chat_id=str(target or ""),
             background=False,
         )
         text = result.get("result") or result.get("error") or ""
         ch = agent.channels.get(channel)
-        if ch and text and owner:
-            await ch.send(owner, text)
+        if ch and text and target:
+            await ch.send(target, text)
         elif not ch:
             log.warning("Scheduler: channel %r not registered, subagent result dropped", channel)
-        elif not owner:
+        elif not target:
             log.warning("Scheduler: no owner chat for channel %r, subagent result dropped", channel)
     except Exception:
         log.exception("Scheduler subagent task failed: %s", task[:100])
@@ -256,6 +275,8 @@ class AgentScheduler:
         task = job.get("task", "")
         channel = job.get("channel", "telegram")
         persona = job.get("persona", "")
+        origin_user_id = job.get("origin_user_id", "")
+        origin_chat_id = job.get("origin_chat_id", "")
         silent = job_type == "agent_silent"
 
         try:
@@ -308,6 +329,8 @@ class AgentScheduler:
                             "task": task,
                             "channel": channel,
                             "job_id": job_id,
+                            "origin_user_id": origin_user_id,
+                            "origin_chat_id": origin_chat_id,
                         },
                         replace_existing=True,
                     )
@@ -322,6 +345,9 @@ class AgentScheduler:
                             "channel": channel,
                             "job_id": job_id,
                             "silent": silent,
+                            "persona": persona,
+                            "origin_user_id": origin_user_id,
+                            "origin_chat_id": origin_chat_id,
                         },
                         replace_existing=True,
                     )
@@ -360,6 +386,8 @@ class AgentScheduler:
                             "task": task,
                             "channel": channel,
                             "job_id": job_id,
+                            "origin_user_id": origin_user_id,
+                            "origin_chat_id": origin_chat_id,
                         },
                         replace_existing=True,
                         **cron_kwargs,
@@ -374,6 +402,9 @@ class AgentScheduler:
                             "channel": channel,
                             "job_id": job_id,
                             "silent": silent,
+                            "persona": persona,
+                            "origin_user_id": origin_user_id,
+                            "origin_chat_id": origin_chat_id,
                         },
                         replace_existing=True,
                         **cron_kwargs,

--- a/docs/content/docs/scheduler.mdx
+++ b/docs/content/docs/scheduler.mdx
@@ -143,3 +143,12 @@ Ask the agent to schedule tasks:
 You: "Check my work email every hour and notify me about anything from Alice"
 Agent: I'll set up an hourly email check for messages from Alice.
 ```
+
+### Originating context
+
+A job scheduled through chat remembers **who** scheduled it and **where**. When the
+job fires it runs as the persona that created it and is delivered back to the same
+chat — so a reminder set by a persona in a group chat is posted by that persona in
+that group, not by the default agent in your 1:1 DM. Jobs created from `config.yml`,
+the CLI, or the admin UI have no chat origin and are delivered to the owner's chat as
+before.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -119,6 +119,30 @@ async def test_run_agent_task_persona_job_generates_as_persona() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_agent_task_runs_as_origin_persona_and_chat() -> None:
+    # Issue #71: a job carrying an origin persona + chat runs AS that persona and
+    # is delivered back to that chat — not the default identity in the owner DM.
+    channel = AsyncMock()
+    agent = SimpleNamespace(
+        channels={"telegram": channel},
+        process=AsyncMock(return_value=SimpleNamespace(text="done")),
+        config=SimpleNamespace(
+            channels=SimpleNamespace(telegram=SimpleNamespace(allowed_user_ids=[123]))
+        ),
+        job_store=None,
+    )
+    set_agent_context(agent)
+
+    await run_agent_task(
+        "do thing", channel="telegram", persona="coach", origin_chat_id="-100200:7"
+    )
+
+    _, kwargs = agent.process.call_args
+    assert kwargs["persona_name"] == "coach"  # not the default identity
+    channel.send.assert_awaited_once_with("-100200:7", "done")  # origin chat, not owner 123
+
+
+@pytest.mark.asyncio
 async def test_run_agent_task_marks_oneshot_done() -> None:
     """One-shot jobs should be marked 'done' after execution."""
     channel = AsyncMock()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -641,6 +641,45 @@ async def test_create_captures_origin_persona_and_chat(agent, monkeypatch) -> No
 
 
 @pytest.mark.asyncio
+async def test_reupsert_without_origin_keeps_it(agent, monkeypatch) -> None:
+    """Editing a job (admin UI / CLI) re-upserts without the origin fields. The
+    persona + chat captured at creation must survive (#71), else the fix silently
+    regresses the first time the owner edits a chat-scheduled reminder."""
+    monkeypatch.setattr(agent.scheduler, "sync_job", _no_sync)
+    state = {
+        "origin": {"channel": "telegram:coach", "user_id": "u7", "chat_id": "-100200:5"},
+        "persona_name": "coach",
+    }
+    res = await agent._tool_manage_jobs(
+        {
+            "action": "create",
+            "job_id": "grp-reminder",
+            "task": "ping",
+            "run_at": "2099-01-01T09:00:00",
+        },
+        state,
+    )
+    assert res.get("ok") is True
+
+    # Simulate an admin/CLI edit: a full upsert that omits persona + origin.
+    await agent.job_store.upsert_job(
+        job_id="grp-reminder",
+        type="agent",
+        schedule="once",
+        run_at="2099-02-02T09:00:00",
+        task="ping edited",
+        channel="telegram",
+        status="active",
+        description="changed",
+    )
+    job = await agent.job_store.get_job("grp-reminder")
+    assert job["task"] == "ping edited"  # the edit applied
+    assert job["persona"] == "coach"  # …but identity + origin survived
+    assert job["origin_user_id"] == "u7"
+    assert job["origin_chat_id"] == "-100200:5"
+
+
+@pytest.mark.asyncio
 async def test_cancelled_job_id_can_be_recreated(agent, monkeypatch) -> None:
     """A done/cancelled id is free to recreate (only live ids block)."""
     monkeypatch.setattr(agent, "_request_approval", _approve)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -478,7 +478,7 @@ async def _approve(name, params, channel, user_id):
     return "approved"
 
 
-async def _ok_manage_jobs(params):
+async def _ok_manage_jobs(params, request_state=None):
     return {"ok": True, "job_id": "job_" + params.get("task", ""), "task": params.get("task")}
 
 
@@ -604,6 +604,40 @@ async def test_recreate_active_job_id_blocked_by_id_not_generic_guard(agent, mon
     assert first.get("ok") is True
     assert "already exists and is active" in second.get("error", "")
     assert "already completed" not in second.get("error", "")
+
+
+@pytest.mark.asyncio
+async def test_create_captures_origin_persona_and_chat(agent, monkeypatch) -> None:
+    """Issue #71: a created job records the persona + chat it was scheduled in,
+    so the scheduler can later run it as that persona in that chat. A job with no
+    origin (pre-#71, CLI, config) keeps empty strings and the legacy behaviour."""
+    monkeypatch.setattr(agent.scheduler, "sync_job", _no_sync)
+
+    origin_state = {
+        "origin": {"channel": "telegram:coach", "user_id": "u7", "chat_id": "-100200:5"},
+        "persona_name": "coach",
+    }
+    res = await agent._tool_manage_jobs(
+        {"action": "create", "task": "remind the group", "run_at": "2099-01-01T09:00:00"},
+        origin_state,
+    )
+    assert res.get("ok") is True
+    job = await agent.job_store.get_job(res["job_id"])
+    assert job["persona"] == "coach"
+    assert job["origin_user_id"] == "u7"
+    assert job["origin_chat_id"] == "-100200:5"
+    assert job["channel"] == "telegram:coach"  # deliver from the same bot
+    assert job["created_by"] == "coach"
+
+    # No request_state → empty origin, default channel (back-compat / CLI path).
+    res2 = await agent._tool_manage_jobs(
+        {"action": "create", "task": "owner ping", "run_at": "2099-01-01T09:00:00"},
+        None,
+    )
+    job2 = await agent.job_store.get_job(res2["job_id"])
+    assert job2["persona"] == ""
+    assert job2["origin_chat_id"] == ""
+    assert job2["channel"] == "telegram"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #71.

## Problem

A reminder/job scheduled by a specific (non-default) persona in a group chat fired in the wrong context:

1. **Wrong agent** — the default agent executed it instead of the persona that scheduled it.
2. **Wrong chat** — it was delivered in the owner's 1:1 DM instead of the originating group/chat.

## Root cause

The `jobs` table persisted no origin. At creation, `manage_jobs` never received the per-turn `request_state`, so the scheduling persona and chat were dropped. At execution, `run_agent_task`/`run_subagent_task` ran with a synthetic context and hard-coded delivery to the owner DM (`allowed_user_ids[0]`); the persona was only ever recovered from a `telegram:<persona>` channel suffix.

## Fix

The job now records its origin and the scheduler restores it:

- **`core/job_store.py`** — two new columns `origin_user_id` / `origin_chat_id` (the persona reuses the existing `persona` column). Added via the existing additive-migration loop, so existing DBs upgrade in place with empty defaults.
- **`core/agent.py`** — `manage_jobs` now receives `request_state` and captures the originating persona, chat, and delivery bot (the same `origin` triple `spawn_subagent` already uses).
- **`core/scheduler.py`** — `run_agent_task` / `run_subagent_task` run as the stored persona and deliver to the originating chat; both fall back to the legacy persona-from-channel + owner-DM behaviour when the origin is empty.
- **`api/admin.py`** — the "run now" trigger honours the same stored origin, so a manual run matches the scheduled one.

The originating `chat_id` is stored in the channel's folded `"<chat>:<thread>"` form, which the Telegram channel already splits on send — so group, topic, and DM targets all work.

## Back-compat

No flag day. Jobs created before this change (and those seeded from `config.yml`, the CLI, or the admin UI) have empty origin fields and behave exactly as before: persona derived from the channel suffix, delivered to the owner's chat.

## Tests

- `tests/test_tools.py` — a created job round-trips the persona + origin chat + delivery bot; a job with no `request_state` keeps empty origin and the default channel.
- `tests/test_scheduler.py` — `run_agent_task` runs as the origin persona and delivers to the origin chat (not the owner DM); existing owner-DM fallback test still passes.

Full suite green (`uv run pytest`), ruff clean. Docs updated (`docs/content/docs/scheduler.mdx`).