### PR TITLE
feat(logs): multi-agent log streams in the Logs tab (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Web artifacts** — The agent publishes pages, multi-file sites, or documents (PDF, image, slides) as shareable links at `/artifacts/<id>/`, with unguessable ids, a sandbox CSP, agent-chosen TTL cleanup, and approval before publishing an on-disk file
 - **Secrets vault** — Encrypted, two-tier secrets store: infrastructure keys (machine-key sealed, served into config via `${vault:NAME}`) and per-persona login/agent secrets (admin-password sealed, used by reference as `{{secret:NAME}}` in commands — values never enter the model's context). Bitwarden import + secure-link credential requests
 - **Permissions** — Glob-pattern rules (ALWAYS/ASK/NEVER) with interactive Telegram approval for write actions
-- **Admin UI** — Web dashboard for configuration, persona & per-chat binding, skills editing, memory inspection, job management, and agent lifecycle control
+- **Admin UI** — Web dashboard for configuration, persona & per-chat binding, skills editing, memory inspection, job management, per-agent log streams (filterable by stream / level / time / text), and agent lifecycle control
 - **Skills** — Teach the agent new capabilities by writing markdown files instead of code
 - **Setup wizard** — Step-by-step first-boot configuration via the admin UI
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -439,8 +439,10 @@ class AgentState:
 # ---------------------------------------------------------------------------
 
 # Structured entries (not formatted strings) so the Logs tab can filter by
-# stream / level / time / text server-side (#75).
-_LOG_BUFFER: collections.deque[dict] = collections.deque(maxlen=500)
+# stream / level / time / text server-side (#75). 5000 lines ≈ a couple of MB and
+# gives the stream/time filters enough history to be useful (the view still caps
+# at the last 300 matches).
+_LOG_BUFFER: collections.deque[dict] = collections.deque(maxlen=5000)
 
 _LOG_INCLUDE_PREFIXES = ("core.", "channels.", "voice.", "tools.")
 _LOG_INCLUDE_NAMES = {"core", "channels", "voice", "tools"}

--- a/api/admin.py
+++ b/api/admin.py
@@ -36,6 +36,7 @@ from core.artifacts import ARTIFACT_CSP, NOT_FOUND_HTML, store_from_config, vali
 from core.config_store import ConfigStore
 from core.goal_decomposition import classify_complexity, decompose_goal
 from core.llm import LLMClient
+from core.log_streams import current_stream, current_subagent
 from core.prompt_builder import (
     DEFAULT_HISTORY_HANDLING_BLOCK,
     DEFAULT_TOOL_USAGE_BLOCK,
@@ -437,7 +438,9 @@ class AgentState:
 # In-memory ring buffer for recent log lines
 # ---------------------------------------------------------------------------
 
-_LOG_BUFFER: collections.deque[str] = collections.deque(maxlen=500)
+# Structured entries (not formatted strings) so the Logs tab can filter by
+# stream / level / time / text server-side (#75).
+_LOG_BUFFER: collections.deque[dict] = collections.deque(maxlen=500)
 
 _LOG_INCLUDE_PREFIXES = ("core.", "channels.", "voice.", "tools.")
 _LOG_INCLUDE_NAMES = {"core", "channels", "voice", "tools"}
@@ -445,6 +448,9 @@ _LOG_INCLUDE_NAMES = {"core", "channels", "voice", "tools"}
 # Model chain-of-thought logger (see core/llm.py). The admin log viewer styles
 # lines from this logger distinctly; the template detects them by this name.
 _REASONING_LOGGER = "core.llm.reasoning"
+
+# Severity levels offered in the Logs tab filter, low → high.
+_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"]
 
 
 def _should_capture_log_record(record: logging.LogRecord) -> bool:
@@ -455,16 +461,86 @@ def _should_capture_log_record(record: logging.LogRecord) -> bool:
     return name.startswith(_LOG_INCLUDE_PREFIXES)
 
 
+def _stream_hue(stream: str) -> int:
+    """A stable hue (0-359) for a stream name, so each agent's lines read in a
+    consistent colour. Deterministic across restarts (no salted hash())."""
+    return (sum(stream.encode()) * 47) % 360
+
+
 class _BufferHandler(logging.Handler):
-    """Logging handler that appends formatted records to an in-memory deque."""
+    """Logging handler that appends structured records to an in-memory deque."""
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
             if not _should_capture_log_record(record):
                 return
-            _LOG_BUFFER.append(self.format(record))
+            stream = current_stream()
+            sub = current_subagent()
+            message = record.getMessage()
+            if sub:
+                message = f"[subagent:{sub}] {message}"
+            _LOG_BUFFER.append(
+                {
+                    "ts": record.created,
+                    "time": datetime.fromtimestamp(record.created).strftime("%H:%M:%S"),
+                    "level": record.levelname,
+                    "levelno": record.levelno,
+                    "name": record.name,
+                    "stream": stream,
+                    "hue": _stream_hue(stream),
+                    "message": message,
+                    "is_reasoning": record.name == _REASONING_LOGGER,
+                }
+            )
         except Exception:
             pass
+
+
+def _filter_log_entries(
+    entries: list[dict],
+    *,
+    stream: str = "",
+    level: str = "",
+    q: str = "",
+    since: str = "",
+    until: str = "",
+) -> list[dict]:
+    """Apply the Logs tab filters. ``stream`` is a regex over the stream name;
+    ``level`` is a minimum severity; ``q`` is a case-insensitive substring over
+    the message; ``since``/``until`` are ``datetime-local`` bounds. Each empty
+    filter is a no-op, so the unfiltered case returns everything."""
+    try:
+        rx = re.compile(stream, re.IGNORECASE) if stream else None
+    except re.error:
+        rx = None  # a half-typed regex shouldn't blank the viewer
+    minlevel = logging.getLevelName(level) if level in _LOG_LEVELS else 0
+    ql = q.strip().lower()
+    lo = _parse_local_dt(since)
+    hi = _parse_local_dt(until)
+    out = []
+    for e in entries:
+        if rx and not rx.search(e["stream"]):
+            continue
+        if minlevel and e["levelno"] < minlevel:
+            continue
+        if ql and ql not in e["message"].lower() and ql not in e["name"].lower():
+            continue
+        if lo is not None and e["ts"] < lo:
+            continue
+        if hi is not None and e["ts"] > hi:
+            continue
+        out.append(e)
+    return out
+
+
+def _parse_local_dt(value: str) -> float | None:
+    """A ``datetime-local`` field (``2026-06-30T14:30``) → epoch seconds, or None."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value).timestamp()
+    except ValueError:
+        return None
 
 
 def install_log_buffer() -> None:
@@ -485,7 +561,6 @@ def install_log_buffer() -> None:
         existing.addFilter(_drop_reasoning)
 
     handler = _BufferHandler()  # added after, so it keeps the reasoning records
-    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)-8s %(name)s — %(message)s"))
     root.addHandler(handler)
 
 
@@ -1495,14 +1570,26 @@ def create_admin_app(
 
     @app.get("/partials/logs", dependencies=[Depends(auth)])
     async def partial_logs() -> HTMLResponse:
-        """Logs tab partial (container with auto-refresh)."""
-        return _render_partial("partials/logs.html")
+        """Logs tab partial (filter controls + auto-refresh)."""
+        return _render_partial("partials/logs.html", levels=_LOG_LEVELS)
 
     @app.get("/partials/logs-content", dependencies=[Depends(auth)])
-    async def partial_logs_content() -> HTMLResponse:
-        """Log lines partial for HTMX swap."""
-        lines = list(_LOG_BUFFER)[-200:]
-        return _render_partial("partials/logs_content.html", lines=lines)
+    async def partial_logs_content(
+        stream: str = "",
+        level: str = "",
+        q: str = "",
+        since: str = "",
+        until: str = "",
+    ) -> HTMLResponse:
+        """Filtered log lines for HTMX swap (#75). Filters: stream (regex), level
+        (min severity), q (text), since/until (time range)."""
+        snapshot = list(_LOG_BUFFER)
+        entries = _filter_log_entries(
+            snapshot, stream=stream, level=level, q=q, since=since, until=until
+        )[-300:]
+        # All stream names ever seen (not just the filtered slice) for the picker.
+        streams = sorted({e["stream"] for e in snapshot})
+        return _render_partial("partials/logs_content.html", entries=entries, streams=streams)
 
     # ── Jobs partial + API ─────────────────────────────────────────────
 

--- a/api/templates/partials/logs.html
+++ b/api/templates/partials/logs.html
@@ -1,28 +1,56 @@
-{# Logs tab partial #}
-<div x-data="{ autoRefresh: false, interval: null }"
+{# Logs tab — per-agent streams with filters (#75).
+   #log-filters carries the filter state; every fetch (manual, on-change, and the
+   auto-refresh poll) sends its values so the view stays filtered. The stream box
+   is a regex with a datalist of live stream names (rendered into #log-content by
+   the content partial); level is a minimum severity. #}
+<div x-data="{ autoRefresh: false, interval: null,
+              poll() {
+                const f = document.getElementById('log-filters');
+                const values = Object.fromEntries(new FormData(f).entries());
+                htmx.ajax('GET', '/partials/logs-content',
+                          {target: '#log-content', swap: 'innerHTML', values});
+              } }"
      x-init="$watch('autoRefresh', val => {
-       if (val) {
-         interval = setInterval(() => htmx.ajax('GET', '/partials/logs-content', {target: '#log-content', swap: 'innerHTML'}), 3000);
-       } else {
-         clearInterval(interval);
-       }
+       clearInterval(interval);
+       if (val) interval = setInterval(() => poll(), 3000);
      })"
      x-effect="() => { return () => clearInterval(interval); }">
 
-  <div class="flex items-center gap-3 mb-4">
-    <button class="btn btn-sm" hx-get="/partials/logs-content" hx-target="#log-content" hx-swap="innerHTML">
-      Refresh
-    </button>
+  <form id="log-filters"
+        hx-get="/partials/logs-content" hx-target="#log-content" hx-swap="innerHTML"
+        hx-trigger="load, change, keyup delay:400ms from:input[name='q']"
+        class="flex flex-wrap items-end gap-3 mb-4">
+    <label class="label">Stream
+      <input type="text" name="stream" list="log-streams" placeholder="all (regex)"
+             class="block w-44 rounded border-border bg-surface text-sm px-2 py-1">
+    </label>
+    <label class="label">Level
+      <select name="level" class="block rounded border-border bg-surface text-sm px-2 py-1">
+        <option value="">all</option>
+        {% for lvl in levels %}<option value="{{ lvl }}">{{ lvl }}</option>{% endfor %}
+      </select>
+    </label>
+    <label class="label">Search
+      <input type="text" name="q" placeholder="text…"
+             class="block w-44 rounded border-border bg-surface text-sm px-2 py-1">
+    </label>
+    <label class="label">From
+      <input type="datetime-local" name="since"
+             class="block rounded border-border bg-surface text-sm px-2 py-1">
+    </label>
+    <label class="label">To
+      <input type="datetime-local" name="until"
+             class="block rounded border-border bg-surface text-sm px-2 py-1">
+    </label>
+    <button type="button" class="btn btn-sm" @click="poll()">Refresh</button>
     <label class="inline-flex items-center gap-1.5 text-xs text-muted cursor-pointer">
       <input type="checkbox" x-model="autoRefresh"
              class="rounded border-border bg-surface text-accent focus:ring-accent">
       Auto-refresh
     </label>
-  </div>
+  </form>
 
-  <div class="log-viewer" id="log-content"
-       hx-get="/partials/logs-content" hx-trigger="load" hx-swap="innerHTML">
-  </div>
+  <div class="log-viewer" id="log-content"></div>
 </div>
 
 <script>
@@ -30,7 +58,6 @@
   document.body.addEventListener('htmx:afterSettle', function(evt) {
     const viewer = document.getElementById('log-content');
     if (!viewer || evt.detail.target !== viewer) return;
-    // Check if auto-refresh is on via the Alpine component
     const alpineRoot = viewer.closest('[x-data]');
     const autoRefresh = alpineRoot && Alpine.$data(alpineRoot).autoRefresh;
     const atBottom = (viewer.scrollHeight - viewer.scrollTop - viewer.clientHeight) < 50;

--- a/api/templates/partials/logs.html
+++ b/api/templates/partials/logs.html
@@ -3,7 +3,7 @@
    auto-refresh poll) sends its values so the view stays filtered. The stream box
    is a regex with a datalist of live stream names (rendered into #log-content by
    the content partial); level is a minimum severity. #}
-<div x-data="{ autoRefresh: false, interval: null,
+<div x-data="{ autoRefresh: false, interval: null, intervalSec: 3,
               poll() {
                 const f = document.getElementById('log-filters');
                 // The form is gone once the user leaves the Logs tab — self-clear
@@ -12,11 +12,15 @@
                 const values = Object.fromEntries(new FormData(f).entries());
                 htmx.ajax('GET', '/partials/logs-content',
                           {target: '#log-content', swap: 'innerHTML', values});
+              },
+              restart() {
+                clearInterval(this.interval);
+                if (this.autoRefresh) {
+                  const ms = Math.max(1, Number(this.intervalSec) || 3) * 1000;
+                  this.interval = setInterval(() => this.poll(), ms);
+                }
               } }"
-     x-init="$watch('autoRefresh', val => {
-       clearInterval(interval);
-       if (val) interval = setInterval(() => poll(), 3000);
-     })">
+     x-init="$watch('autoRefresh', () => restart()); $watch('intervalSec', () => restart())">
 
   <form id="log-filters"
         hx-get="/partials/logs-content" hx-target="#log-content" hx-swap="innerHTML"
@@ -48,7 +52,10 @@
     <label class="inline-flex items-center gap-1.5 text-xs text-muted cursor-pointer">
       <input type="checkbox" x-model="autoRefresh"
              class="rounded border-border bg-surface text-accent focus:ring-accent">
-      Auto-refresh
+      Auto-refresh every
+      <input type="number" min="1" x-model.number="intervalSec"
+             class="w-14 rounded border-border bg-surface text-xs px-1 py-0.5">
+      s
     </label>
   </form>
 

--- a/api/templates/partials/logs.html
+++ b/api/templates/partials/logs.html
@@ -6,6 +6,9 @@
 <div x-data="{ autoRefresh: false, interval: null,
               poll() {
                 const f = document.getElementById('log-filters');
+                // The form is gone once the user leaves the Logs tab — self-clear
+                // the orphaned auto-refresh timer instead of throwing every tick.
+                if (!f) { clearInterval(this.interval); return; }
                 const values = Object.fromEntries(new FormData(f).entries());
                 htmx.ajax('GET', '/partials/logs-content',
                           {target: '#log-content', swap: 'innerHTML', values});
@@ -13,8 +16,7 @@
      x-init="$watch('autoRefresh', val => {
        clearInterval(interval);
        if (val) interval = setInterval(() => poll(), 3000);
-     })"
-     x-effect="() => { return () => clearInterval(interval); }">
+     })">
 
   <form id="log-filters"
         hx-get="/partials/logs-content" hx-target="#log-content" hx-swap="innerHTML"

--- a/api/templates/partials/logs_content.html
+++ b/api/templates/partials/logs_content.html
@@ -1,10 +1,12 @@
 {# Log lines — swapped into #log-content by HTMX (#75).
    Each line carries its stream as a colour-coded badge so concurrent agents are
    distinguishable; subagent lines arrive already prefixed "[subagent:<id>]".
-   Reasoning/CoT lines (logger core.llm.reasoning) keep their distinct style. #}
-<datalist id="log-streams">
-{% for s in streams %}<option value="{{ s }}"></option>{% endfor %}
-</datalist>
-{% if not entries %}<span class="text-muted">No log lines match the current filters.</span>
-{% endif %}{% for e in entries %}<div class="{% if e.is_reasoning %}log-thinking{% endif %}">{% if e.is_reasoning %}💭 {% endif %}<span class="text-muted">{{ e.time }}</span> <span class="text-muted">{{ "%-7s"|format(e.level) }}</span> <span style="color: hsl({{ e.hue }} 70% 65%)">[{{ e.stream }}]</span> {{ e.message }}</div>
-{% endfor %}
+   Reasoning/CoT lines (logger core.llm.reasoning) keep their distinct style.
+   The viewer is white-space: pre-wrap (preserves the level column's padding), so
+   trim markers strip the inter-element newlines that would otherwise render as
+   blank lines between every log line. -#}
+<datalist id="log-streams">{% for s in streams %}<option value="{{ s }}"></option>{% endfor %}</datalist>
+{%- if not entries %}<span class="text-muted">No log lines match the current filters.</span>{% endif -%}
+{%- for e in entries -%}
+<div class="{% if e.is_reasoning %}log-thinking{% endif %}">{% if e.is_reasoning %}💭 {% endif %}<span class="text-muted">{{ e.time }}</span> <span class="text-muted">{{ "%-7s"|format(e.level) }}</span> <span style="color: hsl({{ e.hue }} 70% 65%)">[{{ e.stream }}]</span> {{ e.message }}</div>
+{%- endfor -%}

--- a/api/templates/partials/logs_content.html
+++ b/api/templates/partials/logs_content.html
@@ -1,6 +1,10 @@
-{# Log content — swapped into #log-content by HTMX.
-   Reasoning/CoT lines (logger core.llm.reasoning) render in a distinct style
-   so the model's thinking trace stands apart from regular log lines. #}
-{% for line in lines %}{% if 'core.llm.reasoning — ' in line %}<span class="log-thinking">💭 {{ line }}</span>
-{% else %}{{ line }}
-{% endif %}{% endfor %}
+{# Log lines — swapped into #log-content by HTMX (#75).
+   Each line carries its stream as a colour-coded badge so concurrent agents are
+   distinguishable; subagent lines arrive already prefixed "[subagent:<id>]".
+   Reasoning/CoT lines (logger core.llm.reasoning) keep their distinct style. #}
+<datalist id="log-streams">
+{% for s in streams %}<option value="{{ s }}"></option>{% endfor %}
+</datalist>
+{% if not entries %}<span class="text-muted">No log lines match the current filters.</span>
+{% endif %}{% for e in entries %}<div class="{% if e.is_reasoning %}log-thinking{% endif %}">{% if e.is_reasoning %}💭 {% endif %}<span class="text-muted">{{ e.time }}</span> <span class="text-muted">{{ "%-7s"|format(e.level) }}</span> <span style="color: hsl({{ e.hue }} 70% 65%)">[{{ e.stream }}]</span> {{ e.message }}</div>
+{% endfor %}

--- a/core/agent.py
+++ b/core/agent.py
@@ -28,6 +28,7 @@ from core.history import ConversationHistory
 from core.imagegen import ImageBudget
 from core.job_store import JobStore
 from core.llm import LLMClient, LLMToolCall, model_supports_vision
+from core.log_streams import set_stream, subagent_stream
 from core.memory import MemoryStore
 from core.models import IMAGE_MIME_TYPES, AgentResponse, Attachment
 from core.permissions import PermissionEngine, PermissionLevel, format_approval_message
@@ -806,6 +807,11 @@ class AgentCore:
             persona = await self._load_persona(persona_name)
         else:
             persona = await self._resolve_persona(channel, user_id, chat_id)
+
+        # Tag this turn's log records with the persona's stream (#75) so the admin
+        # Logs tab can filter per agent. Subagents spawned below inherit it (the
+        # ContextVar is copied into their task) and add their own label.
+        set_stream(persona.name if persona else "default")
 
         # Reply decision (#36): in a shared/group chat, stay quiet for messages
         # aimed at someone else or caught in a bot-to-bot reaction loop. Off by
@@ -2414,6 +2420,18 @@ class AgentCore:
         )
 
     async def _run_subagent_loop(
+        self, task: str, child_persona: Persona | None, child_state: dict, run: SubagentRun
+    ) -> str:
+        """Route this subagent's log records into its spawner's stream (#75).
+
+        The label (persona slug, else run id) prefixes each line as
+        ``[subagent:<label>]`` so it filters out of the shared stream; ``fallback``
+        names the stream for a top-level scheduled run that inherited none.
+        """
+        with subagent_stream(run.persona or run.run_id, fallback=run.persona):
+            return await self._run_subagent_loop_inner(task, child_persona, child_state, run)
+
+    async def _run_subagent_loop_inner(
         self, task: str, child_persona: Persona | None, child_state: dict, run: SubagentRun
     ) -> str:
         """The subagent's agentic loop — system semantics, budgeted and depth-capped.

--- a/core/log_streams.py
+++ b/core/log_streams.py
@@ -1,0 +1,95 @@
+"""Per-agent log streams (issue #75).
+
+The admin Logs tab used to show one flat stream, so with several personae and
+subagents running at once you could not tell which line belonged to whom. The
+fix is a :class:`contextvars.ContextVar` that carries the *stream* a log record
+belongs to — the persona slug of the turn in flight, or ``default``.
+
+``asyncio`` copies the context when a task is created, so a background subagent's
+task inherits its spawner's stream for free; a second ContextVar marks subagent
+lines so they read ``[subagent:<id>] …`` inside that one shared stream (issue
+point 2: subagent logs flow into the originating agent's stream, not a separate
+one). The admin log buffer reads both off the live context when a record is
+emitted — logging is synchronous within the emitting task, so the values are
+always the right ones.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+
+DEFAULT_STREAM = "default"
+
+# Empty = "never set by a turn" (distinct from a turn that ran as the default
+# identity, which sets it to "default" explicitly). The distinction matters for
+# subagent_stream's fallback below.
+_stream: contextvars.ContextVar[str] = contextvars.ContextVar("mpa_log_stream", default="")
+_subagent: contextvars.ContextVar[str] = contextvars.ContextVar("mpa_log_subagent", default="")
+
+
+def current_stream() -> str:
+    """The stream the calling task's log records belong to."""
+    return _stream.get() or DEFAULT_STREAM
+
+
+def current_subagent() -> str:
+    """The subagent label for the calling task, or ``""`` for a top-level turn."""
+    return _subagent.get()
+
+
+def set_stream(name: str) -> None:
+    """Tag every later log record in this task with stream ``name``.
+
+    Called once per turn after the persona is resolved. No reset: channels run
+    each turn in its own ``asyncio`` task (so the value dies with the task), and
+    a reused task — the REPL — overwrites it at the next turn's entry anyway.
+    """
+    _stream.set(name or DEFAULT_STREAM)
+
+
+@contextlib.contextmanager
+def subagent_stream(label: str, *, fallback: str = ""):
+    """Mark records inside as a subagent's, routed into the spawner's stream.
+
+    Keeps the inherited stream (the spawner's) when a turn set one. For a
+    top-level run that inherited none — a scheduled ``subagent`` job — it adopts
+    ``fallback`` (the run's own persona slug) so the lines still land in a
+    sensibly named stream instead of ``default``.
+    """
+    stream_token = None
+    if not _stream.get() and fallback:
+        stream_token = _stream.set(fallback)
+    sub_token = _subagent.set(label or "")
+    try:
+        yield
+    finally:
+        _subagent.reset(sub_token)
+        if stream_token is not None:
+            _stream.reset(stream_token)
+
+
+def _demo() -> None:
+    """Self-check: the stream tags follow the context, subagents keep the parent
+    stream while carrying their own label, and nesting unwinds cleanly."""
+    assert current_stream() == "default" and current_subagent() == ""
+
+    set_stream("coding-helper")
+    assert current_stream() == "coding-helper"
+
+    # A spawned subagent keeps the parent stream, adds a label.
+    with subagent_stream("sub_abc123", fallback="other"):
+        assert current_stream() == "coding-helper"  # parent's, not the fallback
+        assert current_subagent() == "sub_abc123"
+    assert current_subagent() == ""  # unwound
+
+    # A top-level subagent (no turn set a stream) adopts its fallback.
+    _stream.set("")
+    with subagent_stream("sub_xyz", fallback="finance-assistant"):
+        assert current_stream() == "finance-assistant"
+    assert current_stream() == "default"
+    print("log_streams demo ok")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -109,7 +109,23 @@ web-only; over Telegram you can see names and access but never values.
 
 ### Logs
 
-Real-time log viewer for debugging and monitoring agent behavior.
+Real-time log viewer for debugging and monitoring agent behavior. Each line is
+tagged with the **stream** it belongs to — the active persona's slug, or
+`default` for the base identity — shown as a colour-coded `[stream]` badge so
+concurrent agents are easy to tell apart. A [subagent](/docs/subagents)'s lines
+(its reasoning and tool calls) flow into the **same stream as the agent that
+spawned it**, prefixed `[subagent:<id>]`, so one stream is a full logical session
+regardless of how many subagents were involved.
+
+The filter bar narrows the view:
+
+- **Stream** — pick a name from the live list, or type a **regex** to match several
+- **Level** — minimum severity (`DEBUG` → `ERROR`)
+- **Search** — free-text match within the line
+- **From / To** — a timestamp range
+
+**Auto-refresh** re-polls every few seconds keeping the active filters; model
+chain-of-thought lines render in a distinct style.
 
 ## Setup wizard
 

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -211,7 +211,7 @@ def test_install_log_buffer_routes_reasoning_to_buffer_not_console() -> None:
         reasoning_logger.info("secret chain of thought")
         agent_logger.info("ordinary log line")
 
-        buffered = "\n".join(_LOG_BUFFER)
+        buffered = "\n".join(e["message"] for e in _LOG_BUFFER)
         assert "secret chain of thought" in buffered  # CoT surfaced in admin UI
         assert "ordinary log line" in buffered
         assert _REASONING_LOGGER not in console_seen  # but kept off the console

--- a/tests/test_log_streams.py
+++ b/tests/test_log_streams.py
@@ -1,0 +1,103 @@
+"""Per-agent log streams (issue #75): context tagging, buffering, filtering."""
+
+from __future__ import annotations
+
+import logging
+
+from api.admin import _BufferHandler, _filter_log_entries, _stream_hue
+from core.log_streams import current_stream, set_stream, subagent_stream
+
+
+def _emit(logger_name: str, level: int = logging.INFO, msg: str = "hi") -> dict:
+    """Emit one record through a fresh _BufferHandler and return the entry."""
+    handler = _BufferHandler()
+    rec = logging.LogRecord(logger_name, level, __file__, 1, msg, None, None)
+    captured: list[dict] = []
+    # The handler appends to the module deque; intercept by swapping it.
+    import api.admin as admin
+
+    saved = admin._LOG_BUFFER
+    admin._LOG_BUFFER = captured  # type: ignore[assignment]
+    try:
+        handler.emit(rec)
+    finally:
+        admin._LOG_BUFFER = saved
+    return captured[0] if captured else {}
+
+
+def test_record_tagged_with_current_stream() -> None:
+    set_stream("coding-helper")
+    entry = _emit("core.agent")
+    assert entry["stream"] == "coding-helper"
+    assert entry["message"] == "hi"
+    set_stream("default")  # restore
+
+
+def test_subagent_lines_prefixed_and_keep_parent_stream() -> None:
+    set_stream("coding-helper")
+    with subagent_stream("sub_abc", fallback="ignored"):
+        # parent stream kept; line marked as the subagent's
+        assert current_stream() == "coding-helper"
+        entry = _emit("core.agent", msg="thinking")
+    assert entry["stream"] == "coding-helper"
+    assert entry["message"] == "[subagent:sub_abc] thinking"
+    set_stream("default")
+
+
+def test_non_core_loggers_not_captured() -> None:
+    assert _emit("httpx") == {}  # outside the include list → dropped
+
+
+def _entries() -> list[dict]:
+    def e(ts, levelno, level, stream, name, message):
+        return {
+            "ts": ts,
+            "levelno": levelno,
+            "level": level,
+            "stream": stream,
+            "name": name,
+            "message": message,
+        }
+
+    return [
+        e(100.0, 20, "INFO", "default", "core.a", "alpha"),
+        e(200.0, 30, "WARNING", "coding-helper", "core.b", "beta"),
+        e(300.0, 40, "ERROR", "finance-assistant", "core.c", "[subagent:sub_x] gamma"),
+    ]
+
+
+def test_filter_by_stream_regex() -> None:
+    out = _filter_log_entries(_entries(), stream="coding|finance")
+    assert {e["stream"] for e in out} == {"coding-helper", "finance-assistant"}
+
+
+def test_filter_by_min_level() -> None:
+    out = _filter_log_entries(_entries(), level="WARNING")
+    assert [e["message"] for e in out] == ["beta", "[subagent:sub_x] gamma"]
+
+
+def test_filter_by_text() -> None:
+    assert [e["message"] for e in _filter_log_entries(_entries(), q="alpha")] == ["alpha"]
+    # subagent prefix is searchable text
+    assert len(_filter_log_entries(_entries(), q="subagent")) == 1
+
+
+def test_filter_by_time_range() -> None:
+    # 150..250 epoch → only the 200.0 entry. datetime-local strings map to epoch.
+    import datetime as dt
+
+    def local(ts: float) -> str:
+        return dt.datetime.fromtimestamp(ts).strftime("%Y-%m-%dT%H:%M:%S")
+
+    out = _filter_log_entries(_entries(), since=local(150), until=local(250))
+    assert [e["message"] for e in out] == ["beta"]
+
+
+def test_bad_regex_is_noop_not_crash() -> None:
+    # an unfinished regex must not blank the viewer
+    assert len(_filter_log_entries(_entries(), stream="[")) == 3
+
+
+def test_stream_hue_is_stable() -> None:
+    assert _stream_hue("default") == _stream_hue("default")
+    assert 0 <= _stream_hue("coding-helper") < 360


### PR DESCRIPTION
Closes #75.

## What

The Logs tab was one flat stream — with several personae and subagents running at once you couldn't tell which line belonged to whom. This gives each agent its own **named, filterable stream**.

### 1. One stream per agent
A `contextvars.ContextVar` carries the **stream** each log record belongs to — the persona slug of the turn in flight, or `default` for the base identity. `set_stream()` is called in `AgentCore.process` once the persona is resolved, so every line of that turn (incl. model chain-of-thought) is tagged. Lines show a colour-coded `[stream]` badge.

### 2. Subagent logs flow into the parent stream
`asyncio` copies the context into child tasks, so a spawned subagent **inherits its spawner's stream for free**; `_run_subagent_loop` is wrapped in `subagent_stream(...)` which keeps that stream and marks the lines, so they read `[subagent:<id>] …` inside the one shared stream — a single stream is a full logical session regardless of how many subagents ran. A top-level scheduled `subagent` job (no parent turn) falls back to its own persona slug.

### 3. Filtering
The ring buffer now holds structured entries (`ts/level/name/stream/message/…`) instead of formatted strings, and the Logs tab gains a filter bar:
- **Stream** — pick from a live datalist, or type a **regex**
- **Level** — minimum severity (`DEBUG`→`ERROR`)
- **Search** — free-text within the line
- **From / To** — a timestamp range

Auto-refresh re-sends the active filters.

## Out of scope (per the issue)
WebSocket streaming, persistent storage, external aggregation.

## Tests
`tests/test_log_streams.py` covers context tagging, the subagent prefix + parent-stream routing, and every filter (stream regex, min level, text, time range, bad-regex no-op). Full suite green (659 passed).