### PR TITLE
fix(llm): config-driven max_tokens + truncation detection (#77)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1069,6 +1069,7 @@ def create_admin_app(
         grok_vaulted = _is_vault_ref(grok_api_key)
         deepseek_vaulted = _is_vault_ref(deepseek_api_key)
         model = await config_store.get("agent.model") or "claude-4-6-sonnet"
+        max_tokens = await config_store.get("agent.max_tokens") or "8192"
         thinking_level = await config_store.get("agent.thinking_level") or ""
         extraction_provider = await config_store.get("memory.extraction_provider") or "deepseek"
         extraction_model = await config_store.get("memory.extraction_model") or "deepseek-v4-flash"
@@ -1132,6 +1133,7 @@ def create_admin_app(
             deepseek_vaulted=deepseek_vaulted,
             deepseek_base_url=deepseek_base_url,
             model=model,
+            max_tokens=max_tokens,
             thinking_level=thinking_level,
             extraction_provider=extraction_provider,
             extraction_model=extraction_model,

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -82,7 +82,7 @@
     }
     window.restartAgentNow = restartAgentNow;
 
-    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds) {
+    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens) {
       const currentProvider = provider || 'anthropic';
       return {
         providerOptions: [
@@ -95,6 +95,7 @@
         provider: currentProvider,
         apiKey: apiKey || '',
         model: model || '',
+        maxTokens: maxTokens || '8192',
         thinkingLevel: thinkingLevel || '',
         extractionThinkingLevel: extractionThinkingLevel || '',
         consolidationThinkingLevel: consolidationThinkingLevel || '',

--- a/api/templates/partials/llm.html
+++ b/api/templates/partials/llm.html
@@ -70,7 +70,8 @@
   {{ rd_thinking_level|default('', true)|tojson|forceescape }},
   {{ rd_group_only|default('true', true)|tojson|forceescape }},
   {{ rd_max_replies|default('6', true)|tojson|forceescape }},
-  {{ rd_window_seconds|default('120', true)|tojson|forceescape }}
+  {{ rd_window_seconds|default('120', true)|tojson|forceescape }},
+  {{ max_tokens|default('8192', true)|tojson|forceescape }}
 )">
   <div class="card">
     <h2 class="text-base mb-1">System Prompt Controls</h2>
@@ -235,6 +236,12 @@
         </div>
       </div>
 
+      <div>
+        <label class="label">Max output tokens</label>
+        <input type="number" min="256" class="input-sm" style="max-width:200px" x-model="maxTokens">
+        <p class="text-muted text-xs mt-1">Hard ceiling on tokens the model may emit per response. Too low truncates large outputs (e.g. web artifacts) mid-generation. Default 8192; raise for capable models (Claude allows up to 128000).</p>
+      </div>
+
 {{ think('thinkingLevel', 'provider', 'model', 'dl-think-main') }}
     </form>
 
@@ -259,7 +266,8 @@
                     'agent.deepseek_api_key': deepseekKey,
                     'agent.deepseek_base_url': deepseekBaseUrl,
                     'agent.model': model,
-                    'agent.thinking_level': thinkingLevel
+                    'agent.thinking_level': thinkingLevel,
+                    'agent.max_tokens': String(maxTokens)
                   }})
                 })
                 .then(r => { resultOk = r.ok; return r.json(); })

--- a/config.yml.example
+++ b/config.yml.example
@@ -12,6 +12,7 @@ agent:
   deepseek_api_key: "${DEEPSEEK_API_KEY}"
   deepseek_base_url: "${DEEPSEEK_BASE_URL}"
   model: "deepseek-v4-flash"
+  max_tokens: 8192                  # max tokens the model may emit per response; raise for capable models (Claude up to 128000)
   timezone: "Europe/Zurich"
   skills_dir: "skills/"
   personae_dir: "personae/"        # starter-gallery seed directory

--- a/core/agent.py
+++ b/core/agent.py
@@ -65,6 +65,37 @@ _VISION_CACHE_MAX = 256
 # un-addressed run legitimately needs more context than this.
 _SILENT_FOLD_MAX_CHARS = 16000
 
+# When the model's response is cut off at the output-token limit (issue #77),
+# any tool call in it has truncated/empty arguments. Instead of running the
+# half-built call (which returns a misleading "missing parameter" error and
+# sends the model into a retry loop), feed back this notice so it produces a
+# smaller output. ponytail: cap consecutive truncations so a model that keeps
+# overflowing can't loop forever — the repeat-failure breaker (#78) generalises this.
+_TRUNCATION_NOTICE = (
+    "Your previous response was cut off at the output token limit before this "
+    "tool call's arguments were complete, so the call was NOT run. Produce a "
+    "smaller output: write large content (HTML, files) to disk incrementally — "
+    "e.g. in chunks via run_command — or split the work across turns, rather "
+    "than passing it all in one tool argument."
+)
+_MAX_TRUNCATION_RETRIES = 3
+
+
+def _truncation_tool_results(response) -> list[dict]:
+    """Error tool_results for a truncated response's pending calls (issue #77).
+
+    The half-built calls are not executed; each tool_use still needs a paired
+    tool_result for the next turn, so emit the truncation notice for each.
+    """
+    return [
+        {
+            "type": "tool_result",
+            "tool_use_id": call.id,
+            "content": json.dumps({"error": _TRUNCATION_NOTICE}),
+        }
+        for call in response.tool_calls
+    ]
+
 
 def _shell_quote(s: str) -> str:
     """Quote a string for safe shell interpolation."""
@@ -1369,7 +1400,7 @@ class AgentCore:
         # Initial LLM call
         response = await self.llm.generate(
             model=self.config.agent.model,
-            max_tokens=4096,
+            max_tokens=self.config.agent.max_tokens,
             system=system,
             messages=messages,
             tools=cast(Any, tools),
@@ -1383,26 +1414,37 @@ class AgentCore:
         # but not in _execute_tool); every tool call this turn reads the cached flag.
         request_state["yolo"] = self.permissions.is_yolo(self._yolo_scope(channel, chat_id))
         tool_log: list[dict] = []
+        truncations = 0
         while response.tool_calls:
-            await self._batch_approve_writes(response.tool_calls, channel, user_id, request_state)
-            tool_results = []
-            for call in response.tool_calls:
-                result = await self._execute_tool(call, channel, user_id, request_state)
-                tool_log.append({"name": call.name, "args": call.arguments, "result": result})
-                tool_results.append(
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": call.id,
-                        "content": json.dumps(result),
-                    }
+            if response.truncated:
+                truncations += 1
+                if truncations > _MAX_TRUNCATION_RETRIES:
+                    log.warning("Giving up after %d truncated responses in a row", truncations)
+                    break
+                tool_results = _truncation_tool_results(response)
+            else:
+                truncations = 0
+                await self._batch_approve_writes(
+                    response.tool_calls, channel, user_id, request_state
                 )
+                tool_results = []
+                for call in response.tool_calls:
+                    result = await self._execute_tool(call, channel, user_id, request_state)
+                    tool_log.append({"name": call.name, "args": call.arguments, "result": result})
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call.id,
+                            "content": json.dumps(result),
+                        }
+                    )
 
             # Feed tool results back to the LLM
             messages.append(self.llm.assistant_message(response))
             messages.extend(self.llm.tool_result_messages(tool_results))
             response = await self.llm.generate(
                 model=self.config.agent.model,
-                max_tokens=4096,
+                max_tokens=self.config.agent.max_tokens,
                 system=system,
                 messages=messages,
                 tools=cast(Any, tools),
@@ -1481,7 +1523,7 @@ class AgentCore:
         # Initial LLM call with the full session
         response = await self.llm.generate(
             model=self.config.agent.model,
-            max_tokens=4096,
+            max_tokens=self.config.agent.max_tokens,
             system=system,
             messages=session,
             tools=cast(Any, tools),
@@ -1496,19 +1538,30 @@ class AgentCore:
         # but not in _execute_tool); every tool call this turn reads the cached flag.
         request_state["yolo"] = self.permissions.is_yolo(self._yolo_scope(channel, chat_id))
         tool_log: list[dict] = []
+        truncations = 0
         while response.tool_calls:
-            await self._batch_approve_writes(response.tool_calls, channel, user_id, request_state)
-            tool_results = []
-            for call in response.tool_calls:
-                result = await self._execute_tool(call, channel, user_id, request_state)
-                tool_log.append({"name": call.name, "args": call.arguments, "result": result})
-                tool_results.append(
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": call.id,
-                        "content": json.dumps(result),
-                    }
+            if response.truncated:
+                truncations += 1
+                if truncations > _MAX_TRUNCATION_RETRIES:
+                    log.warning("Giving up after %d truncated responses in a row", truncations)
+                    break
+                tool_results = _truncation_tool_results(response)
+            else:
+                truncations = 0
+                await self._batch_approve_writes(
+                    response.tool_calls, channel, user_id, request_state
                 )
+                tool_results = []
+                for call in response.tool_calls:
+                    result = await self._execute_tool(call, channel, user_id, request_state)
+                    tool_log.append({"name": call.name, "args": call.arguments, "result": result})
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call.id,
+                            "content": json.dumps(result),
+                        }
+                    )
 
             # Append tool exchange to session
             assistant_msg = self.llm.assistant_message(response)
@@ -1525,7 +1578,7 @@ class AgentCore:
 
             response = await self.llm.generate(
                 model=self.config.agent.model,
-                max_tokens=4096,
+                max_tokens=self.config.agent.max_tokens,
                 system=system,
                 messages=session,
                 tools=cast(Any, tools),
@@ -2448,7 +2501,7 @@ class AgentCore:
             llm = self._background_llm(self.llm.provider, run.effort)
         response = await llm.generate(
             model=self.config.agent.model,
-            max_tokens=4096,
+            max_tokens=self.config.agent.max_tokens,
             system=system,
             messages=messages,
             tools=cast(Any, tools),
@@ -2458,23 +2511,28 @@ class AgentCore:
         while response.tool_calls and steps < run.max_steps and tokens < run.token_budget:
             steps += 1
             run.progress = f"step {steps}: {', '.join(c.name for c in response.tool_calls)}"[:120]
-            tool_results = []
-            for call in response.tool_calls:
-                result = await self._execute_tool(
-                    call, "system", run.origin_user_id or "subagent", child_state
-                )
-                tool_results.append(
-                    {
-                        "type": "tool_result",
-                        "tool_use_id": call.id,
-                        "content": json.dumps(result),
-                    }
-                )
+            # A truncated round (issue #77) has half-built call args; skip
+            # execution and feed back the notice. steps caps the retries here.
+            if response.truncated:
+                tool_results = _truncation_tool_results(response)
+            else:
+                tool_results = []
+                for call in response.tool_calls:
+                    result = await self._execute_tool(
+                        call, "system", run.origin_user_id or "subagent", child_state
+                    )
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call.id,
+                            "content": json.dumps(result),
+                        }
+                    )
             messages.append(llm.assistant_message(response))
             messages.extend(llm.tool_result_messages(tool_results))
             response = await llm.generate(
                 model=self.config.agent.model,
-                max_tokens=4096,
+                max_tokens=self.config.agent.max_tokens,
                 system=system,
                 messages=messages,
                 tools=cast(Any, tools),

--- a/core/agent.py
+++ b/core/agent.py
@@ -79,6 +79,12 @@ _TRUNCATION_NOTICE = (
     "than passing it all in one tool argument."
 )
 _MAX_TRUNCATION_RETRIES = 3
+# Shown to the user when the truncation cap trips and the model produced no
+# usable text (only a cut-off tool call) — better than a blank reply.
+_TRUNCATION_GIVEUP_MESSAGE = (
+    "I couldn't fit my response within the output limit. Try narrowing the "
+    "request, or ask me to produce the result in smaller parts."
+)
 
 
 def _truncation_tool_results(response) -> list[dict]:
@@ -1450,6 +1456,8 @@ class AgentCore:
                 tools=cast(Any, tools),
             )
         final_text = response.text
+        if response.truncated and not final_text:
+            final_text = _TRUNCATION_GIVEUP_MESSAGE
         log.info("Response: %s", final_text[:200])
 
         # Check if the LLM wants to respond with voice
@@ -1584,11 +1592,14 @@ class AgentCore:
                 tools=cast(Any, tools),
             )
 
+        final_text = response.text
+        if response.truncated and not final_text:
+            final_text = _TRUNCATION_GIVEUP_MESSAGE
+
         # Append the final assistant response to the session
-        final_assistant_msg = {"role": "assistant", "content": response.text}
+        final_assistant_msg = {"role": "assistant", "content": final_text}
         await self.history.append_session_message(channel, user_id, final_assistant_msg, chat_id)
 
-        final_text = response.text
         log.info("Response: %s", final_text[:200])
 
         # Compaction — if the context has grown past the configured threshold,

--- a/core/config.py
+++ b/core/config.py
@@ -74,6 +74,12 @@ class AgentConfig(BaseModel):
     deepseek_base_url: str = ""
     model: str = "deepseek-v4-flash"
     thinking_level: str = ""  # "" (off) | "low" | "medium" | "high" — only for reasoning models
+    # Hard ceiling on tokens the model may emit per response. The agentic loop
+    # truncates mid-tool-call when this is too small for the output (e.g. a large
+    # write_artifact payload), so keep it generous. 8192 is safe across providers;
+    # raise it on the LLM admin tab for capable models (Claude allows up to
+    # 128000 — note large non-streaming outputs can approach provider timeouts).
+    max_tokens: int = 8192
     timezone: str = "Europe/Zurich"
     skills_dir: str = "skills/"
     skills_db_path: str = "data/skills.db"

--- a/core/llm.py
+++ b/core/llm.py
@@ -79,6 +79,11 @@ class LLMResponse:
     # input_tokens, output_tokens, cache_read_input_tokens,
     # cache_creation_input_tokens, context_tokens (= full prompt size).
     usage: dict[str, int] | None = None
+    # True when the provider stopped at the output-token limit (Anthropic
+    # stop_reason == "max_tokens" / OpenAI finish_reason == "length"), i.e. the
+    # response — including any tool-call arguments — was cut off mid-stream. The
+    # agent loop surfaces this instead of running a half-built tool call.
+    truncated: bool = False
 
 
 def _anthropic_usage(response: Any) -> dict[str, int] | None:
@@ -314,6 +319,7 @@ class LLMClient:
                 reasoning=reasoning,
                 raw=response.content,
                 usage=_anthropic_usage(response),
+                truncated=getattr(response, "stop_reason", None) == "max_tokens",
             )
 
         openai_tools = _openai_tools(tools)
@@ -347,6 +353,7 @@ class LLMClient:
             reasoning=reasoning,
             raw=message.model_dump(exclude_none=True),
             usage=_openai_usage(response),
+            truncated=getattr(response.choices[0], "finish_reason", None) == "length",
         )
 
     def assistant_message(self, response: LLMResponse) -> dict[str, Any]:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -60,6 +60,65 @@ async def test_anthropic_generate_text_sends_effort_when_set() -> None:
     assert kwargs["output_config"] == {"effort": "low"}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stop_reason", "expected"),
+    [("max_tokens", True), ("end_turn", False)],
+)
+async def test_anthropic_generate_flags_truncation(stop_reason: str, expected: bool) -> None:
+    """stop_reason == 'max_tokens' means the response (incl. tool args) was cut off (#77)."""
+    client = LLMClient("anthropic", "x")
+    resp = type("R", (), {"content": [], "usage": None, "stop_reason": stop_reason})()
+    create = AsyncMock(return_value=resp)
+    client._client = type("C", (), {"messages": type("M", (), {"create": create})()})()
+
+    out = await client.generate(model="claude-4-6-opus", system="s", messages=[], tools=[])
+    assert out.truncated is expected
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_flags_truncation() -> None:
+    """OpenAI/DeepSeek signal the same cut-off via finish_reason == 'length' (#77)."""
+    client = LLMClient("openai", "x")
+    msg = type(
+        "Msg",
+        (),
+        {
+            "tool_calls": None,
+            "content": "hi",
+            "reasoning_content": None,
+            "reasoning": None,
+            "model_dump": lambda self, exclude_none=True: {"role": "assistant", "content": "hi"},
+        },
+    )()
+    choice = type("Choice", (), {"message": msg, "finish_reason": "length"})()
+    resp = type("R", (), {"choices": [choice], "usage": None})()
+    create = AsyncMock(return_value=resp)
+    completions = type("Co", (), {"create": create})()
+    client._client = type("C", (), {"chat": type("Ch", (), {"completions": completions})()})()
+
+    out = await client.generate(model="deepseek-v4-flash", system="s", messages=[], tools=[])
+    assert out.truncated is True
+
+
+def test_truncation_tool_results_carries_notice() -> None:
+    """A truncated round feeds back the notice per pending call instead of executing it (#77)."""
+    import json
+
+    from core.agent import _TRUNCATION_NOTICE, _truncation_tool_results
+
+    call = type("Call", (), {"id": "tu_1"})()
+    response = type("Resp", (), {"tool_calls": [call]})()
+    results = _truncation_tool_results(response)
+    assert results == [
+        {
+            "type": "tool_result",
+            "tool_use_id": "tu_1",
+            "content": json.dumps({"error": _TRUNCATION_NOTICE}),
+        }
+    ]
+
+
 def test_reasoning_kwargs_per_provider() -> None:
     assert LLMClient("openai", "x", thinking_level="high")._reasoning_kwargs() == {
         "reasoning_effort": "high"


### PR DESCRIPTION
Closes #77.

## Problem
Every LLM call hardcoded `max_tokens=4096`. When the model emitted a tool call with a large argument (e.g. a full HTML page to `write_artifact`), the response was cut off **mid-serialization of the tool-call JSON**. The truncated call arrived with `input={}`, the handler rejected it with a generic *"Provide one of 'html', 'files', or 'source_path'"* error, and the model — never told it was truncated — concluded it "forgot the parameter" and looped 30+ times, never producing the artifact. (Small artifacts succeeded; large ones always failed — the signature of output truncation.)

## Fix
1. **Config-driven ceiling.** New `agent.max_tokens` (default **8192**) replaces the `4096` literal at all 6 agent/subagent `generate()` sites, with a field on the **LLM admin tab** to change it live.
   - Default 8192 is safe across every provider including the default DeepSeek model and is non-streaming-timeout-safe; capable models can be raised (Claude up to 128000) from the UI or `config.yml`.
   - *Note:* the issue suggested a 128k/256k default — those exceed most models' output ceilings (128k max on Claude, ~8k on the default DeepSeek) and would 400 the out-of-box config, so the **default stays safe and the knob goes high**. `generate()` is non-streaming, so very large values also risk provider HTTP timeouts.
2. **Truncation detection.** `LLMClient.generate` now reads the stop signal (Anthropic `stop_reason == "max_tokens"` / OpenAI `finish_reason == "length"`) and exposes `LLMResponse.truncated`. On a truncated round the main and subagent loops **skip the half-built tool calls** and feed back an explicit notice ("write large output to disk in chunks / split across turns") instead of running them. Consecutive truncations are capped (`_MAX_TRUNCATION_RETRIES`) so a persistently-overflowing model can't loop forever.

## Acceptance (from the issue)
- ✅ A large `write_artifact` payload no longer truncates at 4096 (config-raisable ceiling).
- ✅ A genuinely over-limit output yields a clear truncation signal to the model, not a misleading "missing parameter" error.

## Tests
`tests/test_llm.py`: truncation flag for both providers + the notice helper. Full suite green (650 passed); `ruff check`/`format` clean.

## Touches
`core/config.py`, `core/llm.py`, `core/agent.py`, `api/admin.py`, `api/templates/base.html`, `api/templates/partials/llm.html`, `config.yml.example`, `tests/test_llm.py`.