### PR TITLE
fix(agent): tool-exec resilience — guard params, catch errors, break repeat-failure loops (#78)

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -104,6 +104,36 @@ def _truncation_tool_results(response) -> list[dict]:
     ]
 
 
+# A malformed tool call (e.g. run_command with no `command`) used to raise out of
+# the loop and kill the turn/subagent (#78). The agentic loop is also unbounded —
+# a model can repeat the same failing call until the token budget is gone. Both
+# are handled at the one point every tool call routes through (_execute_tool):
+# convert any exception into a recoverable error, and refuse a call whose exact
+# signature has already failed this many times.
+_MAX_REPEAT_FAILURES = 3
+_REPEAT_FAILURE_NOTICE = (
+    "You have already called this exact tool with these exact arguments and it "
+    "kept failing. Stop retrying it — change the arguments, take a different "
+    "approach, or report the problem to the user."
+)
+# Hard backstop on tool-call rounds in a single user turn, so even a model that
+# ignores every error signal can't loop forever. ponytail: generous ceiling —
+# normal turns use a handful; raise it if a legitimate workflow needs more.
+_MAX_TOOL_ROUNDS = 50
+_LOOP_ABORT_MESSAGE = (
+    "I had to stop — I made too many tool calls without reaching an answer. "
+    "Could you rephrase, or break the request into smaller steps?"
+)
+
+
+def _failure_signature(name: str, params: object) -> str:
+    """Stable key identifying a tool call, for the repeat-failure breaker (#78)."""
+    try:
+        return f"{name}:{json.dumps(params, sort_keys=True, default=str)}"
+    except TypeError, ValueError:
+        return f"{name}:{params!r}"
+
+
 def _shell_quote(s: str) -> str:
     """Quote a string for safe shell interpolation."""
     return shlex.quote(s)
@@ -1427,7 +1457,9 @@ class AgentCore:
         request_state["yolo"] = self.permissions.is_yolo(self._yolo_scope(channel, chat_id))
         tool_log: list[dict] = []
         truncations = 0
-        while response.tool_calls:
+        rounds = 0
+        while response.tool_calls and rounds < _MAX_TOOL_ROUNDS:
+            rounds += 1
             if response.truncated:
                 truncations += 1
                 if truncations > _MAX_TRUNCATION_RETRIES:
@@ -1464,6 +1496,8 @@ class AgentCore:
         final_text = response.text
         if response.truncated and not final_text:
             final_text = _TRUNCATION_GIVEUP_MESSAGE
+        elif response.tool_calls and not final_text:
+            final_text = _LOOP_ABORT_MESSAGE
         log.info("Response: %s", final_text[:200])
 
         # Check if the LLM wants to respond with voice
@@ -1553,7 +1587,9 @@ class AgentCore:
         request_state["yolo"] = self.permissions.is_yolo(self._yolo_scope(channel, chat_id))
         tool_log: list[dict] = []
         truncations = 0
-        while response.tool_calls:
+        rounds = 0
+        while response.tool_calls and rounds < _MAX_TOOL_ROUNDS:
+            rounds += 1
             if response.truncated:
                 truncations += 1
                 if truncations > _MAX_TRUNCATION_RETRIES:
@@ -1601,6 +1637,8 @@ class AgentCore:
         final_text = response.text
         if response.truncated and not final_text:
             final_text = _TRUNCATION_GIVEUP_MESSAGE
+        elif response.tool_calls and not final_text:
+            final_text = _LOOP_ABORT_MESSAGE
 
         # Append the final assistant response to the session
         final_assistant_msg = {"role": "assistant", "content": final_text}
@@ -1665,6 +1703,41 @@ class AgentCore:
         return None
 
     async def _execute_tool(
+        self,
+        tool_call: LLMToolCall,
+        channel: str,
+        user_id: str,
+        request_state: dict | None = None,
+    ) -> dict:
+        """Run a tool call, never letting a malformed call crash the turn (#78).
+
+        Single choke point for every tool call: convert any unexpected exception
+        into a recoverable error result, and refuse a call whose identical
+        signature has already failed ``_MAX_REPEAT_FAILURES`` times this turn so
+        the model can't burn the budget looping on the same broken call.
+        """
+        if request_state is None:
+            request_state = self._new_request_state()
+        sig = _failure_signature(tool_call.name, tool_call.arguments)
+        failures = request_state.setdefault("failure_counts", {})
+        if failures.get(sig, 0) >= _MAX_REPEAT_FAILURES:
+            return {"error": _REPEAT_FAILURE_NOTICE}
+        try:
+            result = await self._execute_tool_inner(tool_call, channel, user_id, request_state)
+        except Exception as exc:
+            log.exception("Tool %r raised", tool_call.name)
+            result = {
+                "error": (
+                    f"The '{tool_call.name}' tool failed with an unexpected error: {exc}. "
+                    "This usually means the arguments were malformed or incomplete. Do not "
+                    "retry the same call — fix the arguments or try a different approach."
+                )
+            }
+        if isinstance(result, dict) and result.get("error"):
+            failures[sig] = failures.get(sig, 0) + 1
+        return result
+
+    async def _execute_tool_inner(
         self,
         tool_call: LLMToolCall,
         channel: str,
@@ -1765,7 +1838,9 @@ class AgentCore:
         # --- Dispatch ---
         if name == "run_command":
             log.info("Tool call: run_command — %s", params.get("purpose", ""))
-            command = params["command"]
+            command = params.get("command")
+            if not command:
+                return {"error": "run_command requires a non-empty 'command' argument."}
             # Secret substitution boundary (issue #19): {{secret:NAME}} is resolved
             # ONLY here, for the model's generic command tool, after an ACL check.
             # Structured tools (send_email/send_message/…) build their commands

--- a/core/agent.py
+++ b/core/agent.py
@@ -116,9 +116,10 @@ _REPEAT_FAILURE_NOTICE = (
     "kept failing. Stop retrying it — change the arguments, take a different "
     "approach, or report the problem to the user."
 )
-# Hard backstop on tool-call rounds in a single user turn, so even a model that
-# ignores every error signal can't loop forever. ponytail: generous ceiling —
-# normal turns use a handful; raise it if a legitimate workflow needs more.
+# Hard backstop on LLM round-trips in a single user turn (each round may hold
+# several tool calls), so even a model that ignores every error signal can't loop
+# forever. ponytail: generous ceiling — normal turns use a handful; raise it if a
+# legitimate workflow needs more.
 _MAX_TOOL_ROUNDS = 50
 _LOOP_ABORT_MESSAGE = (
     "I had to stop — I made too many tool calls without reaching an answer. "
@@ -1728,11 +1729,14 @@ class AgentCore:
             log.exception("Tool %r raised", tool_call.name)
             result = {
                 "error": (
-                    f"The '{tool_call.name}' tool failed with an unexpected error: {exc}. "
-                    "This usually means the arguments were malformed or incomplete. Do not "
-                    "retry the same call — fix the arguments or try a different approach."
+                    f"The '{tool_call.name}' tool failed unexpectedly: {exc}. "
+                    "Don't repeat the same call — check the arguments, try a different "
+                    "approach, or tell the user if it can't be done."
                 )
             }
+        # Count every error toward the breaker, transient ones (e.g. a command
+        # timeout) included: the failure mode we stop is a model retrying the
+        # *identical* call many times — varying the args resets the count.
         if isinstance(result, dict) and result.get("error"):
             failures[sig] = failures.get(sig, 0) + 1
         return result

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -846,3 +846,63 @@ async def test_recall_memory_requires_query(agent) -> None:
     """A blank query is rejected before hitting the store."""
     result = await agent._execute_tool(_recall_call("1", query="   "), "telegram", "u1")
     assert "error" in result
+
+
+# --- Tool-exec resilience (#78) -------------------------------------------------
+
+
+def test_failure_signature_is_order_stable() -> None:
+    from core.agent import _failure_signature
+
+    assert _failure_signature("t", {"a": 1, "b": 2}) == _failure_signature("t", {"b": 2, "a": 1})
+    assert _failure_signature("t", {"a": 1}) != _failure_signature("t", {"a": 2})
+
+
+@pytest.mark.asyncio
+async def test_run_command_missing_command_is_recoverable(agent) -> None:
+    """A run_command call with no 'command' returns an error, not a KeyError (#78)."""
+    from core.llm import LLMToolCall
+
+    res = await agent._execute_tool(
+        LLMToolCall(id="x", name="run_command", arguments={"purpose": "p"}),
+        "system",
+        "u",
+        agent._new_request_state(),
+    )
+    assert "error" in res and "command" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_catches_inner_exception(agent, monkeypatch) -> None:
+    """An unexpected exception in dispatch becomes a recoverable error, not a crash (#78)."""
+    from core.llm import LLMToolCall
+
+    async def boom(*_a, **_k):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(agent, "_execute_tool_inner", boom)
+    res = await agent._execute_tool(
+        LLMToolCall(id="x", name="run_command", arguments={"command": "ls"}),
+        "system",
+        "u",
+        agent._new_request_state(),
+    )
+    assert "error" in res and "kaboom" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_repeat_failure_breaker_stops_after_n(agent) -> None:
+    """The same failing call is refused after _MAX_REPEAT_FAILURES, not run forever (#78)."""
+    from core.agent import _MAX_REPEAT_FAILURES, _REPEAT_FAILURE_NOTICE
+    from core.llm import LLMToolCall
+
+    state = agent._new_request_state()
+    call = LLMToolCall(id="x", name="run_command", arguments={"purpose": "p"})  # no command
+    errors = [
+        (await agent._execute_tool(call, "system", "u", state))["error"]
+        for _ in range(_MAX_REPEAT_FAILURES + 2)
+    ]
+    # First N reach the real guard; subsequent identical calls are refused.
+    assert all("command" in e for e in errors[:_MAX_REPEAT_FAILURES])
+    assert errors[_MAX_REPEAT_FAILURES] == _REPEAT_FAILURE_NOTICE
+    assert errors[-1] == _REPEAT_FAILURE_NOTICE


### PR DESCRIPTION
Closes #78.

## Problem
A malformed tool call crashed the whole agent turn (main loop) or killed a subagent: required params were accessed unguarded (`params["command"]`) and `_execute_tool` wasn't wrapped, so any exception propagated. Separately, the loop had no protection against the model repeating the same failing call dozens of times until the token budget was gone — the naming-task incident hit both (two subagents died on `KeyError: 'command'`; the model looped ~30× on identical failing calls).

## Fix — one choke point, all callers covered
`_execute_tool` is now a thin wrapper around `_execute_tool_inner` (the former body, unchanged). Every tool call — both main loops **and** the subagent loop — routes through it, so the guards live in one place:

1. **No crashes.** Any exception from dispatch is caught and converted to a recoverable `{"error": ...}` result the model can act on. `run_command` also validates `command` with `.get()` + an explicit message (the exact line the issue names) instead of the unguarded `params["command"]`.
2. **Repeat-failure breaker.** Each `(name, args)` signature that fails is counted in `request_state`; after `_MAX_REPEAT_FAILURES` (3) the identical call is **refused** with a strong "stop retrying — change approach or tell the user" notice instead of being re-run, so the expensive tool stops burning budget.
3. **Hard round cap.** The two previously-unbounded main loops gain a `_MAX_TOOL_ROUNDS` (50) backstop (the subagent loop already had `max_steps`), so even a model that ignores every error signal terminates — and the user gets a clear message instead of a silent stall.

Deliberately **skipped** the optional subagent budget-exhaustion structured-return fold-in: the breaker already neutralises the repeated-identical-spawn burn it targets. Easy follow-up if you want it.

## Acceptance (from the issue)
- ✅ A tool call with missing/invalid params returns a recoverable error; neither the turn nor the subagent crashes.
- ✅ The same failing call repeated N times stops being executed (breaker) and the loop is bounded (round cap) instead of running to budget exhaustion.

## Notes
- Builds on top of #77/#85 (already merged) — the loops already had the truncation branch; the new round cap and breaker compose with it.
- No config/UI/docs change — internal robustness only.

## Tests
`tests/test_tools.py`: `run_command` missing-arg guard, exception→error conversion, the repeat-failure breaker, and the `_failure_signature` helper. Full suite green (667 passed); `ruff check`/`format` clean.