### PR TITLE
fix(telegram): chunk long messages + cap command in approval text (#80)

### DIFF
--- a/channels/telegram.py
+++ b/channels/telegram.py
@@ -47,6 +47,40 @@ _HTML_TAG_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Telegram rejects messages over 4096 chars with "Message is too long" (#80).
+TELEGRAM_LIMIT = 4096
+
+
+def _chunk(text: str, limit: int = TELEGRAM_LIMIT) -> list[str]:
+    """Split ``text`` into pieces no longer than ``limit``, breaking on newlines.
+
+    Splitting the Markdown *source* (before HTML conversion) is safe: the
+    fence/bold/italic regexes in markdown_tg require matching delimiters, so a
+    chunk boundary inside one leaves the markers as literal text rather than an
+    unbalanced tag. A single line longer than ``limit`` is hard-split.
+    """
+    if len(text) <= limit:
+        return [text]
+    chunks: list[str] = []
+    current = ""
+    for line in text.split("\n"):
+        while len(line) > limit:
+            if current:
+                chunks.append(current)
+                current = ""
+            chunks.append(line[:limit])
+            line = line[limit:]
+        if not current:
+            current = line
+        elif len(current) + 1 + len(line) <= limit:
+            current += "\n" + line
+        else:
+            chunks.append(current)
+            current = line
+    if current:
+        chunks.append(current)
+    return chunks
+
 
 class TelegramChannel:
     def __init__(
@@ -579,21 +613,24 @@ class TelegramChannel:
     # -- Outgoing ------------------------------------------------------------
 
     async def send(self, chat_id: int | str, text: str) -> None:
-        """Send a message to a specific chat (used by scheduler, send_message tool, etc.)."""
+        """Send a message to a specific chat (used by scheduler, send_message tool, etc.).
+
+        Long output is chunked to Telegram's 4096-char limit (#80); each chunk
+        is a separate message rather than crashing the turn.
+        """
         # Agent output is Markdown; render to Telegram HTML unless it already carries HTML tags.
-        if _HTML_TAG_RE.search(text):
-            html = text
-        else:
-            html = to_telegram_html(text)
+        html_input = bool(_HTML_TAG_RE.search(text))
         cid, kw = self._route(chat_id)
-        try:
-            await self.app.bot.send_message(cid, html, parse_mode="HTML", **kw)
-        except BadRequest as exc:
-            if "parse entities" in str(exc).lower():
-                log.warning("Telegram HTML parse failed; sending as plain text: %s", exc)
-                await self.app.bot.send_message(cid, text, **kw)
-                return
-            raise
+        for chunk in _chunk(text):
+            payload = chunk if html_input else to_telegram_html(chunk)
+            try:
+                await self.app.bot.send_message(cid, payload, parse_mode="HTML", **kw)
+            except BadRequest as exc:
+                if "parse entities" in str(exc).lower():
+                    log.warning("Telegram HTML parse failed; sending as plain text: %s", exc)
+                    await self.app.bot.send_message(cid, chunk, **kw)
+                    continue
+                raise
 
     async def send_approval_request(
         self, user_id: str, request_id: str, description: str, image_path: str | None = None
@@ -628,7 +665,11 @@ class TelegramChannel:
                 return
             except Exception:
                 log.exception("Failed to send approval screenshot; falling back to text")
-        await self.app.bot.send_message(cid, text, reply_markup=keyboard, **kw)
+        # Chunk so a long prompt sends (#80); the keyboard rides the final piece.
+        *head, last = _chunk(text)
+        for piece in head:
+            await self.app.bot.send_message(cid, piece, **kw)
+        await self.app.bot.send_message(cid, last, reply_markup=keyboard, **kw)
 
     # -- Helpers -------------------------------------------------------------
 

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -528,6 +528,16 @@ class PendingApproval(TypedDict):
     match_key: str
 
 
+def _preview(text: str, limit: int = 200) -> str:
+    """Truncate a free-form field so it can't blow past Telegram's message cap.
+
+    Approval prompts interpolate user/agent-supplied strings (a command, a
+    message body). A `run_command` carrying a large heredoc would otherwise
+    produce a multi-kilobyte prompt that fails to send (#80).
+    """
+    return text[:limit] + ("…" if len(text) > limit else "")
+
+
 def format_approval_message(tool_name: str, params: dict) -> str:
     """Format a human-readable approval prompt for a tool call."""
     if tool_name == "send_email":
@@ -542,8 +552,7 @@ def format_approval_message(tool_name: str, params: dict) -> str:
         channel = params.get("channel", "?")
         to = params.get("to", "?")
         text = params.get("text", "")
-        preview = text[:100] + ("…" if len(text) > 100 else "")
-        return f"Send {channel} message to {to}\n{preview}"
+        return f"Send {channel} message to {to}\n{_preview(text, 100)}"
     if tool_name == "create_calendar_event":
         summary = params.get("summary", "?")
         start = params.get("start", "?")
@@ -567,7 +576,7 @@ def format_approval_message(tool_name: str, params: dict) -> str:
             return "List all scheduled jobs"
         return f"Manage jobs: {action}"
     if tool_name == "run_command":
-        cmd = params.get("command", "?")
+        cmd = _preview(params.get("command", "?"))
         purpose = params.get("purpose", "")
         return f"Run command: {cmd}" + (f"\n({purpose})" if purpose else "")
     if tool_name == "write_file":
@@ -575,7 +584,7 @@ def format_approval_message(tool_name: str, params: dict) -> str:
     if tool_name == "edit_file":
         return f"Edit file: {params.get('path', '?')}"
     if tool_name == "run_command_in_dir":
-        cmd = params.get("command", "?")
+        cmd = _preview(params.get("command", "?"))
         workdir = params.get("workdir", "?")
         return f"Run in {workdir}: {cmd}"
     if tool_name == "write_artifact":

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -171,3 +171,14 @@ def test_format_approval_message_run_command_includes_purpose() -> None:
     )
     assert "jq --version" in text
     assert "check jq install" in text
+
+
+def test_format_approval_message_truncates_huge_command() -> None:
+    # A run_command carrying a large heredoc must not produce a multi-KB prompt
+    # that Telegram rejects as too long (#80).
+    engine = PermissionEngine()
+    text = engine.format_approval_message(
+        "run_command", {"command": "cat <<EOF\n" + "x" * 5000 + "\nEOF"}
+    )
+    assert len(text) < 400
+    assert "…" in text

--- a/tests/test_telegram_channel.py
+++ b/tests/test_telegram_channel.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from channels.telegram import TelegramChannel
+from channels.telegram import TELEGRAM_LIMIT, TelegramChannel, _chunk
 
 
 def _channel_with_mock_bot(delay: float = 0.0) -> TelegramChannel:
@@ -105,3 +105,50 @@ async def test_placeholder_send_failure_is_non_fatal() -> None:
         await _wait_for(lambda: ch.app.bot.send_message.call_count > 0)
 
     ch.app.bot.delete_message.assert_not_awaited()
+
+
+def test_chunk_keeps_pieces_under_limit_and_loses_nothing() -> None:
+    # 50 lines of 200 chars = 10000 chars, well over the 4096 limit (#80).
+    text = "\n".join(f"line{i} " + "x" * 200 for i in range(50))
+    chunks = _chunk(text)
+    assert len(chunks) > 1
+    assert all(len(c) <= TELEGRAM_LIMIT for c in chunks)
+    # Newline-joined chunks reconstruct the original — no data dropped, no dupes.
+    assert "\n".join(chunks) == text
+
+
+def test_chunk_hard_splits_a_single_oversized_line() -> None:
+    # A heredoc with no newlines (the #80 incident) must still be split.
+    text = "y" * (TELEGRAM_LIMIT * 2 + 17)
+    chunks = _chunk(text)
+    assert all(len(c) <= TELEGRAM_LIMIT for c in chunks)
+    assert "".join(chunks) == text
+
+
+def test_chunk_short_text_is_single_piece() -> None:
+    assert _chunk("hello") == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_send_splits_long_reply_into_multiple_messages() -> None:
+    # A >4096-char reply must be split, not crash the turn (#80).
+    ch = _channel_with_mock_bot()
+    await ch.send(123, "z" * (TELEGRAM_LIMIT + 500))
+    assert ch.app.bot.send_message.await_count == 2
+    for call in ch.app.bot.send_message.await_args_list:
+        # call.args[1] is the rendered payload sent to Telegram.
+        assert len(call.args[1]) <= TELEGRAM_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_approval_request_chunks_and_keyboard_rides_last() -> None:
+    # A long approval prompt must send across messages with the buttons only on
+    # the final one, so the keyboard isn't lost (#80).
+    ch = _channel_with_mock_bot()
+    ch._last_chat_for_user = {}
+    await ch.send_approval_request("123", "req1", "D" * (TELEGRAM_LIMIT + 500))
+    calls = ch.app.bot.send_message.await_args_list
+    assert len(calls) >= 2
+    assert all(len(c.args[1]) <= TELEGRAM_LIMIT for c in calls)
+    assert all(c.kwargs.get("reply_markup") is None for c in calls[:-1])
+    assert calls[-1].kwargs.get("reply_markup") is not None


### PR DESCRIPTION
Closes #80.

## Problem

Outgoing Telegram messages weren't split to the 4096-char limit, and approval prompts embedded the full tool payload verbatim. Both raised `telegram.error.BadRequest: Message is too long`:

- `format_approval_message` interpolated the **entire** `run_command` string (a large HTML heredoc in the reported incident) with no cap.
- `send()` caught only "parse entities" `BadRequest` and re-raised everything else, so a >4096-char reply crashed the turn.

## Fix

1. **Cap the command preview** (`core/permissions.py`) — shared `_preview()` truncates the command field in `run_command` / `run_command_in_dir`, mirroring the existing `send_message` 100-char cap.
2. **Chunk the send path** (`channels/telegram.py`) — `_chunk()` splits source Markdown into ≤4096-char pieces on newline boundaries (hard-splitting an oversized single line) before HTML conversion. Both `send()` and `send_approval_request()` send each chunk as its own message; the approval keyboard rides the final chunk.

Splitting the Markdown *source* (not the rendered HTML) is what keeps this safe: the fence/bold/italic regexes require matching delimiters, so a chunk boundary inside one leaves the markers as literal text rather than an unbalanced tag.

## Acceptance

- ✅ An approval request for a huge command renders a truncated preview and sends successfully.
- ✅ A reply longer than 4096 chars is split into multiple messages instead of crashing.

## Tests

- `_chunk` keeps every piece ≤4096, loses nothing, and hard-splits a single oversized line.
- `send()` splits a >4096-char reply into multiple ≤4096 messages.
- `send_approval_request()` chunks and puts the keyboard only on the final message.
- `format_approval_message` truncates a 5000-char heredoc command.

704 passing; `ruff check` clean.