### PR TITLE
feat(voice): add Kokoro 82M offline TTS backend (#84)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,15 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock ./
 RUN uv sync --no-dev --no-install-project
 
+# Offline on-device TTS (Kokoro, issue #84). ON by default so switching the TTS
+# backend to "kokoro" works out of the box (edge-tts stays the default backend).
+# The extra pulls onnxruntime (~200MB) plus the model later (~325MB); opt out for
+# a leaner edge-tts-only image with: docker build --build-arg INSTALL_KOKORO=false .
+ARG INSTALL_KOKORO=true
+RUN if [ "$INSTALL_KOKORO" = "true" ]; then \
+      uv sync --no-dev --no-install-project --extra kokoro; \
+    fi
+
 # Bundle full Chromium for the browser tool (Tools tab: browser, issue #16).
 # ON by default: a self-contained image avoids the runtime `playwright install`
 # fetch, which flakes on remote hosts with spotty networking. Adds ~500-700MB.
@@ -73,6 +82,18 @@ COPY api/ api/
 # default in sync with EmbeddingConfig (core/config.py).
 ARG EMBED_MODEL=BAAI/bge-small-en-v1.5
 RUN uv run python -m core.embeddings prefetch "${EMBED_MODEL}" /app/models
+
+# Prefetch Kokoro TTS model + voices when the kokoro backend is enabled (#84),
+# mirroring the Whisper/embedding prefetch so the container runs fully offline.
+# Stored in /app/models (OUTSIDE the /app/data volume) — keep paths in sync with
+# KokoroConfig (core/config.py). Gated on the same INSTALL_KOKORO arg as above.
+RUN if [ "$INSTALL_KOKORO" = "true" ]; then \
+      mkdir -p /app/models/kokoro && \
+      curl -sSL https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx \
+        -o /app/models/kokoro/kokoro-v1.0.onnx && \
+      curl -sSL https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin \
+        -o /app/models/kokoro/voices-v1.0.bin; \
+    fi
 
 # Build CSS with Tailwind CSS v4 standalone CLI
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-hooks install install-dev sync lock lint format test run repl dev dev-agent dev-css dev-wa clean release css docs docs-dev
+.PHONY: help setup setup-hooks install install-dev sync lock lint format test run repl dev dev-agent dev-css dev-wa kokoro clean release css docs docs-dev
 
 PORT := 8001
 PYTHON := uv run python
@@ -9,6 +9,11 @@ CSS_OUT := api/static/style.css
 
 # Pinned upstream wacli (github.com/openclaw/wacli). Keep in sync with Dockerfile.
 WACLI_VERSION := v0.11.0
+
+# Kokoro offline TTS model (github.com/thewh1teagle/kokoro-onnx releases).
+# Keep the version + paths in sync with the Dockerfile and KokoroConfig.
+KOKORO_DIR := models/kokoro
+KOKORO_BASE_URL := https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0
 
 # Show available targets
 help:
@@ -22,6 +27,7 @@ help:
 	@echo "    make install-dev  Install all dependencies (including dev tools)"
 	@echo "    make sync         Re-sync venv with lockfile"
 	@echo "    make lock         Update lockfile after changing pyproject.toml"
+	@echo "    make kokoro       Install Kokoro offline TTS + download its model (local runs)"
 	@echo ""
 	@echo "  Development:"
 	@echo "    make repl         Chat with the agent from the terminal (no Telegram)"
@@ -133,6 +139,18 @@ dev-wa:
 			go install -tags sqlite_fts5 github.com/openclaw/wacli/cmd/wacli@$(WACLI_VERSION); \
 	}
 	@wacli version 2>/dev/null || "$(HOME)/go/bin/wacli" version
+
+# Install the Kokoro offline TTS extra + download its model for local (non-Docker)
+# runs. The Docker image bundles these via INSTALL_KOKORO. After this, set
+# voice.backend: kokoro and restart. Idempotent — existing files are kept.
+kokoro:
+	$(UV) sync --extra kokoro
+	@mkdir -p $(KOKORO_DIR)
+	@test -f $(KOKORO_DIR)/kokoro-v1.0.onnx || \
+		curl -fL $(KOKORO_BASE_URL)/kokoro-v1.0.onnx -o $(KOKORO_DIR)/kokoro-v1.0.onnx
+	@test -f $(KOKORO_DIR)/voices-v1.0.bin || \
+		curl -fL $(KOKORO_BASE_URL)/voices-v1.0.bin -o $(KOKORO_DIR)/voices-v1.0.bin
+	@echo "Kokoro ready in $(KOKORO_DIR). Set voice.backend: kokoro and restart the agent."
 
 # Remove venv and caches
 clean:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 - **Scheduled tasks** — Cron-based jobs for morning briefings, email checks, contact sync, and custom tasks
 - **Subagents** — Delegate a scoped subtask to a sub-loop under a chosen persona, on demand or scheduled. Runs sync (result returned in-turn) or in the background; a finished background batch is distilled by a summary inference into a one-line chat notification + a concise context digest (raw output never reaches the user or the agent's context). The agent sizes each run (steps / token budget / thinking effort) and defaults the persona to its own; scope is a subset of the caller's (inherit-never-widen). Monitor and cancel from Telegram (`/jobs`) or the admin UI
 - **Reactions** — On Telegram the agent can acknowledge a message with an emoji (`set_reaction`) instead of a text reply — thumbsup for "got it", heart for thanks, eyes for a photo, and so on. Cosmetic and pre-approved, so a quick ack never interrupts with a prompt
-- **Voice** — Speech-to-text (faster-whisper) and text-to-speech (edge-tts)
+- **Voice** — Speech-to-text (faster-whisper) and text-to-speech (edge-tts, or Kokoro 82M for fully offline multilingual voice)
 - **Image generation** — Optional `generate_image` tool (OpenRouter, fal.ai, or OpenAI) that creates images on request and sends them as native photos. Reuses an existing OpenRouter/OpenAI LLM key, with a daily/monthly budget cap (off by default)
 - **Coding harness** — Optional file tools (`read_file`, `write_file`, `edit_file`, `list_dir`, `grep`, `run_command_in_dir`) that let the agent work on a real codebase directly. The file tools are confined to one configurable workspace directory (paths escaping it via `..` or symlink are blocked); `run_command_in_dir` confines only its working directory — the command runs with full process privileges, gated by per-call approval. Reads are pre-approved; writes ask first (off by default)
 - **Web search** — Tavily integration for real-time information
@@ -37,7 +37,7 @@ MPA follows a **Python orchestrator + CLI tools** design. Python glues everythin
 | Contacts | Built-in contacts CLI |
 | Calendar | python-caldav |
 | Storage | SQLite (4 databases) |
-| Voice | faster-whisper (STT) + edge-tts (TTS) |
+| Voice | faster-whisper (STT) + edge-tts / Kokoro 82M (TTS) |
 | Admin UI | FastAPI + HTMX + Tailwind CSS |
 
 Instead of hardcoded integrations, the agent learns to use CLI tools via markdown "skill" files in `skills/`. Adding a new capability means writing a markdown file and adding the tool's command prefix to the executor whitelist.
@@ -120,7 +120,7 @@ api/            Admin web interface
   templates/      Jinja2 templates
   static/         CSS (Tailwind)
 voice/          Voice pipeline
-  pipeline.py     Whisper STT + edge-tts TTS
+  pipeline.py     Whisper STT + edge-tts/Kokoro TTS
 tools/          CLI helper scripts
   calendar_read.py   CalDAV event reader
   calendar_write.py  CalDAV event creator
@@ -186,7 +186,7 @@ The binary is installed from a pinned upstream tag (`WACLI_VERSION` in the `Dock
 - **FastAPI** + **Jinja2** + **HTMX** + **Alpine.js** + **Tailwind CSS v4** for the admin UI
 - **python-telegram-bot** for the Telegram channel
 - **APScheduler** for cron jobs
-- **faster-whisper** + **edge-tts** for voice
+- **faster-whisper** + **edge-tts** (or **Kokoro 82M**, offline) for voice
 - **ruff** for linting and formatting
 - **pytest** with asyncio and xdist for testing
 - **Docker** for production deployment

--- a/api/admin.py
+++ b/api/admin.py
@@ -653,6 +653,11 @@ class PromptPreviewIn(BaseModel):
     include_reflections: bool = True
 
 
+class VoicePreviewIn(BaseModel):
+    voice: str = ""
+    text: str = "Hi! This is a quick preview of how this voice sounds."
+
+
 # ---------------------------------------------------------------------------
 # Auth dependency
 # ---------------------------------------------------------------------------
@@ -944,6 +949,8 @@ def create_admin_app(
         A globally-disabled feature (e.g. artifacts) is dropped so its tool is
         hidden from the persona scope UI.
         """
+        from voice.pipeline import KOKORO_VOICES
+
         store = await _skills_store_from_config(config_store)
         all_skills = [s["name"] for s in await store.list_skills()]
         sub_enabled = await config_store.get("subagents.enabled")
@@ -959,6 +966,7 @@ def create_admin_app(
                 imagegen_enabled=ig_on,
                 workspace_enabled=ws_on,
             ),
+            "kokoro_voices": KOKORO_VOICES,
         }
 
     @app.get("/admin/personae/new", response_model=None)
@@ -1033,12 +1041,16 @@ def create_admin_app(
     @app.get("/partials/identity", dependencies=[Depends(auth)])
     async def partial_identity() -> HTMLResponse:
         """Agent identity tab partial."""
+        from voice.pipeline import KOKORO_VOICES
+
         character = await config_store.get("agent.character") or ""
         personalia = await config_store.get("agent.personalia") or ""
         agent_name = await config_store.get("agent.name") or ""
         stt_model = await config_store.get("voice.stt_model") or "base"
         tts_voice = await config_store.get("voice.tts_voice") or "en-US-AvaNeural"
         tts_enabled = await config_store.get("voice.tts_enabled") or "true"
+        backend = await config_store.get("voice.backend") or "edge-tts"
+        kokoro_voice = await config_store.get("voice.kokoro.default_voice") or "af_bella"
         return _render_partial(
             "partials/identity.html",
             character=character,
@@ -1047,6 +1059,9 @@ def create_admin_app(
             stt_model=stt_model,
             tts_voice=tts_voice,
             tts_enabled=tts_enabled,
+            backend=backend,
+            kokoro_voice=kokoro_voice,
+            kokoro_voices=KOKORO_VOICES,
         )
 
     @app.get("/partials/you", dependencies=[Depends(auth)])
@@ -2011,6 +2026,24 @@ def create_admin_app(
             "updated": list(values.keys()),
             "restart_required": _config_requires_restart(changed),
         }
+
+    @app.post("/voice/preview", dependencies=[Depends(auth)])
+    async def voice_preview(body: VoicePreviewIn) -> Response:
+        """Synthesize a short sample of the given voice and return the audio so
+        the admin UI can play it (voice selection/testing, #84).  Edge-tts
+        voices preview anytime; Kokoro voices need the Kokoro backend loaded."""
+        agent = agent_state.agent
+        pipeline = getattr(agent, "voice", None) if agent else None
+        if pipeline is None:
+            raise HTTPException(
+                503, "Voice pipeline not loaded — enable TTS and restart the agent."
+            )
+        text = (body.text or "").strip() or "Hi! This is a quick preview of this voice."
+        try:
+            audio, mime = await pipeline.preview(text, body.voice.strip())
+        except Exception as exc:
+            raise HTTPException(503, f"Preview failed: {exc}") from exc
+        return Response(content=audio, media_type=mime)
 
     @app.post("/debug/system-prompt/preview", dependencies=[Depends(auth)])
     async def system_prompt_preview(body: PromptPreviewIn) -> dict:

--- a/api/admin.py
+++ b/api/admin.py
@@ -30,7 +30,7 @@ from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse, Resp
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from core.artifacts import ARTIFACT_CSP, NOT_FOUND_HTML, resolve, serving_base, valid_id
 from core.config_store import ConfigStore
@@ -654,8 +654,10 @@ class PromptPreviewIn(BaseModel):
 
 
 class VoicePreviewIn(BaseModel):
-    voice: str = ""
-    text: str = "Hi! This is a quick preview of how this voice sounds."
+    # Bounded so an authenticated admin can't request synthesis of megabytes of
+    # text (RAM / worker-thread exhaustion). A preview is a short sample.
+    voice: str = Field("", max_length=64)
+    text: str = Field("Hi! This is a quick preview of this voice.", max_length=600)
 
 
 # ---------------------------------------------------------------------------

--- a/api/admin.py
+++ b/api/admin.py
@@ -658,6 +658,7 @@ class VoicePreviewIn(BaseModel):
     # text (RAM / worker-thread exhaustion). A preview is a short sample.
     voice: str = Field("", max_length=64)
     text: str = Field("Hi! This is a quick preview of this voice.", max_length=600)
+    lang: str = Field("", max_length=16)  # Kokoro pronunciation override; "" = derive from voice
 
 
 # ---------------------------------------------------------------------------
@@ -951,7 +952,7 @@ def create_admin_app(
         A globally-disabled feature (e.g. artifacts) is dropped so its tool is
         hidden from the persona scope UI.
         """
-        from voice.pipeline import KOKORO_VOICES
+        from voice.pipeline import KOKORO_LANGUAGES, KOKORO_VOICES
 
         store = await _skills_store_from_config(config_store)
         all_skills = [s["name"] for s in await store.list_skills()]
@@ -969,6 +970,7 @@ def create_admin_app(
                 workspace_enabled=ws_on,
             ),
             "kokoro_voices": KOKORO_VOICES,
+            "kokoro_languages": KOKORO_LANGUAGES,
         }
 
     @app.get("/admin/personae/new", response_model=None)
@@ -1043,7 +1045,7 @@ def create_admin_app(
     @app.get("/partials/identity", dependencies=[Depends(auth)])
     async def partial_identity() -> HTMLResponse:
         """Agent identity tab partial."""
-        from voice.pipeline import KOKORO_VOICES
+        from voice.pipeline import KOKORO_LANGUAGES, KOKORO_VOICES
 
         character = await config_store.get("agent.character") or ""
         personalia = await config_store.get("agent.personalia") or ""
@@ -1064,6 +1066,7 @@ def create_admin_app(
             backend=backend,
             kokoro_voice=kokoro_voice,
             kokoro_voices=KOKORO_VOICES,
+            kokoro_languages=KOKORO_LANGUAGES,
         )
 
     @app.get("/partials/you", dependencies=[Depends(auth)])
@@ -2042,7 +2045,7 @@ def create_admin_app(
             )
         text = (body.text or "").strip() or "Hi! This is a quick preview of this voice."
         try:
-            audio, mime = await pipeline.preview(text, body.voice.strip())
+            audio, mime = await pipeline.preview(text, body.voice.strip(), body.lang.strip())
         except Exception as exc:
             raise HTTPException(503, f"Preview failed: {exc}") from exc
         return Response(content=audio, media_type=mime)

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -100,8 +100,10 @@
         .then(blob => {
           const url = URL.createObjectURL(blob);
           const audio = new Audio(url);
-          audio.onended = () => URL.revokeObjectURL(url);
-          audio.play();
+          const cleanup = () => URL.revokeObjectURL(url);
+          audio.onended = cleanup;
+          audio.onerror = cleanup;
+          audio.play().catch(cleanup);  // autoplay rejection etc. — don't leak the URL
         })
         .catch(e => { if (window.showToast) showToast(e.message, false); })
         .finally(() => { if (btn) { btn.disabled = false; btn.textContent = original || '▶ Preview'; } });

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -82,6 +82,32 @@
     }
     window.restartAgentNow = restartAgentNow;
 
+    // Voice preview (#84): synthesize a sample of `voice` and play it. The engine
+    // is chosen server-side from the voice name. `btn` (optional) shows progress.
+    function previewVoice(voice, btn) {
+      const key = localStorage.getItem('admin_api_key') || '';
+      const original = btn ? btn.textContent : '';
+      if (btn) { btn.disabled = true; btn.textContent = '…'; }
+      fetch('/voice/preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + key },
+        body: JSON.stringify({ voice: voice || '' })
+      })
+        .then(async r => {
+          if (!r.ok) { const d = await r.json().catch(() => ({})); throw new Error(d.detail || 'Preview failed'); }
+          return r.blob();
+        })
+        .then(blob => {
+          const url = URL.createObjectURL(blob);
+          const audio = new Audio(url);
+          audio.onended = () => URL.revokeObjectURL(url);
+          audio.play();
+        })
+        .catch(e => { if (window.showToast) showToast(e.message, false); })
+        .finally(() => { if (btn) { btn.disabled = false; btn.textContent = original || '▶ Preview'; } });
+    }
+    window.previewVoice = previewVoice;
+
     function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens) {
       const currentProvider = provider || 'anthropic';
       return {

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -82,16 +82,18 @@
     }
     window.restartAgentNow = restartAgentNow;
 
-    // Voice preview (#84): synthesize a sample of `voice` and play it. The engine
-    // is chosen server-side from the voice name. `btn` (optional) shows progress.
-    function previewVoice(voice, btn) {
+    // Voice preview (#84): synthesize `text` in `voice` and play it. The engine
+    // is chosen server-side from the voice name; `lang` (Kokoro only) overrides
+    // the pronunciation language. `text`/`lang` blank → server defaults. `btn`
+    // (optional) shows progress.
+    function previewVoice(voice, text, lang, btn) {
       const key = localStorage.getItem('admin_api_key') || '';
       const original = btn ? btn.textContent : '';
       if (btn) { btn.disabled = true; btn.textContent = '…'; }
       fetch('/voice/preview', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + key },
-        body: JSON.stringify({ voice: voice || '' })
+        body: JSON.stringify({ voice: voice || '', text: text || '', lang: lang || '' })
       })
         .then(async r => {
           if (!r.ok) { const d = await r.json().catch(() => ({})); throw new Error(d.detail || 'Preview failed'); }

--- a/api/templates/partials/identity.html
+++ b/api/templates/partials/identity.html
@@ -119,6 +119,8 @@
     ttsEnabled: {{ tts_enabled|default('true', true)|tojson|forceescape }},
     sttModel: {{ stt_model|default('base', true)|tojson|forceescape }},
     ttsVoice: {{ tts_voice|default('en-US-AvaNeural', true)|tojson|forceescape }},
+    backend: {{ backend|default('edge-tts', true)|tojson|forceescape }},
+    kokoroVoice: {{ kokoro_voice|default('af_bella', true)|tojson|forceescape }},
     voiceResult: '',
     voiceOk: false
   }">
@@ -144,9 +146,36 @@
       </div>
 
       <div>
+        <label class="label">TTS backend</label>
+        <select class="input-sm" style="max-width:240px" x-model="backend">
+          <option value="edge-tts">Edge TTS (cloud)</option>
+          <option value="kokoro">Kokoro 82M (offline, multilingual)</option>
+        </select>
+        <p class="text-muted text-xs mt-1">Kokoro runs on-device and needs the model bundled (<code>--build-arg INSTALL_KOKORO=true</code>); it falls back to Edge TTS if unavailable.</p>
+      </div>
+
+      {# Edge voice #}
+      <div x-show="backend === 'edge-tts'">
         <label class="label">TTS voice</label>
-        <input type="text" class="input-sm" style="max-width:260px" x-model="ttsVoice" placeholder="en-US-AvaNeural">
+        <div class="flex items-center gap-2">
+          <input type="text" class="input-sm" style="max-width:260px" x-model="ttsVoice" placeholder="en-US-AvaNeural">
+          <button type="button" class="btn btn-sm" @click="previewVoice(ttsVoice, $event.currentTarget)">▶ Preview</button>
+        </div>
         <p class="text-muted text-xs mt-1">Use Edge TTS voice names. Example: en-US-AvaNeural.</p>
+      </div>
+
+      {# Kokoro default voice #}
+      <div x-show="backend === 'kokoro'">
+        <label class="label">Default Kokoro voice</label>
+        <div class="flex items-center gap-2">
+          <select class="input-sm" style="max-width:260px" x-model="kokoroVoice">
+            {% for v in kokoro_voices %}
+            <option value="{{ v }}">{{ v }}</option>
+            {% endfor %}
+          </select>
+          <button type="button" class="btn btn-sm" @click="previewVoice(kokoroVoice, $event.currentTarget)">▶ Preview</button>
+        </div>
+        <p class="text-muted text-xs mt-1">Voice prefix sets the language (af/am = English, ff = French, jf/jm = Japanese, …). Preview needs the Kokoro backend running.</p>
       </div>
       {% include "partials/restart_note.html" %}
     </div>
@@ -157,7 +186,9 @@
                 const vals = {
                   'voice.tts_enabled': String(ttsEnabled === true || ttsEnabled === 'true'),
                   'voice.stt_model': sttModel,
-                  'voice.tts_voice': ttsVoice
+                  'voice.backend': backend,
+                  'voice.tts_voice': ttsVoice,
+                  'voice.kokoro.default_voice': kokoroVoice
                 };
                 fetch('/config', {
                   method: 'PATCH',

--- a/api/templates/partials/identity.html
+++ b/api/templates/partials/identity.html
@@ -121,6 +121,8 @@
     ttsVoice: {{ tts_voice|default('en-US-AvaNeural', true)|tojson|forceescape }},
     backend: {{ backend|default('edge-tts', true)|tojson|forceescape }},
     kokoroVoice: {{ kokoro_voice|default('af_bella', true)|tojson|forceescape }},
+    previewText: '',
+    previewLang: '',
     voiceResult: '',
     voiceOk: false
   }">
@@ -157,25 +159,42 @@
       {# Edge voice #}
       <div x-show="backend === 'edge-tts'">
         <label class="label">TTS voice</label>
-        <div class="flex items-center gap-2">
-          <input type="text" class="input-sm" style="max-width:260px" x-model="ttsVoice" placeholder="en-US-AvaNeural">
-          <button type="button" class="btn btn-sm" @click="previewVoice(ttsVoice, $event.currentTarget)">▶ Preview</button>
-        </div>
+        <input type="text" class="input-sm" style="max-width:260px" x-model="ttsVoice" placeholder="en-US-AvaNeural">
         <p class="text-muted text-xs mt-1">Use Edge TTS voice names. Example: en-US-AvaNeural.</p>
       </div>
 
       {# Kokoro default voice #}
       <div x-show="backend === 'kokoro'">
         <label class="label">Default Kokoro voice</label>
-        <div class="flex items-center gap-2">
-          <select class="input-sm" style="max-width:260px" x-model="kokoroVoice">
-            {% for v in kokoro_voices %}
-            <option value="{{ v }}">{{ v }}</option>
+        <select class="input-sm" style="max-width:260px" x-model="kokoroVoice">
+          {% for v in kokoro_voices %}
+          <option value="{{ v }}">{{ v }}</option>
+          {% endfor %}
+        </select>
+        <p class="text-muted text-xs mt-1">Voice prefix sets the default language (af/am = English, ff = French, jf/jm = Japanese, …). Preview needs the Kokoro backend running.</p>
+      </div>
+
+      {# Preview — type text, pick a language (Kokoro), hear the selected voice #}
+      <div>
+        <label class="label">Preview</label>
+        <div class="flex items-center gap-2 flex-wrap">
+          <input type="text" class="input-sm" style="max-width:300px" x-model="previewText"
+                 placeholder="Type a few words to hear… (blank = sample)">
+          <select x-show="backend === 'kokoro'" class="input-sm" style="max-width:180px"
+                  x-model="previewLang" title="Pronunciation language">
+            <option value="">Auto (match voice)</option>
+            {% for code, label in kokoro_languages %}
+            <option value="{{ code }}">{{ label }}</option>
             {% endfor %}
           </select>
-          <button type="button" class="btn btn-sm" @click="previewVoice(kokoroVoice, $event.currentTarget)">▶ Preview</button>
+          <button type="button" class="btn btn-sm"
+                  @click="previewVoice(
+                    backend === 'kokoro' ? kokoroVoice : ttsVoice,
+                    previewText,
+                    backend === 'kokoro' ? previewLang : '',
+                    $event.currentTarget)">▶ Preview</button>
         </div>
-        <p class="text-muted text-xs mt-1">Voice prefix sets the language (af/am = English, ff = French, jf/jm = Japanese, …). Preview needs the Kokoro backend running.</p>
+        <p class="text-muted text-xs mt-1" x-show="backend === 'kokoro'">Language sets pronunciation independently of the voice — e.g. an Italian voice can read English text.</p>
       </div>
       {% include "partials/restart_note.html" %}
     </div>

--- a/api/templates/partials/identity.html
+++ b/api/templates/partials/identity.html
@@ -151,7 +151,7 @@
           <option value="edge-tts">Edge TTS (cloud)</option>
           <option value="kokoro">Kokoro 82M (offline, multilingual)</option>
         </select>
-        <p class="text-muted text-xs mt-1">Kokoro runs on-device and needs the model bundled (<code>--build-arg INSTALL_KOKORO=true</code>); it falls back to Edge TTS if unavailable.</p>
+        <p class="text-muted text-xs mt-1">Kokoro runs on-device (model bundled by default); it falls back to Edge TTS if the model isn't available. Restart after changing.</p>
       </div>
 
       {# Edge voice #}

--- a/api/templates/persona_editor.html
+++ b/api/templates/persona_editor.html
@@ -46,10 +46,7 @@
         </div>
         <div>
           <label class="label">Voice <span class="text-muted">(TTS — blank = default)</span></label>
-          <div class="flex items-center gap-2">
-            <input class="input-sm" x-model="voice" list="voice-options" placeholder="en-US-AvaNeural">
-            <button type="button" class="btn btn-sm" @click="previewVoice(voice, $event.currentTarget)">▶ Preview</button>
-          </div>
+          <input class="input-sm" x-model="voice" list="voice-options" placeholder="en-US-AvaNeural">
           <datalist id="voice-options">
             <option value="en-US-AvaNeural"></option>
             <option value="en-US-AndrewNeural"></option>
@@ -61,7 +58,20 @@
             <option value="{{ v }}"></option>
             {% endfor %}
           </datalist>
-          <p class="text-muted text-xs mt-1">Edge TTS names (<code>en-US-AvaNeural</code>) or Kokoro names (<code>af_bella</code>) — match the active backend. Preview plays the selected voice.</p>
+          <div class="flex items-center gap-2 mt-2 flex-wrap">
+            <input type="text" class="input-sm" style="max-width:240px" x-model="previewText"
+                   placeholder="Preview text… (blank = sample)">
+            <select x-show="/^[a-z][fm]_/.test(voice)" class="input-sm" style="max-width:170px"
+                    x-model="previewLang" title="Pronunciation language">
+              <option value="">Auto (match voice)</option>
+              {% for code, label in kokoro_languages %}
+              <option value="{{ code }}">{{ label }}</option>
+              {% endfor %}
+            </select>
+            <button type="button" class="btn btn-sm"
+                    @click="previewVoice(voice, previewText, /^[a-z][fm]_/.test(voice) ? previewLang : '', $event.currentTarget)">▶ Preview</button>
+          </div>
+          <p class="text-muted text-xs mt-1">Edge TTS names (<code>en-US-AvaNeural</code>) or Kokoro names (<code>af_bella</code>) — match the active backend. Preview plays the selected voice; for Kokoro you can override the language.</p>
         </div>
       </div>
 
@@ -152,6 +162,8 @@
       role: {{ persona.role|tojson }},
       emoji: {{ persona.emoji|tojson }},
       voice: {{ persona.voice|tojson }},
+      previewText: '',
+      previewLang: '',
       bot_token: {{ persona.bot_token|tojson }},
       allowedUserIds: {{ (persona.allowed_user_ids|join(', '))|tojson }},
       personalia: {{ persona.personalia|tojson }},

--- a/api/templates/persona_editor.html
+++ b/api/templates/persona_editor.html
@@ -46,7 +46,10 @@
         </div>
         <div>
           <label class="label">Voice <span class="text-muted">(TTS — blank = default)</span></label>
-          <input class="input-sm" x-model="voice" list="voice-options" placeholder="en-US-AvaNeural">
+          <div class="flex items-center gap-2">
+            <input class="input-sm" x-model="voice" list="voice-options" placeholder="en-US-AvaNeural">
+            <button type="button" class="btn btn-sm" @click="previewVoice(voice, $event.currentTarget)">▶ Preview</button>
+          </div>
           <datalist id="voice-options">
             <option value="en-US-AvaNeural"></option>
             <option value="en-US-AndrewNeural"></option>
@@ -54,7 +57,11 @@
             <option value="en-GB-SoniaNeural"></option>
             <option value="en-GB-RyanNeural"></option>
             <option value="en-AU-NatashaNeural"></option>
+            {% for v in kokoro_voices %}
+            <option value="{{ v }}"></option>
+            {% endfor %}
           </datalist>
+          <p class="text-muted text-xs mt-1">Edge TTS names (<code>en-US-AvaNeural</code>) or Kokoro names (<code>af_bella</code>) — match the active backend. Preview plays the selected voice.</p>
         </div>
       </div>
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -61,10 +61,10 @@ voice:
   tts_voice: "en-US-GuyNeural"
   tts_enabled: true
   backend: "edge-tts"          # "edge-tts" (cloud, default) | "kokoro" (offline, on-device)
-  # Kokoro 82M: offline multilingual TTS (#84). Build the image with
-  # --build-arg INSTALL_KOKORO=true to bundle the model, then set backend: kokoro.
-  # Falls back to edge-tts if the model can't load. Per-persona voices: set
-  # `voice: af_bella` in a persona's frontmatter.
+  # Kokoro 82M: offline multilingual TTS (#84). The Docker image bundles the
+  # model by default, so just set backend: kokoro. (Opt out of the bundle with
+  # --build-arg INSTALL_KOKORO=false.) Falls back to edge-tts if the model can't
+  # load. Per-persona voices: set `voice: af_bella` in a persona's frontmatter.
   kokoro:
     model_path: "models/kokoro/kokoro-v1.0.onnx"
     voices_path: "models/kokoro/voices-v1.0.bin"

--- a/config.yml.example
+++ b/config.yml.example
@@ -60,6 +60,15 @@ voice:
   stt_model: "base"
   tts_voice: "en-US-GuyNeural"
   tts_enabled: true
+  backend: "edge-tts"          # "edge-tts" (cloud, default) | "kokoro" (offline, on-device)
+  # Kokoro 82M: offline multilingual TTS (#84). Build the image with
+  # --build-arg INSTALL_KOKORO=true to bundle the model, then set backend: kokoro.
+  # Falls back to edge-tts if the model can't load. Per-persona voices: set
+  # `voice: af_bella` in a persona's frontmatter.
+  kokoro:
+    model_path: "models/kokoro/kokoro-v1.0.onnx"
+    voices_path: "models/kokoro/voices-v1.0.bin"
+    default_voice: "af_bella"  # af_*/am_* en, bf_*/bm_* en-GB, jf_* ja, ff_* fr, …
 
 scheduler:
   jobs:

--- a/core/config.py
+++ b/core/config.py
@@ -181,10 +181,18 @@ class CalendarConfig(BaseModel):
     providers: list[CalendarProvider] = Field(default_factory=list)
 
 
+class KokoroConfig(BaseModel):
+    model_path: str = "models/kokoro/kokoro-v1.0.onnx"
+    voices_path: str = "models/kokoro/voices-v1.0.bin"
+    default_voice: str = "af_bella"
+
+
 class VoiceConfig(BaseModel):
     stt_model: str = "base"
     tts_voice: str = "en-US-AvaNeural"
     tts_enabled: bool = True
+    backend: str = "edge-tts"  # "edge-tts" | "kokoro"
+    kokoro: KokoroConfig = KokoroConfig()
 
 
 class SchedulerJob(BaseModel):

--- a/core/main.py
+++ b/core/main.py
@@ -73,14 +73,19 @@ async def _start_agent(config_store: ConfigStore):
     voice: VoicePipeline | None = None
     if config.voice.tts_enabled:
         log.info(
-            "Initializing voice pipeline (model=%s, voice=%s)…",
+            "Initializing voice pipeline (model=%s, voice=%s, backend=%s)…",
             config.voice.stt_model,
             config.voice.tts_voice,
+            config.voice.backend,
         )
         voice = VoicePipeline(
             stt_model=config.voice.stt_model,
             tts_voice=config.voice.tts_voice,
             tts_enabled=config.voice.tts_enabled,
+            backend=config.voice.backend,
+            kokoro_model_path=config.voice.kokoro.model_path,
+            kokoro_voices_path=config.voice.kokoro.voices_path,
+            kokoro_default_voice=config.voice.kokoro.default_voice,
         )
         agent.voice = voice
 

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -46,7 +46,7 @@ Edit agent settings without touching config files:
 - **Email** — Himalaya configuration
 - **Search** — Tavily API configuration
 - **Tools** — enable optional external CLI tools the agent can use
-- **Voice** — STT/TTS settings
+- **Voice** — STT/TTS settings, including the **TTS backend** (Edge TTS or offline Kokoro), the default voice, and a **Preview** button to hear a voice before saving
 
 ### Tools
 
@@ -60,7 +60,7 @@ Built-in skill editor for creating, editing, and deleting skill files. Changes t
 
 ### Personae
 
-Manage swappable agent identities — each with its own character, skill allowlist, tool scope, voice, and secret scope. Cards show every persona and the active one; **Use** activates one (applied live to new turns) or revert to **Default** (the Assistant-tab identity). The editor offers a **guided form** (identity, agent name, voice, skill + tool checkboxes, secret scope) and a **raw markdown** toggle for power users. Six starter personae ship seeded. The page is responsive at phone width. See [Personae](/docs/personae) for the full model.
+Manage swappable agent identities — each with its own character, skill allowlist, tool scope, voice, and secret scope. Cards show every persona and the active one; **Use** activates one (applied live to new turns) or revert to **Default** (the Assistant-tab identity). The editor offers a **guided form** (identity, agent name, voice with a **Preview** button and Edge/Kokoro suggestions, skill + tool checkboxes, secret scope) and a **raw markdown** toggle for power users. Six starter personae ship seeded. The page is responsive at phone width. See [Personae](/docs/personae) for the full model.
 
 ### Chats
 

--- a/docs/content/docs/voice.mdx
+++ b/docs/content/docs/voice.mdx
@@ -96,12 +96,13 @@ Set `backend: "kokoro"` to use it.
 
 ### Enabling it
 
-Kokoro and its model are **not bundled by default** (edge-tts is the default
-backend and the model adds ~325 MB). Build the image with the model and the
-Python extra:
+The Docker image **bundles Kokoro and its model by default**, so switching the
+backend to `kokoro` works out of the box. edge-tts remains the default backend;
+the Kokoro extra (onnxruntime ~200 MB) and model (~325 MB) just ride along ready
+to use. For a leaner edge-tts-only image, opt out at build time:
 
 ```bash
-docker build --build-arg INSTALL_KOKORO=true -t mpa .
+docker build --build-arg INSTALL_KOKORO=false -t mpa .
 ```
 
 For a local (non-Docker) run, install the extra and download the model files to

--- a/docs/content/docs/voice.mdx
+++ b/docs/content/docs/voice.mdx
@@ -61,7 +61,7 @@ voice:
     default_voice: "af_bella"
 ```
 
-You can also set the backend and default voice from the admin UI (**Assistant → Voice**), and pick a per-persona voice in the persona editor — both with a **Preview** button to hear a voice before saving.
+You can also set the backend and default voice from the admin UI (**Assistant → Voice**), and pick a per-persona voice in the persona editor. Both have a **Preview** box: type a few words, optionally pick a **language**, and hear the voice before saving. Because the voice (timbre) and the pronunciation language are independent in Kokoro, any voice can read any language — e.g. an Italian voice reading English.
 
 ### Whisper model sizes
 

--- a/docs/content/docs/voice.mdx
+++ b/docs/content/docs/voice.mdx
@@ -105,11 +105,21 @@ to use. For a leaner edge-tts-only image, opt out at build time:
 docker build --build-arg INSTALL_KOKORO=false -t mpa .
 ```
 
-For a local (non-Docker) run, install the extra and download the model files to
-the configured `kokoro.model_path` / `kokoro.voices_path`:
+For a local (non-Docker) run, fetch the extra and the model with one command:
+
+```bash
+make kokoro
+```
+
+That installs the `kokoro` Python extra and downloads the model files into
+`models/kokoro/` (the configured `kokoro.model_path` / `kokoro.voices_path`).
+Then set `backend: kokoro` and restart the agent. To do it by hand instead:
 
 ```bash
 uv sync --extra kokoro
+mkdir -p models/kokoro
+curl -fL https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx -o models/kokoro/kokoro-v1.0.onnx
+curl -fL https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin -o models/kokoro/voices-v1.0.bin
 ```
 
 If the model can't be loaded (missing file, OOM), MPA logs a warning and **falls

--- a/docs/content/docs/voice.mdx
+++ b/docs/content/docs/voice.mdx
@@ -61,6 +61,8 @@ voice:
     default_voice: "af_bella"
 ```
 
+You can also set the backend and default voice from the admin UI (**Assistant → Voice**), and pick a per-persona voice in the persona editor — both with a **Preview** button to hear a voice before saving.
+
 ### Whisper model sizes
 
 | Model | Size | Speed | Accuracy |

--- a/docs/content/docs/voice.mdx
+++ b/docs/content/docs/voice.mdx
@@ -12,7 +12,7 @@ MPA includes a voice pipeline for receiving and sending voice messages through m
 | Component | Technology | Purpose |
 |-----------|-----------|---------|
 | **Speech-to-Text** | [faster-whisper](https://github.com/guillaumekln/faster-whisper) | Transcribe incoming voice messages |
-| **Text-to-Speech** | [edge-tts](https://github.com/rany2/edge-tts) | Synthesize voice responses |
+| **Text-to-Speech** | [edge-tts](https://github.com/rany2/edge-tts) (default) or [Kokoro 82M](https://huggingface.co/hexgrad/Kokoro-82M) | Synthesize voice responses |
 
 ## How it works
 
@@ -54,6 +54,11 @@ voice:
   stt_model: "base"           # Whisper model size
   tts_voice: "en-US-GuyNeural"  # edge-tts voice name
   tts_enabled: true
+  backend: "edge-tts"         # "edge-tts" (cloud) | "kokoro" (offline)
+  kokoro:                     # only used when backend: kokoro
+    model_path: "models/kokoro/kokoro-v1.0.onnx"
+    voices_path: "models/kokoro/voices-v1.0.bin"
+    default_voice: "af_bella"
 ```
 
 ### Whisper model sizes
@@ -80,9 +85,63 @@ edge-tts provides a wide selection of voices. Some popular options:
 | `it-IT-DiegoNeural` | Italian | Male |
 | `de-DE-ConradNeural` | German | Male |
 
+## Kokoro (offline TTS)
+
+[Kokoro 82M](https://huggingface.co/hexgrad/Kokoro-82M) is an open-weight TTS
+model that runs on CPU in real time — **fully offline**, no cloud calls, and
+**multilingual** so the agent can answer in the language it's conversing in.
+Set `backend: "kokoro"` to use it.
+
+### Enabling it
+
+Kokoro and its model are **not bundled by default** (edge-tts is the default
+backend and the model adds ~325 MB). Build the image with the model and the
+Python extra:
+
+```bash
+docker build --build-arg INSTALL_KOKORO=true -t mpa .
+```
+
+For a local (non-Docker) run, install the extra and download the model files to
+the configured `kokoro.model_path` / `kokoro.voices_path`:
+
+```bash
+uv sync --extra kokoro
+```
+
+If the model can't be loaded (missing file, OOM), MPA logs a warning and **falls
+back to edge-tts** — both at startup and per-reply — so voice replies are never
+lost.
+
+### Voices
+
+The voice name's first letter selects the language (used for phonemization):
+
+| Prefix | Language | Example voices |
+|--------|----------|----------------|
+| `af_`, `am_` | English (US) F/M | `af_bella`, `af_nicole`, `am_adam` |
+| `bf_`, `bm_` | English (UK) F/M | `bf_emma`, `bm_george` |
+| `ff_` | French | `ff_siwis` |
+| `jf_`, `jm_` | Japanese F/M | `jf_alpha`, `jm_kuma` |
+| `zf_`, `zm_` | Mandarin F/M | `zf_xiaobei` |
+| `ef_`, `em_` | Spanish F/M | `ef_dora`, `em_alex` |
+| `pf_`, `pm_` | Portuguese F/M | `pf_dora`, `pm_alex` |
+| `hf_`, `hm_` | Hindi F/M | `hm_omega` |
+
+### Per-persona voice
+
+A persona can speak in its own voice — set `voice:` in the persona's frontmatter
+to a Kokoro voice name (e.g. a French tutor using `ff_siwis`). The same field
+also works for edge-tts voice names; pick one that matches the active backend.
+
+```yaml
+voice: "ff_siwis"   # this persona speaks French
+```
+
 ## Resource requirements
 
 | Component | RAM | CPU |
 |-----------|-----|-----|
 | faster-whisper (`base`) | ~300 MB | 1 core during transcription |
 | edge-tts | Minimal | Minimal (streams from Microsoft) |
+| Kokoro 82M | ~400 MB | 1 core during synthesis (real-time on CPU) |

--- a/docs/content/docs/voice.mdx
+++ b/docs/content/docs/voice.mdx
@@ -122,6 +122,7 @@ The voice name's first letter selects the language (used for phonemization):
 | `af_`, `am_` | English (US) F/M | `af_bella`, `af_nicole`, `am_adam` |
 | `bf_`, `bm_` | English (UK) F/M | `bf_emma`, `bm_george` |
 | `ff_` | French | `ff_siwis` |
+| `if_`, `im_` | Italian F/M | `if_sara`, `im_nicola` |
 | `jf_`, `jm_` | Japanese F/M | `jf_alpha`, `jm_kuma` |
 | `zf_`, `zm_` | Mandarin F/M | `zf_xiaobei` |
 | `ef_`, `em_` | Spanish F/M | `ef_dora`, `em_alex` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ dependencies = [
     "cryptography",
 ]
 
+[project.optional-dependencies]
+# Offline on-device TTS (issue #84). Optional: pulls onnxruntime (~200MB), only
+# needed when voice.backend = "kokoro". Install with `uv sync --extra kokoro`.
+kokoro = ["kokoro-onnx>=0.4"]
+
 [dependency-groups]
 dev = [
     "pytest",

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -206,6 +206,36 @@ class TestPartialRoutes:
         assert "text/html" in resp.headers["content-type"]
         assert "character" in resp.text.lower() or "personalia" in resp.text.lower()
 
+    def test_identity_partial_has_voice_backend_and_kokoro(self):
+        # #84: backend selector + Kokoro voice picker + preview wiring.
+        client = _client(setup_complete=True)
+        resp = client.get("/partials/identity", headers=AUTH)
+        assert resp.status_code == 200
+        assert "TTS backend" in resp.text
+        assert "kokoro" in resp.text.lower()
+        assert "af_bella" in resp.text
+        assert "previewVoice" in resp.text
+
+
+class TestVoicePreview:
+    def test_preview_503_without_voice_pipeline(self):
+        # Agent present but no voice pipeline loaded → graceful 503.
+        client = _client(agent=cast(Any, SimpleNamespace()))
+        resp = client.post("/voice/preview", json={"voice": "af_bella"}, headers=AUTH)
+        assert resp.status_code == 503
+
+    def test_preview_returns_audio(self):
+        class _VoiceStub:
+            async def preview(self, text: str, voice: str):
+                assert voice == "en-US-AvaNeural"
+                return b"AUDIO-BYTES", "audio/mpeg"
+
+        client = _client(agent=cast(Any, SimpleNamespace(voice=_VoiceStub())))
+        resp = client.post("/voice/preview", json={"voice": "en-US-AvaNeural"}, headers=AUTH)
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/mpeg"
+        assert resp.content == b"AUDIO-BYTES"
+
     def test_permissions_partial(self):
         client = _client(setup_complete=True)
         resp = client.get("/partials/permissions", headers=AUTH)

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -234,7 +234,7 @@ class TestVoicePreview:
 
     def test_preview_returns_audio(self):
         class _VoiceStub:
-            async def preview(self, text: str, voice: str):
+            async def preview(self, text: str, voice: str, lang: str = ""):
                 assert voice == "en-US-AvaNeural"
                 return b"AUDIO-BYTES", "audio/mpeg"
 
@@ -243,6 +243,24 @@ class TestVoicePreview:
         assert resp.status_code == 200
         assert resp.headers["content-type"] == "audio/mpeg"
         assert resp.content == b"AUDIO-BYTES"
+
+    def test_preview_passes_text_and_lang(self):
+        # #84: custom preview text + Kokoro language override reach the pipeline.
+        seen = {}
+
+        class _VoiceStub:
+            async def preview(self, text: str, voice: str, lang: str = ""):
+                seen.update(text=text, voice=voice, lang=lang)
+                return b"OGG", "audio/ogg"
+
+        client = _client(agent=cast(Any, SimpleNamespace(voice=_VoiceStub())))
+        resp = client.post(
+            "/voice/preview",
+            json={"voice": "if_sara", "text": "Hello world", "lang": "en-us"},
+            headers=AUTH,
+        )
+        assert resp.status_code == 200
+        assert seen == {"text": "Hello world", "voice": "if_sara", "lang": "en-us"}
 
     def test_permissions_partial(self):
         client = _client(setup_complete=True)

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -224,6 +224,14 @@ class TestVoicePreview:
         resp = client.post("/voice/preview", json={"voice": "af_bella"}, headers=AUTH)
         assert resp.status_code == 503
 
+    def test_preview_rejects_oversized_text(self):
+        # #84: bounded input so an admin can't request megabytes of synthesis.
+        client = _client(setup_complete=True)
+        resp = client.post(
+            "/voice/preview", json={"voice": "af_bella", "text": "x" * 1000}, headers=AUTH
+        )
+        assert resp.status_code == 422
+
     def test_preview_returns_audio(self):
         class _VoiceStub:
             async def preview(self, text: str, voice: str):

--- a/tests/test_voice_kokoro.py
+++ b/tests/test_voice_kokoro.py
@@ -1,0 +1,83 @@
+"""Kokoro TTS backend: lang mapping, WAV encoding, fallback dispatch (#84).
+
+Builds a bare VoicePipeline via ``object.__new__`` so we never load Whisper or
+the ONNX model — only the new branch logic is under test.
+"""
+
+import asyncio
+import wave
+
+import numpy as np
+
+from voice.pipeline import VoicePipeline, _lang_for_voice, _pcm_to_wav
+
+
+def test_lang_for_voice_prefix():
+    assert _lang_for_voice("af_bella") == "en-us"
+    assert _lang_for_voice("bm_george") == "en-gb"
+    assert _lang_for_voice("jf_alpha") == "ja"
+    assert _lang_for_voice("ff_siwis") == "fr-fr"
+    assert _lang_for_voice("xx_unknown") == "en-us"  # default
+
+
+def test_pcm_to_wav_roundtrip():
+    samples = np.array([0.0, 1.0, -1.0, 2.0, -2.0], dtype=np.float32)  # last two clip
+    data = _pcm_to_wav(samples, 24000)
+    assert data[:4] == b"RIFF"
+    import io
+
+    with wave.open(io.BytesIO(data), "rb") as w:
+        assert w.getframerate() == 24000
+        assert w.getnchannels() == 1
+        assert w.getsampwidth() == 2
+        frames = np.frombuffer(w.readframes(w.getnframes()), dtype="<i2")
+    assert frames[1] == 32767 and frames[2] == -32767  # clipped to int16 range
+    assert frames[3] == 32767 and frames[4] == -32767
+
+
+def _bare_pipeline():
+    p = object.__new__(VoicePipeline)
+    p.tts_enabled = True
+    p.tts_voice = "en-US-AvaNeural"
+    p.kokoro_default_voice = "af_bella"
+    p._kokoro = None
+    return p
+
+
+class _FakeKokoro:
+    def __init__(self, raise_it=False):
+        self.raise_it = raise_it
+        self.calls = []
+
+    def create(self, text, voice, speed, lang):
+        self.calls.append((text, voice, lang))
+        if self.raise_it:
+            raise RuntimeError("onnx boom")
+        return np.zeros(10, dtype=np.float32), 24000
+
+
+def test_synthesize_uses_kokoro_when_loaded():
+    p = _bare_pipeline()
+    p._kokoro = _FakeKokoro()
+    out = asyncio.run(p.synthesize("hello", voice="jf_alpha"))
+    assert out[:4] == b"RIFF"
+    assert p._kokoro.calls == [("hello", "jf_alpha", "ja")]
+
+
+def test_synthesize_falls_back_to_edge_on_kokoro_error(monkeypatch):
+    p = _bare_pipeline()
+    p._kokoro = _FakeKokoro(raise_it=True)
+
+    async def fake_edge(text, voice):
+        return b"EDGE-AUDIO"
+
+    monkeypatch.setattr(p, "_synthesize_edge", fake_edge)
+    out = asyncio.run(p.synthesize("hello", voice="af_bella"))
+    assert out == b"EDGE-AUDIO"  # kokoro raised → edge fallback
+
+
+def test_synthesize_default_voice_when_none():
+    p = _bare_pipeline()
+    p._kokoro = _FakeKokoro()
+    asyncio.run(p.synthesize("hi", voice=None))
+    assert p._kokoro.calls[0][1] == "af_bella"  # fell back to kokoro_default_voice

--- a/tests/test_voice_kokoro.py
+++ b/tests/test_voice_kokoro.py
@@ -98,6 +98,23 @@ def test_synthesize_falls_back_to_edge_on_kokoro_error(monkeypatch):
     assert seen["voice"] is None  # Kokoro voice name dropped so edge-tts accepts it (#84)
 
 
+def test_synthesize_edge_backend_drops_kokoro_voice(monkeypatch):
+    """Edge backend (no Kokoro loaded) must not hand a Kokoro voice to edge-tts,
+    but must keep a real edge voice (#84)."""
+    p = _bare_pipeline()  # _kokoro is None → plain edge path
+    seen = {}
+
+    async def fake_edge(text, voice):
+        seen["voice"] = voice
+        return b"EDGE"
+
+    monkeypatch.setattr(p, "_synthesize_edge", fake_edge)
+    asyncio.run(p.synthesize("hi", voice="af_bella"))
+    assert seen["voice"] is None  # kokoro name dropped on the plain edge path
+    asyncio.run(p.synthesize("hi", voice="en-US-GuyNeural"))
+    assert seen["voice"] == "en-US-GuyNeural"  # edge voice preserved
+
+
 def test_synthesize_fallback_keeps_edge_voice(monkeypatch):
     """A persona's valid edge-tts voice must survive a Kokoro failure (#84)."""
     p = _bare_pipeline()

--- a/tests/test_voice_kokoro.py
+++ b/tests/test_voice_kokoro.py
@@ -143,3 +143,33 @@ def test_wav_to_ogg_real_ffmpeg():
         pytest.skip("ffmpeg not installed")
     ogg = _wav_to_ogg(_pcm_to_wav(np.zeros(2400, dtype=np.float32), 24000))
     assert ogg[:4] == b"OggS"  # valid Ogg stream
+
+
+def test_preview_lang_override(monkeypatch):
+    """Explicit lang reaches Kokoro.create instead of the voice-derived one (#84):
+    an Italian voice can read English."""
+    monkeypatch.setattr("voice.pipeline._wav_to_ogg", lambda wav: b"OGG")
+    p = _bare_pipeline()
+    p._kokoro = _FakeKokoro()
+    audio, mime = asyncio.run(p.preview("Hello world", "if_sara", "en-us"))
+    assert mime == "audio/ogg"
+    assert p._kokoro.calls == [("Hello world", "if_sara", "en-us")]  # not derived "it"
+
+
+def test_preview_lang_blank_derives_from_voice(monkeypatch):
+    monkeypatch.setattr("voice.pipeline._wav_to_ogg", lambda wav: b"OGG")
+    p = _bare_pipeline()
+    p._kokoro = _FakeKokoro()
+    asyncio.run(p.preview("Ciao", "if_sara", ""))
+    assert p._kokoro.calls[0][2] == "it"  # blank lang → derived from voice prefix
+
+
+def test_preview_edge_voice_ignores_lang(monkeypatch):
+    p = _bare_pipeline()  # edge voice → no Kokoro needed
+
+    async def fake_edge(text, voice):
+        return b"MP3"
+
+    monkeypatch.setattr(p, "_synthesize_edge", fake_edge)
+    audio, mime = asyncio.run(p.preview("Hi", "en-US-AvaNeural", "it"))
+    assert (audio, mime) == (b"MP3", "audio/mpeg")  # edge path, lang irrelevant

--- a/tests/test_voice_kokoro.py
+++ b/tests/test_voice_kokoro.py
@@ -13,7 +13,13 @@ import wave
 import numpy as np
 import pytest
 
-from voice.pipeline import VoicePipeline, _lang_for_voice, _pcm_to_wav, _wav_to_ogg
+from voice.pipeline import (
+    VoicePipeline,
+    _is_kokoro_voice,
+    _lang_for_voice,
+    _pcm_to_wav,
+    _wav_to_ogg,
+)
 
 
 def test_lang_for_voice_prefix():
@@ -23,6 +29,14 @@ def test_lang_for_voice_prefix():
     assert _lang_for_voice("ff_siwis") == "fr-fr"
     assert _lang_for_voice("if_sara") == "it"
     assert _lang_for_voice("xx_unknown") == "en-us"  # default
+
+
+def test_is_kokoro_voice():
+    assert _is_kokoro_voice("af_bella")
+    assert _is_kokoro_voice("jm_kuma")
+    assert not _is_kokoro_voice("en-US-GuyNeural")  # edge-tts name
+    assert not _is_kokoro_voice("")
+    assert not _is_kokoro_voice(None)
 
 
 def test_pcm_to_wav_roundtrip():
@@ -82,6 +96,21 @@ def test_synthesize_falls_back_to_edge_on_kokoro_error(monkeypatch):
     out = asyncio.run(p.synthesize("hello", voice="af_bella"))
     assert out == b"EDGE-AUDIO"  # kokoro raised → edge fallback
     assert seen["voice"] is None  # Kokoro voice name dropped so edge-tts accepts it (#84)
+
+
+def test_synthesize_fallback_keeps_edge_voice(monkeypatch):
+    """A persona's valid edge-tts voice must survive a Kokoro failure (#84)."""
+    p = _bare_pipeline()
+    p._kokoro = _FakeKokoro(raise_it=True)
+    seen = {}
+
+    async def fake_edge(text, voice):
+        seen["voice"] = voice
+        return b"EDGE-AUDIO"
+
+    monkeypatch.setattr(p, "_synthesize_edge", fake_edge)
+    asyncio.run(p.synthesize("hello", voice="en-US-GuyNeural"))
+    assert seen["voice"] == "en-US-GuyNeural"  # edge voice preserved, not dropped
 
 
 def test_synthesize_default_voice_when_none(monkeypatch):

--- a/tests/test_voice_kokoro.py
+++ b/tests/test_voice_kokoro.py
@@ -1,15 +1,19 @@
-"""Kokoro TTS backend: lang mapping, WAV encoding, fallback dispatch (#84).
+"""Kokoro TTS backend: lang mapping, WAV encoding, OGG transcode, fallback (#84).
 
 Builds a bare VoicePipeline via ``object.__new__`` so we never load Whisper or
-the ONNX model — only the new branch logic is under test.
+the ONNX model — only the new branch logic is under test.  ffmpeg is stubbed so
+the dispatch tests don't shell out; one guarded test exercises real ffmpeg.
 """
 
 import asyncio
+import io
+import shutil
 import wave
 
 import numpy as np
+import pytest
 
-from voice.pipeline import VoicePipeline, _lang_for_voice, _pcm_to_wav
+from voice.pipeline import VoicePipeline, _lang_for_voice, _pcm_to_wav, _wav_to_ogg
 
 
 def test_lang_for_voice_prefix():
@@ -17,15 +21,14 @@ def test_lang_for_voice_prefix():
     assert _lang_for_voice("bm_george") == "en-gb"
     assert _lang_for_voice("jf_alpha") == "ja"
     assert _lang_for_voice("ff_siwis") == "fr-fr"
+    assert _lang_for_voice("if_sara") == "it"
     assert _lang_for_voice("xx_unknown") == "en-us"  # default
 
 
 def test_pcm_to_wav_roundtrip():
-    samples = np.array([0.0, 1.0, -1.0, 2.0, -2.0], dtype=np.float32)  # last two clip
+    samples = np.array([0.0, 1.0, -1.0, 2.0, -2.0, 0.5], dtype=np.float32)  # ±2.0 clip
     data = _pcm_to_wav(samples, 24000)
     assert data[:4] == b"RIFF"
-    import io
-
     with wave.open(io.BytesIO(data), "rb") as w:
         assert w.getframerate() == 24000
         assert w.getnchannels() == 1
@@ -33,6 +36,7 @@ def test_pcm_to_wav_roundtrip():
         frames = np.frombuffer(w.readframes(w.getnframes()), dtype="<i2")
     assert frames[1] == 32767 and frames[2] == -32767  # clipped to int16 range
     assert frames[3] == 32767 and frames[4] == -32767
+    assert frames[5] == 16384  # 0.5 rounded; truncation would give 16383
 
 
 def _bare_pipeline():
@@ -56,28 +60,40 @@ class _FakeKokoro:
         return np.zeros(10, dtype=np.float32), 24000
 
 
-def test_synthesize_uses_kokoro_when_loaded():
+def test_synthesize_uses_kokoro_when_loaded(monkeypatch):
+    monkeypatch.setattr("voice.pipeline._wav_to_ogg", lambda wav: b"OGG:" + wav[:4])
     p = _bare_pipeline()
     p._kokoro = _FakeKokoro()
     out = asyncio.run(p.synthesize("hello", voice="jf_alpha"))
-    assert out[:4] == b"RIFF"
+    assert out == b"OGG:RIFF"  # kokoro WAV transcoded via _wav_to_ogg
     assert p._kokoro.calls == [("hello", "jf_alpha", "ja")]
 
 
 def test_synthesize_falls_back_to_edge_on_kokoro_error(monkeypatch):
     p = _bare_pipeline()
     p._kokoro = _FakeKokoro(raise_it=True)
+    seen = {}
 
     async def fake_edge(text, voice):
+        seen["voice"] = voice
         return b"EDGE-AUDIO"
 
     monkeypatch.setattr(p, "_synthesize_edge", fake_edge)
     out = asyncio.run(p.synthesize("hello", voice="af_bella"))
     assert out == b"EDGE-AUDIO"  # kokoro raised → edge fallback
+    assert seen["voice"] is None  # Kokoro voice name dropped so edge-tts accepts it (#84)
 
 
-def test_synthesize_default_voice_when_none():
+def test_synthesize_default_voice_when_none(monkeypatch):
+    monkeypatch.setattr("voice.pipeline._wav_to_ogg", lambda wav: wav)
     p = _bare_pipeline()
     p._kokoro = _FakeKokoro()
     asyncio.run(p.synthesize("hi", voice=None))
     assert p._kokoro.calls[0][1] == "af_bella"  # fell back to kokoro_default_voice
+
+
+def test_wav_to_ogg_real_ffmpeg():
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("ffmpeg not installed")
+    ogg = _wav_to_ogg(_pcm_to_wav(np.zeros(2400, dtype=np.float32), 24000))
+    assert ogg[:4] == b"OggS"  # valid Ogg stream

--- a/uv.lock
+++ b/uv.lock
@@ -176,6 +176,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "caldav"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -333,6 +342,26 @@ wheels = [
 ]
 
 [[package]]
+name = "csvw"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "isodate" },
+    { name = "jsonschema" },
+    { name = "language-tags" },
+    { name = "python-dateutil" },
+    { name = "rdflib" },
+    { name = "rfc3986" },
+    { name = "termcolor" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/50/ff0bd8c3663dad0dae929775a6078c5bb7f4038d93032369786b1fe6a91c/csvw-4.0.0.tar.gz", hash = "sha256:060e9bedf3c274d0fce6d6f7f892a16cc8c72f39c2bc49b69b5f0858fb2f6217", size = 83025, upload-time = "2026-05-05T06:25:26.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/88/9713d1ecac111742d60e1d9c2c15fec56fd121940f97a73d014dc9a7d521/csvw-4.0.0-py2.py3-none-any.whl", hash = "sha256:df875fcb1505afd15061b5f370268522bf162640de0662a724453dcb4db6a88b", size = 69424, upload-time = "2026-05-05T06:25:24.646Z" },
+]
+
+[[package]]
 name = "ctranslate2"
 version = "4.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -361,6 +390,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dlinfo"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/8e/8f2f94cd40af1b51e8e371a83b385d622170d42f98776441a6118f4dd682/dlinfo-2.0.0.tar.gz", hash = "sha256:88a2bc04f51d01bc604cdc9eb1c3cc0bde89057532ca6a3e71a41f6235433e17", size = 12727, upload-time = "2025-01-16T15:43:10.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/90/022c79d6e5e6f843268c10b84d4a021ee3afba0621d3c176d3ff2024bfc8/dlinfo-2.0.0-py3-none-any.whl", hash = "sha256:b32cc18e3ea67c0ca9ca409e5b41eed863bd1363dbc9dd3de90fedf11b61e7bc", size = 3654, upload-time = "2025-01-16T15:43:09.474Z" },
 ]
 
 [[package]]
@@ -394,6 +432,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/d2/1ce38f6e4fe7275207f4033b0971db489a0b594340ae6bac2320127e71ee/edge_tts-7.2.7.tar.gz", hash = "sha256:0127fba57a742bc48ff0a2a3b24b8324f7859260185274c335b4e54735aff325", size = 27508, upload-time = "2025-12-12T20:54:28.403Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/89/92ac6b154ab87d236c15e5e0c73cb99be58efb1ea3eb9318c266bf9a36bf/edge_tts-7.2.7-py3-none-any.whl", hash = "sha256:ac11d9e834347e5ee62cbe72e8a56ffd65d3c4e795be14b1e593b72cf6480dd9", size = 30556, upload-time = "2025-12-12T20:54:26.956Z" },
+]
+
+[[package]]
+name = "espeakng-loader"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/92/f44ed7f531143c3c6c97d56e2b0f9be8728dc05e18b96d46eb539230ed46/espeakng_loader-0.2.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b77477ae2ddf62a748e04e49714eabb2f3a24f344166200b00539083bd669904", size = 9938387, upload-time = "2025-01-17T01:22:42.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/26/258c0cd43b9bc1043301c5f61767d6a6c3b679df82790c9cb43a3277b865/espeakng_loader-0.2.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d27cdca31112226e7299d8562e889d3e38a1e48055c9ee381b45d669072ee59f", size = 9892565, upload-time = "2025-01-17T01:22:40.365Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/25ec5ab07528c0fbb215a61800a38eca05c8a99445515a02d7fa5debcb32/espeakng_loader-0.2.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08721baf27d13d461f6be6eed9a65277e70d68234ff484fd8b9897b222cdcb6d", size = 10078484, upload-time = "2025-01-17T01:22:43.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ad/1b768d8daffc2996e07bbcb6f534d8de3202cd75fce1f1c45eced1ce6465/espeakng_loader-0.2.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d1e798141b46a050cdb75fcf3c17db969bb2c40394f3f4a48910655d547508b9", size = 10037736, upload-time = "2025-01-17T01:22:42.576Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ed/a3d872fbad4f3a3f3db0e8c31768ab14e77cd77306de16b8b20b1e1df7ea/espeakng_loader-0.2.4-py3-none-win_amd64.whl", hash = "sha256:41f1e08ac9deda2efd1ea9de0b81dab9f5ae3c4b24284f76533d0a7b1dd7abd7", size = 9437292, upload-time = "2025-01-17T01:23:27.463Z" },
+    { url = "https://files.pythonhosted.org/packages/29/64/0b75bc50ec53b4e000bac913625511215aa96124adf5dba8c4baa17c02cd/espeakng_loader-0.2.4-py3-none-win_arm64.whl", hash = "sha256:d7a2928843eaeb2df82f99a370f44e8a630f59b02f9b0d1f168a03c4eeb76b89", size = 9426841, upload-time = "2025-01-17T01:23:21.766Z" },
 ]
 
 [[package]]
@@ -690,6 +741,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "jh2"
 version = "5.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -771,6 +831,66 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
     { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
     { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kokoro-onnx"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "espeakng-loader" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "phonemizer-fork" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/18/277bd18aeeceaf5c46a51bb50c1cbdccdad8cab7fd1d58f0173bbeeec708/kokoro_onnx-0.5.0.tar.gz", hash = "sha256:5beb15f085e2828ed8d493f792c079af857103ab2dceaa1e112b1760587ac96a", size = 84570, upload-time = "2026-01-30T03:05:45.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/55/0bfcb4aa50033c89e5ac132af3d07fac0543824ce6eaefd4d1bfdcc3795b/kokoro_onnx-0.5.0-py3-none-any.whl", hash = "sha256:4e1c38a296db5dbc1f722f69f5e3c13f2e2877b3e5b145287f56ec057013e357", size = 17448, upload-time = "2026-01-30T03:05:46.931Z" },
+]
+
+[[package]]
+name = "language-tags"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/d1/b37165bed9016c19e2cdecf4176fbd902a014fb8a87dd44415438e190969/language_tags-1.3.1.tar.gz", hash = "sha256:b15f05505dad3ad296a1782d5a6083fd141309186094d1ab08095348f4203f37", size = 222642, upload-time = "2026-05-08T11:46:24.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/21/b48b9e8408b3faec9fb7cb2f68352c7724add35a980c948eaceb29ac41e4/language_tags-1.3.1-py3-none-any.whl", hash = "sha256:f7db7ef8879523019603e09644a86d95ba60595ce5e5ea82d46e8971b0f68f7b", size = 216654, upload-time = "2026-05-08T11:46:17.836Z" },
 ]
 
 [[package]]
@@ -956,6 +1076,11 @@ dependencies = [
     { name = "vobject" },
 ]
 
+[package.optional-dependencies]
+kokoro = [
+    { name = "kokoro-onnx" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -977,6 +1102,7 @@ requires-dist = [
     { name = "faster-whisper" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "kokoro-onnx", marker = "extra == 'kokoro'", specifier = ">=0.4" },
     { name = "numpy" },
     { name = "openai" },
     { name = "playwright" },
@@ -990,6 +1116,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"] },
     { name = "vobject", specifier = ">=0.9.9" },
 ]
+provides-extras = ["kokoro"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1133,6 +1260,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "phonemizer-fork"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dlinfo" },
+    { name = "joblib" },
+    { name = "segments" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/fa/9294d2f11890ca49d0bdac7a4da60cbe5686629bfd4987cae0ad75e051cc/phonemizer_fork-3.3.2.tar.gz", hash = "sha256:10e16e827d0443b087062e21b55e805c00989cf1343b2e81e734cae5f6c0cf69", size = 300989, upload-time = "2025-01-30T13:02:31.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/f1/0dcce21b0ae16a82df4b6583f8f3ad8e55b35f7e98b6bf536a4dd225fa08/phonemizer_fork-3.3.2-py3-none-any.whl", hash = "sha256:97305c76f4183b3825dae8f4c032265fe78c9946ce58c47d4b62161349264b74", size = 82700, upload-time = "2025-01-30T13:02:28.667Z" },
 ]
 
 [[package]]
@@ -1367,6 +1510,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1524,6 +1676,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rdflib"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416, upload-time = "2026-02-13T07:15:46.487Z" },
+]
+
+[[package]]
 name = "recurring-ical-events"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1536,6 +1700,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/90/05dfcc02ecf58bd170305c88db9e3e3933aa73a1f8abac2b326c7fdc1a98/recurring_ical_events-3.8.0.tar.gz", hash = "sha256:3e8c7c35d9bd8956a7ab91afad51477c60d972e1236d3fd1b55087a66bce7d04", size = 602665, upload-time = "2025-06-10T13:23:50.662Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/25/88a4218cccae06ce6b15e41d2f263dd4a73e8e8cbe41537cd7784a17479b/recurring_ical_events-3.8.0-py3-none-any.whl", hash = "sha256:cf958eb17c92d4dca5c621e44c2b3fffd4ba700dca0db66287c5dc11438f63ba", size = 238228, upload-time = "2025-06-10T13:23:49.048Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -1594,6 +1771,15 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3986"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/30/5b1b6c28c105629cc12b33bdcbb0b11b5bb1880c6cfbd955f9e792921aa8/rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835", size = 49378, upload-time = "2021-05-07T23:29:27.183Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/e5/63ca2c4edf4e00657584608bee1001302bbf8c5f569340b78304f2f446cb/rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97", size = 31976, upload-time = "2021-05-07T23:29:25.611Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1604,6 +1790,72 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
 ]
 
 [[package]]
@@ -1629,6 +1881,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/58/ac864a75067dcbd3b95be5ab4eb2b601d7fbc3d3d736a27e391a4f92a5c1/ruff-0.15.1-py3-none-win32.whl", hash = "sha256:660975d9cb49b5d5278b12b03bb9951d554543a90b74ed5d366b20e2c57c2098", size = 10462555, upload-time = "2026-02-12T23:09:29.899Z" },
     { url = "https://files.pythonhosted.org/packages/e0/5e/d4ccc8a27ecdb78116feac4935dfc39d1304536f4296168f91ed3ec00cd2/ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336", size = 11599956, upload-time = "2026-02-12T23:09:01.157Z" },
     { url = "https://files.pythonhosted.org/packages/2a/07/5bda6a85b220c64c65686bc85bd0bbb23b29c62b3a9f9433fa55f17cda93/ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416", size = 10874604, upload-time = "2026-02-12T23:09:05.515Z" },
+]
+
+[[package]]
+name = "segments"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "csvw" },
+    { name = "regex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/57/85cac3a8e32370e88fa5fa92812edb6025db7fcbed51452bd56ee1524957/segments-2.4.0.tar.gz", hash = "sha256:bba71f5520ddd54c8aa2f4d765a60618c6862162d6e7356a4a097f2223166f5b", size = 18662, upload-time = "2026-03-07T10:01:28.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/60/eef9acce946177f92c9aabf432224d87ab908bafafac516a36ab924199f3/segments-2.4.0-py2.py3-none-any.whl", hash = "sha256:4021dc67f201cc03c864c74c618bdb163b1af629da3040babbaa37d8813f3db0", size = 16321, upload-time = "2026-03-07T10:01:27.885Z" },
 ]
 
 [[package]]
@@ -1724,6 +1989,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/1f/9d5c4ca7034754d1fc232af64638b905162bdf3012e9629030e3d755856f/tavily_python-0.7.21.tar.gz", hash = "sha256:897bedf9b1c2fad8605be642e417d6c7ec1b79bf6199563477cf69c4313f824a", size = 21813, upload-time = "2026-01-30T16:57:33.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/39/85e5be4e9a912022f86f38288d1f4dd2d100b60ec75ebf3da37ca0122375/tavily_python-0.7.21-py3-none-any.whl", hash = "sha256:acfb5b62f2d1053d56321b4fb1ddfd2e98bb975cc4446b86b3fe2d3dd0850288", size = 17957, upload-time = "2026-01-30T16:57:32.278Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]
@@ -1857,6 +2131,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]

--- a/voice/__init__.py
+++ b/voice/__init__.py
@@ -1,1 +1,1 @@
-"""Voice pipeline — STT (Whisper) and TTS (edge-tts)."""
+"""Voice pipeline — STT (Whisper) and TTS (edge-tts or Kokoro)."""

--- a/voice/pipeline.py
+++ b/voice/pipeline.py
@@ -39,7 +39,7 @@ def _lang_for_voice(voice: str) -> str:
 
 
 def _is_kokoro_voice(voice: str | None) -> bool:
-    """True for Kokoro-style names (``af_bella``, ``jm_kuma``) vs edge-tts
+    """True for Kokoro-style names (``af_bella``, ``jm_kumo``) vs edge-tts
     names (``en-US-GuyNeural``).  Lets the edge fallback keep a persona's
     edge voice instead of dropping every voice on Kokoro failure."""
     return bool(re.match(r"[a-z][fm]_", voice or ""))
@@ -253,13 +253,12 @@ class VoicePipeline:
             try:
                 return await self._synthesize_kokoro(text, voice)
             except Exception:
-                # A Kokoro voice name means nothing to edge-tts — drop it so the
-                # fallback uses the configured edge voice; but keep a real edge
-                # voice (e.g. a persona's) so its preference survives.
                 log.exception("Kokoro synthesis failed, falling back to edge-tts")
-                fallback = None if _is_kokoro_voice(voice) else voice
-                return await self._synthesize_edge(text, fallback)
-        return await self._synthesize_edge(text, voice)
+        # edge-tts path — primary backend, or the Kokoro fallback. edge-tts can't
+        # speak a Kokoro voice name (e.g. a persona configured with af_bella while
+        # the backend is edge-tts), so drop it to the configured default; keep a
+        # real edge voice so its preference survives.
+        return await self._synthesize_edge(text, None if _is_kokoro_voice(voice) else voice)
 
     async def _synthesize_edge(self, text: str, voice: str | None) -> bytes:
         communicate = edge_tts.Communicate(text, voice or self.tts_voice)

--- a/voice/pipeline.py
+++ b/voice/pipeline.py
@@ -100,6 +100,20 @@ KOKORO_VOICES: tuple[str, ...] = (
     "pm_alex",
 )
 
+# Kokoro phonemization languages (code, label) for the admin preview dropdown.
+# The language is independent of the voice, so any voice can read any language.
+KOKORO_LANGUAGES: tuple[tuple[str, str], ...] = (
+    ("en-us", "English (US)"),
+    ("en-gb", "English (UK)"),
+    ("it", "Italian"),
+    ("fr-fr", "French"),
+    ("es", "Spanish"),
+    ("pt-br", "Portuguese (BR)"),
+    ("hi", "Hindi"),
+    ("ja", "Japanese"),
+    ("cmn", "Mandarin"),
+)
+
 
 def _pcm_to_wav(samples, sample_rate: int) -> bytes:
     """Encode float32 PCM samples (-1..1) from Kokoro into 16-bit mono WAV bytes."""
@@ -271,26 +285,38 @@ class VoicePipeline:
         log.info("Synthesized %d chars → %d bytes audio (edge-tts)", len(text), len(audio))
         return audio
 
-    async def _synthesize_kokoro(self, text: str, voice: str | None) -> bytes:
-        """Kokoro is synchronous and CPU-bound — run it off the event loop."""
+    async def _synthesize_kokoro(
+        self, text: str, voice: str | None, lang: str | None = None
+    ) -> bytes:
+        """Kokoro is synchronous and CPU-bound — run it off the event loop.
+
+        ``lang`` overrides the phonemization language (independent of the voice,
+        so an Italian voice can read English); ``None`` derives it from the voice.
+        """
         import asyncio as _asyncio
 
         name = voice or self.kokoro_default_voice
         loop = _asyncio.get_running_loop()
-        return await loop.run_in_executor(None, partial(self._kokoro_sync, text, name))
+        return await loop.run_in_executor(None, partial(self._kokoro_sync, text, name, lang))
 
-    def _kokoro_sync(self, text: str, voice: str) -> bytes:
-        samples, sample_rate = self._kokoro.create(
-            text, voice=voice, speed=1.0, lang=_lang_for_voice(voice)
-        )
+    def _kokoro_sync(self, text: str, voice: str, lang: str | None = None) -> bytes:
+        lang = lang or _lang_for_voice(voice)
+        samples, sample_rate = self._kokoro.create(text, voice=voice, speed=1.0, lang=lang)
         audio = _wav_to_ogg(_pcm_to_wav(samples, sample_rate))
-        log.info("Synthesized %d chars → %d bytes audio (kokoro/%s)", len(text), len(audio), voice)
+        log.info(
+            "Synthesized %d chars → %d bytes audio (kokoro/%s/%s)",
+            len(text),
+            len(audio),
+            voice,
+            lang,
+        )
         return audio
 
-    async def preview(self, text: str, voice: str) -> tuple[bytes, str]:
+    async def preview(self, text: str, voice: str, lang: str = "") -> tuple[bytes, str]:
         """Synthesize a short sample with a SPECIFIC voice for the admin voice
         picker.  The engine is chosen from the voice name (Kokoro-style →
-        Kokoro, else edge-tts), independent of the configured backend.  Returns
+        Kokoro, else edge-tts), independent of the configured backend.  ``lang``
+        (Kokoro only) overrides the pronunciation language.  Returns
         ``(audio_bytes, mime_type)``.
         """
         text = clean_for_speech(text) or text
@@ -300,5 +326,5 @@ class VoicePipeline:
                     "Kokoro model isn't loaded — switch the TTS backend to "
                     "'kokoro' and restart to preview Kokoro voices."
                 )
-            return await self._synthesize_kokoro(text, voice), "audio/ogg"
+            return await self._synthesize_kokoro(text, voice, lang or None), "audio/ogg"
         return await self._synthesize_edge(text, voice), "audio/mpeg"

--- a/voice/pipeline.py
+++ b/voice/pipeline.py
@@ -1,4 +1,4 @@
-"""Voice pipeline — Whisper STT + edge-tts TTS."""
+"""Voice pipeline — Whisper STT + edge-tts / Kokoro TTS."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ import io
 import logging
 import re
 import unicodedata
+import wave
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,44 @@ if TYPE_CHECKING:
     import asyncio
 
 log = logging.getLogger(__name__)
+
+# Kokoro voice names encode language in the first letter (af_bella → "a" → en-us).
+# kokoro-onnx needs the lang for phonemization; map the prefix, default en-us.
+_KOKORO_LANG = {
+    "a": "en-us",  # American English
+    "b": "en-gb",  # British English
+    "j": "ja",  # Japanese
+    "z": "cmn",  # Mandarin Chinese
+    "e": "es",  # Spanish
+    "f": "fr-fr",  # French
+    "h": "hi",  # Hindi
+    "i": "it",  # Italian
+    "p": "pt-br",  # Brazilian Portuguese
+}
+
+
+def _lang_for_voice(voice: str) -> str:
+    return _KOKORO_LANG.get(voice[:1], "en-us")
+
+
+def _pcm_to_wav(samples, sample_rate: int) -> bytes:
+    """Encode float32 PCM samples (-1..1) from Kokoro into WAV bytes.
+
+    Stdlib ``wave`` keeps this dependency-free; Telegram ``send_voice`` and web
+    browsers both play WAV.  ponytail: WAV via stdlib; transcode to ogg/opus
+    with ffmpeg only if some client rejects it.
+    """
+    import numpy as np
+
+    pcm16 = (np.clip(np.asarray(samples), -1.0, 1.0) * 32767).astype("<i2")
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(pcm16.tobytes())
+    return buf.getvalue()
+
 
 _CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)  # fenced code
 _INLINE_CODE_RE = re.compile(r"`[^`]*`")
@@ -46,20 +85,40 @@ def clean_for_speech(text: str) -> str:
 
 
 class VoicePipeline:
-    """Speech-to-text via faster-whisper, text-to-speech via edge-tts."""
+    """Speech-to-text via faster-whisper; text-to-speech via edge-tts or Kokoro."""
 
     def __init__(
         self,
         stt_model: str = "base",
         tts_voice: str = "en-US-AvaNeural",
         tts_enabled: bool = True,
+        backend: str = "edge-tts",
+        kokoro_model_path: str = "models/kokoro/kokoro-v1.0.onnx",
+        kokoro_voices_path: str = "models/kokoro/voices-v1.0.bin",
+        kokoro_default_voice: str = "af_bella",
     ):
         self.tts_voice = tts_voice
         self.tts_enabled = tts_enabled
+        self.backend = backend
+        self.kokoro_default_voice = kokoro_default_voice
+        self._kokoro = None
 
         log.info("Loading Whisper model '%s' …", stt_model)
         self._whisper = WhisperModel(stt_model, compute_type="int8")
         log.info("Whisper model loaded.")
+
+        if backend == "kokoro":
+            # Load eagerly so a bad path/missing model degrades to edge-tts at
+            # startup (logged once) rather than on every reply.  Issue #84.
+            try:
+                from kokoro_onnx import Kokoro
+
+                log.info("Loading Kokoro TTS (%s) …", kokoro_model_path)
+                self._kokoro = Kokoro(kokoro_model_path, kokoro_voices_path)
+                log.info("Kokoro TTS loaded.")
+            except Exception:
+                log.exception("Kokoro TTS unavailable, falling back to edge-tts")
+                self.backend = "edge-tts"
 
     # -- STT ----------------------------------------------------------------
 
@@ -87,15 +146,26 @@ class VoicePipeline:
     # -- TTS ----------------------------------------------------------------
 
     async def synthesize(self, text: str, voice: str | None = None) -> bytes:
-        """Convert text to speech using edge-tts.  Returns raw MP3 bytes.
+        """Convert text to speech.  Returns raw audio bytes (MP3 for edge-tts,
+        WAV for Kokoro).
 
         ``voice`` overrides the configured default (e.g. an active persona's
-        own voice); empty/None falls back to ``self.tts_voice``.
+        own voice); empty/None falls back to the backend default.  Kokoro runs
+        on-device; if it fails for any reason we fall back to edge-tts so a
+        reply is never lost (issue #84).
         """
         if not self.tts_enabled:
             raise RuntimeError("TTS is disabled in config")
 
         text = clean_for_speech(text)
+        if self._kokoro is not None:
+            try:
+                return await self._synthesize_kokoro(text, voice)
+            except Exception:
+                log.exception("Kokoro synthesis failed, falling back to edge-tts")
+        return await self._synthesize_edge(text, voice)
+
+    async def _synthesize_edge(self, text: str, voice: str | None) -> bytes:
         communicate = edge_tts.Communicate(text, voice or self.tts_voice)
         buf = io.BytesIO()
         async for chunk in communicate.stream():
@@ -103,5 +173,21 @@ class VoicePipeline:
                 buf.write(chunk["data"])
 
         audio = buf.getvalue()
-        log.info("Synthesized %d chars → %d bytes audio", len(text), len(audio))
+        log.info("Synthesized %d chars → %d bytes audio (edge-tts)", len(text), len(audio))
+        return audio
+
+    async def _synthesize_kokoro(self, text: str, voice: str | None) -> bytes:
+        """Kokoro is synchronous and CPU-bound — run it off the event loop."""
+        import asyncio as _asyncio
+
+        name = voice or self.kokoro_default_voice
+        loop = _asyncio.get_running_loop()
+        return await loop.run_in_executor(None, partial(self._kokoro_sync, text, name))
+
+    def _kokoro_sync(self, text: str, voice: str) -> bytes:
+        samples, sample_rate = self._kokoro.create(
+            text, voice=voice, speed=1.0, lang=_lang_for_voice(voice)
+        )
+        audio = _pcm_to_wav(samples, sample_rate)
+        log.info("Synthesized %d chars → %d bytes audio (kokoro/%s)", len(text), len(audio), voice)
         return audio

--- a/voice/pipeline.py
+++ b/voice/pipeline.py
@@ -45,6 +45,62 @@ def _is_kokoro_voice(voice: str | None) -> bool:
     return bool(re.match(r"[a-z][fm]_", voice or ""))
 
 
+# Kokoro v1.0 voice names, grouped by language, for the admin voice picker.
+# Free-text fields still accept any name; this is the suggestion/selection list.
+KOKORO_VOICES: tuple[str, ...] = (
+    # English (US)
+    "af_bella",
+    "af_heart",
+    "af_nicole",
+    "af_nova",
+    "af_sarah",
+    "af_sky",
+    "am_adam",
+    "am_echo",
+    "am_eric",
+    "am_fenrir",
+    "am_liam",
+    "am_michael",
+    "am_onyx",
+    "am_puck",
+    # English (UK)
+    "bf_alice",
+    "bf_emma",
+    "bf_isabella",
+    "bf_lily",
+    "bm_daniel",
+    "bm_fable",
+    "bm_george",
+    "bm_lewis",
+    # French
+    "ff_siwis",
+    # Italian
+    "if_sara",
+    "im_nicola",
+    # Japanese
+    "jf_alpha",
+    "jf_gongitsune",
+    "jf_nezumi",
+    "jm_kumo",
+    # Mandarin Chinese
+    "zf_xiaobei",
+    "zf_xiaoxiao",
+    "zm_yunjian",
+    "zm_yunxi",
+    # Spanish
+    "ef_dora",
+    "em_alex",
+    # Hindi
+    "hf_alpha",
+    "hf_beta",
+    "hm_omega",
+    "hm_psi",
+    # Brazilian Portuguese
+    "pf_dora",
+    "pm_alex",
+)
+
+
 def _pcm_to_wav(samples, sample_rate: int) -> bytes:
     """Encode float32 PCM samples (-1..1) from Kokoro into 16-bit mono WAV bytes."""
     import numpy as np
@@ -231,3 +287,19 @@ class VoicePipeline:
         audio = _wav_to_ogg(_pcm_to_wav(samples, sample_rate))
         log.info("Synthesized %d chars → %d bytes audio (kokoro/%s)", len(text), len(audio), voice)
         return audio
+
+    async def preview(self, text: str, voice: str) -> tuple[bytes, str]:
+        """Synthesize a short sample with a SPECIFIC voice for the admin voice
+        picker.  The engine is chosen from the voice name (Kokoro-style →
+        Kokoro, else edge-tts), independent of the configured backend.  Returns
+        ``(audio_bytes, mime_type)``.
+        """
+        text = clean_for_speech(text) or text
+        if _is_kokoro_voice(voice):
+            if self._kokoro is None:
+                raise RuntimeError(
+                    "Kokoro model isn't loaded — switch the TTS backend to "
+                    "'kokoro' and restart to preview Kokoro voices."
+                )
+            return await self._synthesize_kokoro(text, voice), "audio/ogg"
+        return await self._synthesize_edge(text, voice), "audio/mpeg"

--- a/voice/pipeline.py
+++ b/voice/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import logging
 import re
+import subprocess
 import unicodedata
 import wave
 from functools import partial
@@ -38,15 +39,11 @@ def _lang_for_voice(voice: str) -> str:
 
 
 def _pcm_to_wav(samples, sample_rate: int) -> bytes:
-    """Encode float32 PCM samples (-1..1) from Kokoro into WAV bytes.
-
-    Stdlib ``wave`` keeps this dependency-free; Telegram ``send_voice`` and web
-    browsers both play WAV.  ponytail: WAV via stdlib; transcode to ogg/opus
-    with ffmpeg only if some client rejects it.
-    """
+    """Encode float32 PCM samples (-1..1) from Kokoro into 16-bit mono WAV bytes."""
     import numpy as np
 
-    pcm16 = (np.clip(np.asarray(samples), -1.0, 1.0) * 32767).astype("<i2")
+    # round (not truncate) before int16 cast — truncation biases samples toward 0
+    pcm16 = np.rint(np.clip(np.asarray(samples), -1.0, 1.0) * 32767).astype("<i2")
     buf = io.BytesIO()
     with wave.open(buf, "wb") as w:
         w.setnchannels(1)
@@ -54,6 +51,36 @@ def _pcm_to_wav(samples, sample_rate: int) -> bytes:
         w.setframerate(sample_rate)
         w.writeframes(pcm16.tobytes())
     return buf.getvalue()
+
+
+def _wav_to_ogg(wav: bytes) -> bytes:
+    """Transcode WAV → OGG/Opus, the format Telegram ``send_voice`` expects.
+
+    ffmpeg already ships in the image (it decodes incoming voice messages), so
+    no new dependency.  Raises if ffmpeg is missing or fails — the caller treats
+    that like any Kokoro failure and falls back to edge-tts.
+    """
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            "pipe:0",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "32k",
+            "-f",
+            "ogg",
+            "pipe:1",
+        ],
+        input=wav,
+        capture_output=True,
+        check=True,
+    )
+    return proc.stdout
 
 
 _CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)  # fenced code
@@ -147,7 +174,7 @@ class VoicePipeline:
 
     async def synthesize(self, text: str, voice: str | None = None) -> bytes:
         """Convert text to speech.  Returns raw audio bytes (MP3 for edge-tts,
-        WAV for Kokoro).
+        OGG/Opus for Kokoro) — both formats Telegram ``send_voice`` accepts.
 
         ``voice`` overrides the configured default (e.g. an active persona's
         own voice); empty/None falls back to the backend default.  Kokoro runs
@@ -162,7 +189,10 @@ class VoicePipeline:
             try:
                 return await self._synthesize_kokoro(text, voice)
             except Exception:
+                # ``voice`` here is a Kokoro name edge-tts won't recognise — drop
+                # it (voice=None) so the fallback uses the configured edge voice.
                 log.exception("Kokoro synthesis failed, falling back to edge-tts")
+                return await self._synthesize_edge(text, None)
         return await self._synthesize_edge(text, voice)
 
     async def _synthesize_edge(self, text: str, voice: str | None) -> bytes:
@@ -188,6 +218,6 @@ class VoicePipeline:
         samples, sample_rate = self._kokoro.create(
             text, voice=voice, speed=1.0, lang=_lang_for_voice(voice)
         )
-        audio = _pcm_to_wav(samples, sample_rate)
+        audio = _wav_to_ogg(_pcm_to_wav(samples, sample_rate))
         log.info("Synthesized %d chars → %d bytes audio (kokoro/%s)", len(text), len(audio), voice)
         return audio

--- a/voice/pipeline.py
+++ b/voice/pipeline.py
@@ -38,6 +38,13 @@ def _lang_for_voice(voice: str) -> str:
     return _KOKORO_LANG.get(voice[:1], "en-us")
 
 
+def _is_kokoro_voice(voice: str | None) -> bool:
+    """True for Kokoro-style names (``af_bella``, ``jm_kuma``) vs edge-tts
+    names (``en-US-GuyNeural``).  Lets the edge fallback keep a persona's
+    edge voice instead of dropping every voice on Kokoro failure."""
+    return bool(re.match(r"[a-z][fm]_", voice or ""))
+
+
 def _pcm_to_wav(samples, sample_rate: int) -> bytes:
     """Encode float32 PCM samples (-1..1) from Kokoro into 16-bit mono WAV bytes."""
     import numpy as np
@@ -79,6 +86,7 @@ def _wav_to_ogg(wav: bytes) -> bytes:
         input=wav,
         capture_output=True,
         check=True,
+        timeout=30,  # bound the blocking call so a stuck ffmpeg can't starve the pool
     )
     return proc.stdout
 
@@ -189,10 +197,12 @@ class VoicePipeline:
             try:
                 return await self._synthesize_kokoro(text, voice)
             except Exception:
-                # ``voice`` here is a Kokoro name edge-tts won't recognise — drop
-                # it (voice=None) so the fallback uses the configured edge voice.
+                # A Kokoro voice name means nothing to edge-tts — drop it so the
+                # fallback uses the configured edge voice; but keep a real edge
+                # voice (e.g. a persona's) so its preference survives.
                 log.exception("Kokoro synthesis failed, falling back to edge-tts")
-                return await self._synthesize_edge(text, None)
+                fallback = None if _is_kokoro_voice(voice) else voice
+                return await self._synthesize_edge(text, fallback)
         return await self._synthesize_edge(text, voice)
 
     async def _synthesize_edge(self, text: str, voice: str | None) -> bytes:


### PR DESCRIPTION
Closes #84.

## What

Adds **Kokoro 82M** as an on-device, multilingual TTS backend alongside edge-tts. edge-tts stays the default; Kokoro is opt-in and runs fully offline.

## How (lazy by design)

- **One chokepoint, one branch.** No new class hierarchy. `VoicePipeline.synthesize()` already routed every reply (including each persona's `voice`) through a single method — Kokoro is one branch there.
- **Double fallback to edge-tts** so a voice reply is never lost:
  - *load time* — missing/bad model or `kokoro-onnx` not installed → log + degrade to edge-tts at startup
  - *per-synthesis* — any runtime error → log + edge-tts for that reply
- **Per-persona voices come for free** — they already flow through `persona.voice → synthesize(voice=)`. Set `voice: ff_siwis` in a persona's frontmatter to make it speak French.
- **Lean by default.** `kokoro-onnx` (pulls onnxruntime ~200MB) is an **optional extra**, lazy-imported. The image bundles the ~325MB model **only** with `--build-arg INSTALL_KOKORO=true` — mirroring the existing `INSTALL_BROWSER` pattern. A non-default backend should not bloat every image.
- **No new runtime dep for audio.** Kokoro's float32 PCM is encoded to WAV with stdlib `wave`. (`ponytail:` comment flags ffmpeg→ogg as the upgrade path if any client rejects WAV.)
- Voice language for phonemization is derived from the voice-name prefix (`af_`→en-us, `jf_`→ja, …).

## Config

```yaml
voice:
  backend: "edge-tts"   # "edge-tts" (default) | "kokoro"
  kokoro:
    model_path: "models/kokoro/kokoro-v1.0.onnx"
    voices_path: "models/kokoro/voices-v1.0.bin"
    default_voice: "af_bella"
```

## Tests

`tests/test_voice_kokoro.py` — lang-prefix mapping, WAV encode/clip roundtrip, and the dispatch/fallback logic (bare `VoicePipeline` via `object.__new__`, so no Whisper/ONNX load). Full suite: 711 passed.

## Notes / scope

- Out of scope per the issue: streaming/chunked audio, SSML, voice cloning.
- A persona whose `voice` is an edge-tts name while backend=kokoro will simply fall back to edge for that reply — pick voices that match the active backend.