### PR TITLE
feat: per-persona tool identities (own gh token + browser profile) (#93)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -42,8 +42,8 @@ from core.prompt_builder import (
     DEFAULT_TOOL_USAGE_BLOCK,
     build_prompt_sections,
 )
+from core.tools import gh_token_secret_name, tool_env
 from core.tools import registry as tool_registry
-from core.tools import tool_env
 from core.wacli import WacliManager
 
 if TYPE_CHECKING:
@@ -618,6 +618,8 @@ class PersonaUpsertIn(BaseModel):
     secrets: list[str] = []
     bot_token: str = ""  # per-persona Telegram bot (#29); empty = no own bot
     allowed_user_ids: str = ""  # comma/newline-separated; empty = inherit global
+    tool_config: dict = {}  # per-persona external-tool config (gh/browser) — #93
+    gh_token: str = ""  # this persona's GitHub PAT → infra vault; empty = leave unchanged
     raw: str = ""  # when set, the markdown doc is parsed instead of the fields above
 
 
@@ -971,7 +973,25 @@ def create_admin_app(
             ),
             "kokoro_voices": KOKORO_VOICES,
             "kokoro_languages": KOKORO_LANGUAGES,
+            # External CLI tools that support a per-persona identity (#93). Only the
+            # system-wide enabled ones are offered, so the registry stays the
+            # source of truth for what exists.
+            "tool_specs": [
+                {"key": s.key, "label": s.label, "summary": s.summary}
+                for s in tool_registry()
+                if (await config_store.get(f"tools.{s.key}.enabled")) == "true"
+            ],
+            "infra_available": bool(secret_store and secret_store.infra.available),
         }
+
+    async def _persona_gh_token_set(name: str) -> bool:
+        """Whether this persona already has a GitHub token in the infra vault (#93)."""
+        if not name or secret_store is None or not secret_store.infra.available:
+            return False
+        try:
+            return await secret_store.get_infra_secret(gh_token_secret_name(name)) is not None
+        except Exception:
+            return False
 
     @app.get("/admin/personae/new", response_model=None)
     async def admin_persona_new() -> Response:
@@ -986,6 +1006,7 @@ def create_admin_app(
             is_new=True,
             persona=Persona(name=""),
             raw=to_markdown(Persona(name="")),
+            gh_token_set=False,
             **ctx,
         )
 
@@ -1006,6 +1027,7 @@ def create_admin_app(
             is_new=False,
             persona=persona,
             raw=to_markdown(persona),
+            gh_token_set=await _persona_gh_token_set(name),
             **ctx,
         )
 
@@ -2735,7 +2757,7 @@ def create_admin_app(
 
     @app.post("/personae", dependencies=[Depends(auth)])
     async def upsert_persona(body: PersonaUpsertIn) -> HTMLResponse:
-        from core.personae import Persona, _as_int_list, parse_markdown
+        from core.personae import Persona, _as_int_list, _as_tool_config, parse_markdown
 
         name = body.name.strip()
         if not name:
@@ -2759,6 +2781,21 @@ def create_admin_app(
                 secrets=[s.strip() for s in body.secrets if s.strip()],
                 bot_token=body.bot_token.strip(),
                 allowed_user_ids=_as_int_list(body.allowed_user_ids),
+                tool_config=_as_tool_config(body.tool_config),
+            )
+        # A per-persona GitHub token goes into the infra vault (machine-key,
+        # boot-unsealed so it works headless), namespaced per persona (#93). Empty
+        # = leave any existing token untouched.
+        if body.gh_token.strip():
+            if secret_store is None or not secret_store.infra.available:
+                raise HTTPException(
+                    400,
+                    "Set a master key in the Secrets tab before storing per-persona tokens.",
+                )
+            await secret_store.set_infra_secret(
+                gh_token_secret_name(name),
+                body.gh_token.strip(),
+                f"GitHub token for persona {name}",
             )
         store = await _persona_store_from_config(config_store)
         await store.upsert(persona)

--- a/api/admin.py
+++ b/api/admin.py
@@ -982,6 +982,14 @@ def create_admin_app(
                 if (await config_store.get(f"tools.{s.key}.enabled")) == "true"
             ],
             "infra_available": bool(secret_store and secret_store.infra.available),
+            # Existing infra-vault secret names a persona can reuse as its gh token
+            # instead of storing its own copy (#93). Infra vault only (boot-unsealed,
+            # so it resolves headless like the per-persona token does).
+            "infra_names": (
+                [r["name"] for r in await secret_store.list_infra_names()]
+                if secret_store and secret_store.infra.available
+                else []
+            ),
         }
 
     async def _persona_gh_token_set(name: str) -> bool:

--- a/api/templates/partials/tools.html
+++ b/api/templates/partials/tools.html
@@ -283,7 +283,9 @@
     <p class="text-muted text-xs mb-4">
       Let the agent query and act on GitHub (issues, PRs, repos, <code>gh api</code>,
       search). Read operations run without asking; creating issues, PRs or releases
-      ask for confirmation first.
+      ask for confirmation first. This token is the <strong>system-wide default</strong> —
+      give a persona its own GitHub identity in the <strong>Personae</strong> editor
+      (Tool identities), which overrides this token for that persona.
     </p>
 
     <div class="space-y-3">

--- a/api/templates/persona_editor.html
+++ b/api/templates/persona_editor.html
@@ -143,7 +143,8 @@
           Give this persona its own credentials for the external CLI tools, so it acts
           as a distinct identity. <strong>Inherit</strong> = use the system-wide config
           (shared with the owner). <strong>Enabled</strong> = use this persona's own
-          token/profile below. <strong>Disabled</strong> = this tool is off for this persona.
+          token/profile below. <strong>Disabled</strong> = the tool is hidden from this
+          persona's prompt and its credentials are withheld (so it can't act as the owner).
         </p>
         {% for spec in tool_specs %}
         <div class="mb-3 pb-3 border-b border-border last:border-0 last:mb-0 last:pb-0">

--- a/api/templates/persona_editor.html
+++ b/api/templates/persona_editor.html
@@ -135,6 +135,54 @@
         <textarea class="textarea" x-model="secretsText" style="min-height:64px; font-size:0.75rem"
                   placeholder="persona:fitness-coach:*"></textarea>
       </div>
+
+      {# ── Tool identities (#93) ── #}
+      <div class="card">
+        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Tool identities</h3>
+        <p class="text-xs text-muted mb-3">
+          Give this persona its own credentials for the external CLI tools, so it acts
+          as a distinct identity. <strong>Inherit</strong> = use the system-wide config
+          (shared with the owner). <strong>Enabled</strong> = use this persona's own
+          token/profile below. <strong>Disabled</strong> = this tool is off for this persona.
+        </p>
+        {% for spec in tool_specs %}
+        <div class="mb-3 pb-3 border-b border-border last:border-0 last:mb-0 last:pb-0">
+          <div class="flex items-center justify-between gap-2">
+            <label class="label mb-0">{{ spec.label }}</label>
+            <select class="select input-sm" style="max-width:160px" x-model="modes['{{ spec.key }}']">
+              <option value="inherit">Inherit</option>
+              <option value="on">Enabled</option>
+              <option value="off">Disabled</option>
+            </select>
+          </div>
+          {% if spec.key == "gh" %}
+          <div x-show="modes['gh'] === 'on'" class="mt-2">
+            <template x-if="!infraAvailable">
+              <p class="text-xs text-warn">Set a master key in the <strong>Secrets</strong> tab to store a per-persona token.</p>
+            </template>
+            <template x-if="infraAvailable">
+              <div>
+                <input type="password" class="input-sm" autocomplete="new-password"
+                       x-model="ghToken" placeholder="ghp_… (leave blank to keep current)">
+                <p class="text-xs text-muted mt-1">
+                  <span x-show="ghTokenSet">🔒 A token is stored for this persona — type a new one to replace it.</span>
+                  <span x-show="!ghTokenSet">Stored encrypted in the infra vault; injected as this persona's <code>GH_TOKEN</code>.</span>
+                </p>
+              </div>
+            </template>
+          </div>
+          {% elif spec.key == "browser" %}
+          <div x-show="modes['browser'] === 'on'" class="mt-2">
+            <input type="text" class="input-sm" x-model="profiles['browser']"
+                   :placeholder="name.trim() || 'profile'">
+            <p class="text-xs text-muted mt-1">Isolated browser profile (cookies/sessions). Blank = the persona slug.</p>
+          </div>
+          {% endif %}
+        </div>
+        {% else %}
+        <p class="text-xs text-muted">No external tools are enabled system-wide. Enable them in the <strong>Tools</strong> tab first.</p>
+        {% endfor %}
+      </div>
     </div>
   </div>
 
@@ -175,6 +223,37 @@
       result: '',
       ok: false,
 
+      // Per-persona tool identities (#93).
+      toolConfig: {{ persona.tool_config|tojson }},
+      toolKeys: {{ tool_specs|map(attribute='key')|list|tojson }},
+      ghToken: '',
+      ghTokenSet: {{ gh_token_set|tojson }},
+      infraAvailable: {{ infra_available|tojson }},
+      modes: {},
+      profiles: {},
+
+      init() {
+        for (const k of this.toolKeys) {
+          const e = this.toolConfig[k];
+          this.modes[k] = !e ? 'inherit' : (e.enabled ? 'on' : 'off');
+          this.profiles[k] = (e && e.profile) || '';
+        }
+      },
+
+      // Only configured tools get an entry; 'inherit' leaves them out so the
+      // persona keeps using the system-wide config (migration-safe).
+      buildToolConfig() {
+        const tc = {};
+        for (const k of this.toolKeys) {
+          const m = this.modes[k];
+          if (m === 'inherit') continue;
+          const e = { enabled: m === 'on' };
+          if (k === 'browser' && (this.profiles[k] || '').trim()) e.profile = this.profiles[k].trim();
+          tc[k] = e;
+        }
+        return tc;
+      },
+
       // Regenerate the raw doc from the structured fields before showing it.
       syncRaw() {
         const esc = (s) => (s || '').replace(/\n/g, '\n  ');
@@ -192,6 +271,7 @@
           'skills: ' + list(this.skills) + '\n' +
           'tools: ' + list(this.tools) + '\n' +
           'secrets: ' + list(secrets) + '\n' +
+          'tool_config: ' + JSON.stringify(this.buildToolConfig()) + '\n' +
           'personalia: |\n  ' + esc(this.personalia) + '\n' +
           'character: |\n  ' + esc(this.character) + '\n' +
           '---\n';
@@ -206,7 +286,7 @@
 
       _upsert(name) {
         const body = this.mode === 'raw'
-          ? { name: name, raw: this.raw }
+          ? { name: name, raw: this.raw, gh_token: this.ghToken }
           : {
               name: name, agent_name: this.agent_name, role: this.role,
               emoji: this.emoji, voice: this.voice,
@@ -214,12 +294,16 @@
               skills: this.skills, tools: this.tools,
               secrets: this.secretsText.split('\n').map(s => s.trim()).filter(Boolean),
               bot_token: this.bot_token, allowed_user_ids: this.allowedUserIds,
+              tool_config: this.buildToolConfig(), gh_token: this.ghToken,
             };
         fetch('/personae', { method: 'POST', headers: this._headers(), body: JSON.stringify(body) })
           .then(r => { this.ok = r.ok; return r.text().then(t => ({ ok: r.ok, t })); })
           .then(({ ok, t }) => {
             this.result = ok ? 'Saved.' : ('Error: ' + t.slice(0, 200));
-            if (ok && window.showToast) window.showToast('Persona saved');
+            if (ok) {
+              if (this.ghToken.trim()) { this.ghTokenSet = true; this.ghToken = ''; }
+              if (window.showToast) window.showToast('Persona saved');
+            }
           })
           .catch(e => { this.ok = false; this.result = e.message; });
       },

--- a/api/templates/persona_editor.html
+++ b/api/templates/persona_editor.html
@@ -3,17 +3,15 @@
 
 {% block body %}
 <div x-data="personaEditor()">
+  <a class="text-xs text-muted hover:text-accent inline-flex items-center gap-1 mb-2" href="/admin?tab=personae">← Back to Personae</a>
   <div class="flex items-center justify-between gap-2 mb-4 flex-wrap">
     <div>
       <h1 class="text-xl text-accent">{% if is_new %}New Persona{% else %}Edit Persona{% endif %}</h1>
       <p class="text-muted text-xs mt-1">A persona is a swappable identity: its own character, the skills and tools it may use, and its voice.</p>
     </div>
-    <div class="flex items-center gap-2">
-      <div class="flex items-center gap-1 text-xs">
-        <button class="btn btn-sm" :class="mode === 'guided' && 'btn-primary'" @click="mode = 'guided'">Guided</button>
-        <button class="btn btn-sm" :class="mode === 'raw' && 'btn-primary'" @click="syncRaw(); mode = 'raw'">Raw markdown</button>
-      </div>
-      <a class="btn btn-sm" href="/admin?tab=personae">Back to Personae</a>
+    <div class="flex items-center gap-1 text-xs">
+      <button class="btn btn-sm" :class="mode === 'guided' && 'btn-primary'" @click="mode = 'guided'">Guided</button>
+      <button class="btn btn-sm" :class="mode === 'raw' && 'btn-primary'" @click="syncRaw(); mode = 'raw'">Raw markdown</button>
     </div>
   </div>
 
@@ -157,17 +155,34 @@
             </select>
           </div>
           {% if spec.key == "gh" %}
-          <div x-show="modes['gh'] === 'on'" class="mt-2">
+          <div x-show="modes['gh'] === 'on'" class="mt-2 space-y-2">
             <template x-if="!infraAvailable">
-              <p class="text-xs text-warn">Set a master key in the <strong>Secrets</strong> tab to store a per-persona token.</p>
+              <p class="text-xs text-warn">Set a master key in the <strong>Secrets</strong> tab to give this persona its own token.</p>
             </template>
             <template x-if="infraAvailable">
-              <div>
-                <input type="password" class="input-sm" autocomplete="new-password"
-                       x-model="ghToken" placeholder="ghp_… (leave blank to keep current)">
-                <p class="text-xs text-muted mt-1">
-                  <span x-show="ghTokenSet">🔒 A token is stored for this persona — type a new one to replace it.</span>
-                  <span x-show="!ghTokenSet">Stored encrypted in the infra vault; injected as this persona's <code>GH_TOKEN</code>.</span>
+              <div class="space-y-2">
+                <div>
+                  <label class="label">Token source</label>
+                  <select class="select input-sm" x-model="ghTokenSecret">
+                    <option value="">Type a new token…</option>
+                    <template x-for="n in infraNames" :key="n">
+                      <option :value="n" x-text="'Vault secret: ' + n"></option>
+                    </template>
+                  </select>
+                </div>
+                {# Type a new PAT (stored as this persona's own vault token). #}
+                <div x-show="!ghTokenSecret">
+                  <input type="password" class="input-sm" autocomplete="new-password"
+                         x-model="ghToken" placeholder="ghp_… (leave blank to keep current)">
+                  <p class="text-xs text-muted mt-1">
+                    <span x-show="ghTokenSet">🔒 A token is stored for this persona — type a new one to replace it.</span>
+                    <span x-show="!ghTokenSet">Stored encrypted in the infra vault; injected as this persona's <code>GH_TOKEN</code>.</span>
+                  </p>
+                </div>
+                {# Reuse an existing vault secret — no second copy stored. #}
+                <p class="text-xs text-muted" x-show="ghTokenSecret">
+                  Reuses the vault secret <code x-text="ghTokenSecret"></code> as this persona's
+                  <code>GH_TOKEN</code> — no separate copy is stored.
                 </p>
               </div>
             </template>
@@ -229,7 +244,9 @@
       toolKeys: {{ tool_specs|map(attribute='key')|list|tojson }},
       ghToken: '',
       ghTokenSet: {{ gh_token_set|tojson }},
+      ghTokenSecret: '',
       infraAvailable: {{ infra_available|tojson }},
+      infraNames: {{ infra_names|tojson }},
       modes: {},
       profiles: {},
 
@@ -239,6 +256,7 @@
           this.modes[k] = !e ? 'inherit' : (e.enabled ? 'on' : 'off');
           this.profiles[k] = (e && e.profile) || '';
         }
+        this.ghTokenSecret = (this.toolConfig.gh && this.toolConfig.gh.token_secret) || '';
       },
 
       // Only configured tools get an entry; 'inherit' leaves them out so the
@@ -250,6 +268,8 @@
           if (m === 'inherit') continue;
           const e = { enabled: m === 'on' };
           if (k === 'browser' && (this.profiles[k] || '').trim()) e.profile = this.profiles[k].trim();
+          // gh: a chosen vault secret is referenced instead of storing a copy.
+          if (k === 'gh' && this.ghTokenSecret) e.token_secret = this.ghTokenSecret;
           tc[k] = e;
         }
         return tc;
@@ -286,8 +306,10 @@
       },
 
       _upsert(name) {
+        // A referenced vault secret means no inline PAT to store.
+        const ghToken = this.ghTokenSecret ? '' : this.ghToken;
         const body = this.mode === 'raw'
-          ? { name: name, raw: this.raw, gh_token: this.ghToken }
+          ? { name: name, raw: this.raw, gh_token: ghToken }
           : {
               name: name, agent_name: this.agent_name, role: this.role,
               emoji: this.emoji, voice: this.voice,
@@ -295,7 +317,7 @@
               skills: this.skills, tools: this.tools,
               secrets: this.secretsText.split('\n').map(s => s.trim()).filter(Boolean),
               bot_token: this.bot_token, allowed_user_ids: this.allowedUserIds,
-              tool_config: this.buildToolConfig(), gh_token: this.ghToken,
+              tool_config: this.buildToolConfig(), gh_token: ghToken,
             };
         fetch('/personae', { method: 'POST', headers: this._headers(), body: JSON.stringify(body) })
           .then(r => { this.ok = r.ok; return r.text().then(t => ({ ok: r.ok, t })); })

--- a/core/agent.py
+++ b/core/agent.py
@@ -2895,6 +2895,11 @@ class AgentCore:
             skills=narrow_scope(p_skills, requested.skills),
             tools=narrow_scope(p_tools, requested.tools),
             secrets=narrow_scope(p_secrets, requested.secrets),
+            # Tool identity travels verbatim with the persona (#93) — it is who the
+            # child IS (its own gh token / browser profile), not a caller-subset
+            # scope. Dropping it would silently fall back to the owner's token and
+            # re-open the very identity bleed this feature prevents.
+            tool_config=requested.tool_config,
         )
 
     async def _run_subagent_loop(

--- a/core/agent.py
+++ b/core/agent.py
@@ -51,7 +51,7 @@ from core.subagents import (
     summarize_batch,
 )
 from core.task_reflection import ReflectionStore
-from core.tools import tool_env
+from core.tools import effective_tool_env, tool_env
 from voice.pipeline import VoicePipeline
 
 log = logging.getLogger(__name__)
@@ -2063,7 +2063,16 @@ class AgentCore:
                 command, serr = await self.secret_store.resolve_command_secrets(command, allowed)
                 if serr:
                     return {"error": serr}
-            return await self.executor.run_command(command)
+            # Per-persona tool identity (#93): a persona runs `gh`/`browser` with its
+            # own credentials/profile, never the owner's. No persona → the shared
+            # default env (unchanged path).
+            persona = request_state.get("persona_obj")
+            persona_env = None
+            if persona is not None:
+                store = self.secret_store
+                resolve = store.infra_resolve if store else (lambda _n: None)
+                persona_env = effective_tool_env(self.config, persona, resolve)
+            return await self.executor.run_command(command, tool_env=persona_env)
 
         if name == "send_email":
             result = await self._tool_send_email(params)

--- a/core/executor.py
+++ b/core/executor.py
@@ -77,8 +77,15 @@ class ToolExecutor:
             return command
         return command.replace("/app/tools/", f"{local_tools_dir}/")
 
-    async def run_command(self, command: str, timeout: int = 30) -> dict:
-        """Execute a shell command and return its output."""
+    async def run_command(
+        self, command: str, timeout: int = 30, tool_env: dict[str, str] | None = None
+    ) -> dict:
+        """Execute a shell command and return its output.
+
+        ``tool_env`` overrides the default :attr:`tool_env` for this one call —
+        used to inject the active persona's own tool identity (own GH_TOKEN,
+        browser profile) so each agent authenticates as itself (#93).
+        """
         # Security: validate against whitelist
         if not any(command.startswith(p) for p in self.ALLOWED_PREFIXES):
             return {
@@ -88,7 +95,7 @@ class ToolExecutor:
         # minutes, not the 30s default — otherwise it's always killed mid-booking.
         if "browser.py explore" in command:
             timeout = max(timeout, 480)
-        return await self._exec(self._resolve_command(command), timeout)
+        return await self._exec(self._resolve_command(command), timeout, tool_env=tool_env)
 
     async def run_command_trusted(self, command: str, timeout: int = 30) -> dict:
         """Execute a shell command without prefix validation.
@@ -106,19 +113,36 @@ class ToolExecutor:
         timeout than the 30s interactive default."""
         return await self._exec(command, timeout, cwd=cwd)
 
-    async def _exec(self, command: str, timeout: int, cwd: str | None = None) -> dict:
+    async def _exec(
+        self,
+        command: str,
+        timeout: int,
+        cwd: str | None = None,
+        tool_env: dict[str, str] | None = None,
+    ) -> dict:
         """Run a shell command and capture output."""
+        # Per-call override (active persona's identity) wins over the shared default.
+        persona_scoped = tool_env is not None
+        effective_tool_env = self.tool_env if tool_env is None else tool_env
         env = None
         wants_wacli_label = "wacli" in command and "WACLI_DEVICE_LABEL" not in os.environ
-        if "himalaya" in command or self.tool_env or wants_wacli_label:
+        if "himalaya" in command or effective_tool_env or wants_wacli_label or persona_scoped:
             env = os.environ.copy()
             if "himalaya" in command:
                 env.update(himalaya_env())
             # wacli: identify the linked device as MPA (matches the Docker ENV).
             if wants_wacli_label:
                 env.setdefault("WACLI_DEVICE_LABEL", "MPA")
+            # A persona-scoped override is authoritative over the registry's managed
+            # keys: strip any it didn't set so a persona can't inherit a tool
+            # credential (e.g. GH_TOKEN from .env) its policy dropped (#93).
+            if persona_scoped:
+                from core.tools import MANAGED_TOOL_ENV_KEYS
+
+                for key in MANAGED_TOOL_ENV_KEYS - effective_tool_env.keys():
+                    env.pop(key, None)
             # Tool auth (e.g. GH_TOKEN) — only set when a tool is enabled.
-            env.update(self.tool_env)
+            env.update(effective_tool_env)
         proc = await asyncio.create_subprocess_shell(
             command,
             stdout=asyncio.subprocess.PIPE,

--- a/core/personae.py
+++ b/core/personae.py
@@ -6,7 +6,9 @@ finance assistant, …). It is exactly four things (issue #13):
 - its own system-prompt identity (``personalia`` + ``character``),
 - a **skill allowlist** (which skills it may load — empty means *all*),
 - a **tool scope** (which function-tools are advertised — empty means *all*),
-- a **secret scope** (vault namespaces it may use — stored now, enforced by #19).
+- a **secret scope** (vault namespaces it may use — stored now, enforced by #19),
+- **tool identities** (``tool_config``: own ``gh`` token / browser profile per
+  external CLI tool — #93; empty means *inherit the system-wide config*).
 
 The store mirrors :mod:`core.skills`: markdown files with YAML frontmatter,
 seeded into SQLite at startup, editable in the admin UI. When no persona is

--- a/core/personae.py
+++ b/core/personae.py
@@ -16,6 +16,7 @@ first-run behaviour is unchanged.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -36,6 +37,7 @@ CREATE TABLE IF NOT EXISTS personae (
     secrets TEXT DEFAULT '',
     bot_token TEXT DEFAULT '',
     allowed_user_ids TEXT DEFAULT '',
+    tool_config TEXT DEFAULT '',
     created_at DATETIME DEFAULT (datetime('now')),
     updated_at DATETIME DEFAULT (datetime('now'))
 );
@@ -45,6 +47,7 @@ CREATE TABLE IF NOT EXISTS personae (
 _MIGRATIONS = (
     "ALTER TABLE personae ADD COLUMN bot_token TEXT DEFAULT ''",  # #29
     "ALTER TABLE personae ADD COLUMN allowed_user_ids TEXT DEFAULT ''",  # #29
+    "ALTER TABLE personae ADD COLUMN tool_config TEXT DEFAULT ''",  # #93
 )
 
 
@@ -64,12 +67,22 @@ class Persona:
     secrets: list[str] = field(default_factory=list)  # vault scope; stored only (#19)
     bot_token: str = ""  # own Telegram bot; empty = reachable only via the default bot (#29)
     allowed_user_ids: list[int] = field(default_factory=list)  # bot ACL; [] = inherit global
+    # Per-persona config for the optional external CLI tools (gh, browser) — #93.
+    # Shape: {tool_key: {"enabled": bool, **tool-specific cfg}}. Empty = inherit
+    # the system-wide tool config (own credentials/profile fall back to shared).
+    tool_config: dict = field(default_factory=dict)
 
     def allows_skill(self, name: str) -> bool:
         return not self.skills or name in self.skills
 
     def allows_tool(self, name: str) -> bool:
         return not self.tools or name in self.tools
+
+    def tool_setting(self, key: str) -> dict | None:
+        """This persona's config for external tool ``key`` (gh/browser), or None
+        if it has none — in which case the system-wide config applies (#93)."""
+        cfg = self.tool_config.get(key) if isinstance(self.tool_config, dict) else None
+        return cfg if isinstance(cfg, dict) else None
 
 
 def _as_list(value: object) -> list[str]:
@@ -82,6 +95,23 @@ def _as_list(value: object) -> list[str]:
     if isinstance(value, (list, tuple)):
         return [str(p).strip() for p in value if str(p).strip()]
     return []
+
+
+def _as_tool_config(value: object) -> dict:
+    """Coerce a frontmatter / DB-column value into a per-tool config dict (#93).
+
+    Accepts an already-parsed dict (frontmatter) or a JSON string (DB column).
+    Anything malformed degrades to ``{}`` so a broken value never breaks load.
+    """
+    if isinstance(value, dict):
+        return {k: v for k, v in value.items() if isinstance(v, dict)}
+    if isinstance(value, str) and value.strip():
+        try:
+            loaded = json.loads(value)
+        except json.JSONDecodeError, ValueError:
+            return {}
+        return _as_tool_config(loaded)
+    return {}
 
 
 def _as_int_list(value: object) -> list[int]:
@@ -140,6 +170,7 @@ def parse_markdown(text: str, *, name: str) -> Persona:
         secrets=_as_list(fm.get("secrets")),
         bot_token=str(fm.get("bot_token", "") or ""),
         allowed_user_ids=_as_int_list(fm.get("allowed_user_ids")),
+        tool_config=_as_tool_config(fm.get("tool_config")),
     )
 
 
@@ -155,6 +186,7 @@ def to_markdown(p: Persona) -> str:
         "skills": p.skills,
         "tools": p.tools,
         "secrets": p.secrets,
+        "tool_config": p.tool_config,
         "personalia": p.personalia,
         "character": p.character,
     }
@@ -207,14 +239,14 @@ class PersonaStore:
         await db.execute(
             "INSERT INTO personae "
             "(name, agent_name, role, emoji, voice, personalia, character, skills, tools, "
-            "secrets, bot_token, allowed_user_ids) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "secrets, bot_token, allowed_user_ids, tool_config) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(name) DO UPDATE SET "
             "agent_name=excluded.agent_name, role=excluded.role, emoji=excluded.emoji, "
             "voice=excluded.voice, personalia=excluded.personalia, character=excluded.character, "
             "skills=excluded.skills, tools=excluded.tools, secrets=excluded.secrets, "
             "bot_token=excluded.bot_token, allowed_user_ids=excluded.allowed_user_ids, "
-            "updated_at=datetime('now')",
+            "tool_config=excluded.tool_config, updated_at=datetime('now')",
             (
                 p.name,
                 p.agent_name,
@@ -228,6 +260,7 @@ class PersonaStore:
                 "\n".join(p.secrets),
                 p.bot_token,
                 "\n".join(str(i) for i in p.allowed_user_ids),
+                json.dumps(p.tool_config) if p.tool_config else "",
             ),
         )
 
@@ -248,6 +281,7 @@ class PersonaStore:
             allowed_user_ids=_as_int_list(
                 row["allowed_user_ids"] if "allowed_user_ids" in row.keys() else ""
             ),
+            tool_config=_as_tool_config(row["tool_config"] if "tool_config" in row.keys() else ""),
         )
 
     async def list_personae(self) -> list[Persona]:
@@ -313,6 +347,12 @@ tools:
 secrets: []
 bot_token: "123:ABC"
 allowed_user_ids: [111, 222]
+tool_config:
+  gh:
+    enabled: true
+  browser:
+    enabled: true
+    profile: forge
 personalia: |
   You are Forge, a strength coach.
 character: |
@@ -332,14 +372,19 @@ Extra prose in the body.
     assert "motivating" in p.character and "Extra prose" in p.character  # body appended
     assert p.allows_skill("scheduling") and not p.allows_skill("email")
     assert p.allows_tool("run_command") and not p.allows_tool("send_email")
+    assert p.tool_setting("gh") == {"enabled": True}, p.tool_setting("gh")
+    assert p.tool_setting("browser") == {"enabled": True, "profile": "forge"}
+    assert p.tool_setting("weather") is None  # no entry = inherit system config
 
     # Empty allowlists = allow everything (default persona semantics).
     blank = Persona(name="default")
     assert blank.allows_skill("anything") and blank.allows_tool("anything")
+    assert blank.tool_setting("gh") is None  # no per-tool config by default
 
     # Round-trip through markdown preserves the structured fields.
     p2 = parse_markdown(to_markdown(p), name="fitness-coach")
     assert p2.agent_name == p.agent_name and p2.skills == p.skills and p2.tools == p.tools
     assert p2.personalia.strip() == p.personalia.strip()
     assert p2.bot_token == p.bot_token and p2.allowed_user_ids == p.allowed_user_ids
+    assert p2.tool_config == p.tool_config, p2.tool_config
     print("personae.py self-check OK")

--- a/core/prompt_builder.py
+++ b/core/prompt_builder.py
@@ -173,7 +173,7 @@ def build_prompt_sections(
     about_user = f"<about_user>\n{about_user_block}\n</about_user>" if about_user_block else ""
     tool_usage = f"<tool_usage>\n{tool_usage_text}\n</tool_usage>"
 
-    tool_blocks = active_tool_prompts(config)
+    tool_blocks = active_tool_prompts(config, persona)
     tools_section = ""
     if tool_blocks:
         tools_section = "<tools>\n" + "\n\n".join(tool_blocks) + "\n</tools>"

--- a/core/tools.py
+++ b/core/tools.py
@@ -17,10 +17,15 @@ entry to ``_REGISTRY`` below describing its env + prompt advertisement.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from core.config import Config
+
+if TYPE_CHECKING:
+    from core.personae import Persona
 
 # Advertisement injected into the system prompt when `gh` is active.
 _GH_PROMPT = """<tool name="gh">
@@ -146,6 +151,15 @@ _REGISTRY: tuple[ToolSpec, ...] = (
 )
 
 
+# Env vars the tool registry manages. When a per-persona env override is applied
+# (#93), any managed key absent from the override is stripped from the inherited
+# process environment too — so a persona that switched `gh` off can never inherit
+# a GH_TOKEN that leaked in via `.env`/Docker ENV and act as the owner.
+MANAGED_TOOL_ENV_KEYS: frozenset[str] = frozenset(
+    {"GH_TOKEN", "BROWSER_HEADLESS", "BROWSER_CDP_URL", "BROWSER_USER_AGENT", "BROWSER_PROFILE"}
+)
+
+
 def registry() -> tuple[ToolSpec, ...]:
     """Return all known optional tools."""
     return _REGISTRY
@@ -156,14 +170,27 @@ def _is_enabled(config: Config, key: str) -> bool:
     return bool(getattr(sub, "enabled", False))
 
 
-def active_tool_prompts(config: Config) -> list[str]:
-    """Return system-prompt advertisement blocks for every *enabled* tool."""
+def active_tool_prompts(config: Config, persona: Persona | None = None) -> list[str]:
+    """Return system-prompt advertisement blocks for every *enabled* tool.
+
+    When ``persona`` is active and has per-tool config (#93), a tool it opted out
+    of is dropped, and a note about its own identity (own ``gh`` token, own browser
+    profile) is injected into the tool block so the model authenticates as itself.
+    """
     blocks: list[str] = []
     for spec in _REGISTRY:
-        if _is_enabled(config, spec.key):
-            block = spec.prompt(config).strip()
-            if block:
-                blocks.append(block)
+        if not _is_enabled(config, spec.key):
+            continue
+        setting = persona.tool_setting(spec.key) if persona else None
+        if setting is not None and not setting.get("enabled"):
+            continue  # this persona has the tool switched off
+        block = spec.prompt(config).strip()
+        if not block:
+            continue
+        note = _persona_tool_note(spec.key, setting, persona)
+        if note:
+            block = block.replace("</tool>", f"{note}\n</tool>", 1)
+        blocks.append(block)
     return blocks
 
 
@@ -174,3 +201,131 @@ def tool_env(config: Config) -> dict[str, str]:
         if _is_enabled(config, spec.key):
             env.update(spec.env(config))
     return env
+
+
+# -- Per-persona tool identity (#93) ----------------------------------------
+
+
+def gh_token_secret_name(persona_name: str) -> str:
+    """Infra-vault name holding a persona's own GitHub token.
+
+    Namespaced per persona so each agent authenticates as a distinct GitHub user.
+    Stored in the *infra* vault (machine-key, boot-unsealed) so it works headless
+    and in scheduled jobs — same on-disk posture as the system-wide ``GH_TOKEN``.
+    """
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "_", (persona_name or "").strip()).upper()
+    return f"GH_TOKEN_{slug}"
+
+
+def _persona_tool_note(key: str, setting: dict | None, persona: Persona | None) -> str:
+    """A one-line identity note injected into a tool's prompt block for a persona."""
+    if persona is None or setting is None:
+        return ""
+    if key == "gh":
+        return (
+            f'Running as persona "{persona.name}": `gh` is authenticated with this '
+            "persona's OWN GitHub token (a distinct identity from the owner). Every "
+            "gh/git action appears as this persona's GitHub user."
+        )
+    if key == "browser":
+        profile = (setting.get("profile") or persona.name).strip()
+        if profile:
+            return (
+                f'Running as persona "{persona.name}": your browser profile is '
+                f'"{profile}" — it is used by default, so your logged-in sessions are '
+                "isolated from other personae. Pass `--profile " + profile + "` "
+                "explicitly when a command needs it."
+            )
+    return ""
+
+
+def effective_tool_env(
+    config: Config,
+    persona: Persona | None,
+    resolve_secret: Callable[[str], str | None],
+) -> dict[str, str]:
+    """The tool environment for a turn, adjusted for the active persona (#93).
+
+    Starts from the system-wide :func:`tool_env` and, for a persona that has its
+    own tool config, swaps in its own identity:
+
+    * ``gh`` — replace ``GH_TOKEN`` with the persona's own token (resolved from the
+      infra vault). If the persona switched ``gh`` off, ``GH_TOKEN`` is *removed*
+      so it can never act as the owner; if it has no own token, it also falls back
+      to no token rather than silently borrowing the owner's.
+    * ``browser`` — set ``BROWSER_PROFILE`` to the persona's isolated profile.
+
+    A persona with no entry for a tool inherits the system config unchanged, so
+    existing setups keep working (migration §6).
+    """
+    env = tool_env(config)
+    if persona is None:
+        return env
+
+    gh = persona.tool_setting("gh")
+    if gh is not None:
+        # Persona has an explicit gh policy → never inherit the owner's token.
+        env.pop("GH_TOKEN", None)
+        if gh.get("enabled") and config.tools.gh.enabled:
+            token = resolve_secret(gh_token_secret_name(persona.name))
+            if token:
+                env["GH_TOKEN"] = token
+
+    browser = persona.tool_setting("browser")
+    if browser is not None and browser.get("enabled") and config.tools.browser.enabled:
+        profile = (browser.get("profile") or persona.name).strip()
+        if profile:
+            env["BROWSER_PROFILE"] = profile
+
+    return env
+
+
+if __name__ == "__main__":
+    # ponytail: one runnable check covering per-persona env swap + prompt notes.
+    from core.personae import Persona
+
+    cfg = Config()
+    cfg.tools.gh.enabled = True
+    cfg.tools.gh.token = "owner-token"
+    cfg.tools.browser.enabled = True
+
+    assert gh_token_secret_name("coding-helper") == "GH_TOKEN_CODING-HELPER"
+
+    vault = {"GH_TOKEN_HOPPER": "hopper-token"}
+    resolve = vault.get  # Callable[[str], str | None]
+
+    # No persona → system token, no profile.
+    base = effective_tool_env(cfg, None, resolve)
+    assert base["GH_TOKEN"] == "owner-token" and "BROWSER_PROFILE" not in base
+
+    # Persona with no tool_config → inherits system config unchanged (migration).
+    plain = Persona(name="plain")
+    assert effective_tool_env(cfg, plain, resolve)["GH_TOKEN"] == "owner-token"
+
+    # Persona with its own gh token + browser profile → own identity.
+    hopper = Persona(
+        name="hopper",
+        tool_config={"gh": {"enabled": True}, "browser": {"enabled": True, "profile": "hop"}},
+    )
+    env = effective_tool_env(cfg, hopper, resolve)
+    assert env["GH_TOKEN"] == "hopper-token", env.get("GH_TOKEN")
+    assert env["BROWSER_PROFILE"] == "hop"
+
+    # gh enabled but no own token stored → no token (never borrows the owner's).
+    atlas = Persona(name="atlas", tool_config={"gh": {"enabled": True}})
+    assert "GH_TOKEN" not in effective_tool_env(cfg, atlas, resolve)
+
+    # gh explicitly disabled → GH_TOKEN removed.
+    lingua = Persona(name="lingua", tool_config={"gh": {"enabled": False}})
+    assert "GH_TOKEN" not in effective_tool_env(cfg, lingua, resolve)
+
+    # Prompts: hopper sees gh + browser, with identity notes; lingua's gh is hidden.
+    hp = "\n".join(active_tool_prompts(cfg, hopper))
+    assert 'persona "hopper"' in hp and "OWN GitHub token" in hp and "hop" in hp
+    lp = "\n".join(active_tool_prompts(cfg, lingua))
+    assert 'name="gh"' not in lp and 'name="browser"' in lp
+    # No persona → plain blocks, no identity notes.
+    nop = "\n".join(active_tool_prompts(cfg))
+    assert 'name="gh"' in nop and "Running as persona" not in nop
+
+    print("tools.py self-check OK")

--- a/core/tools.py
+++ b/core/tools.py
@@ -154,9 +154,20 @@ _REGISTRY: tuple[ToolSpec, ...] = (
 # Env vars the tool registry manages. When a per-persona env override is applied
 # (#93), any managed key absent from the override is stripped from the inherited
 # process environment too — so a persona that switched `gh` off can never inherit
-# a GH_TOKEN that leaked in via `.env`/Docker ENV and act as the owner.
+# a token that leaked in via `.env`/Docker ENV and act as the owner. `gh` reads
+# GH_TOKEN, then GITHUB_TOKEN, then the enterprise variants (in that precedence),
+# so ALL of them must be stripped, not just GH_TOKEN.
 MANAGED_TOOL_ENV_KEYS: frozenset[str] = frozenset(
-    {"GH_TOKEN", "BROWSER_HEADLESS", "BROWSER_CDP_URL", "BROWSER_USER_AGENT", "BROWSER_PROFILE"}
+    {
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_ENTERPRISE_TOKEN",
+        "GITHUB_ENTERPRISE_TOKEN",
+        "BROWSER_HEADLESS",
+        "BROWSER_CDP_URL",
+        "BROWSER_USER_AGENT",
+        "BROWSER_PROFILE",
+    }
 )
 
 
@@ -212,8 +223,11 @@ def gh_token_secret_name(persona_name: str) -> str:
     Namespaced per persona so each agent authenticates as a distinct GitHub user.
     Stored in the *infra* vault (machine-key, boot-unsealed) so it works headless
     and in scheduled jobs — same on-disk posture as the system-wide ``GH_TOKEN``.
+
+    The slug is kept verbatim (case preserved; infra names are case-sensitive) so
+    two personae whose slugs differ only by case don't collide on one token.
     """
-    slug = re.sub(r"[^A-Za-z0-9_-]+", "_", (persona_name or "").strip()).upper()
+    slug = re.sub(r"[^A-Za-z0-9_-]+", "_", (persona_name or "").strip())
     return f"GH_TOKEN_{slug}"
 
 
@@ -289,9 +303,10 @@ if __name__ == "__main__":
     cfg.tools.gh.token = "owner-token"
     cfg.tools.browser.enabled = True
 
-    assert gh_token_secret_name("coding-helper") == "GH_TOKEN_CODING-HELPER"
+    assert gh_token_secret_name("coding-helper") == "GH_TOKEN_coding-helper"
+    assert gh_token_secret_name("Hopper") != gh_token_secret_name("hopper")  # case-distinct
 
-    vault = {"GH_TOKEN_HOPPER": "hopper-token"}
+    vault = {"GH_TOKEN_hopper": "hopper-token"}
     resolve = vault.get  # Callable[[str], str | None]
 
     # No persona → system token, no profile.

--- a/core/tools.py
+++ b/core/tools.py
@@ -236,6 +236,12 @@ def _persona_tool_note(key: str, setting: dict | None, persona: Persona | None) 
     if persona is None or setting is None:
         return ""
     if key == "gh":
+        if (setting.get("token_secret") or "").strip():
+            return (
+                f'Running as persona "{persona.name}": `gh` is authenticated with the '
+                "GitHub token configured for this persona. Every gh/git action appears "
+                "as that token's GitHub user."
+            )
         return (
             f'Running as persona "{persona.name}": `gh` is authenticated with this '
             "persona's OWN GitHub token (a distinct identity from the owner). Every "
@@ -281,7 +287,11 @@ def effective_tool_env(
         # Persona has an explicit gh policy → never inherit the owner's token.
         env.pop("GH_TOKEN", None)
         if gh.get("enabled") and config.tools.gh.enabled:
-            token = resolve_secret(gh_token_secret_name(persona.name))
+            # ``token_secret`` lets a persona reuse an existing infra-vault secret
+            # (e.g. the system GH_TOKEN, or a shared PAT) instead of storing its own
+            # copy; otherwise its own namespaced token is used (#93).
+            name = (gh.get("token_secret") or "").strip() or gh_token_secret_name(persona.name)
+            token = resolve_secret(name)
             if token:
                 env["GH_TOKEN"] = token
 
@@ -306,7 +316,7 @@ if __name__ == "__main__":
     assert gh_token_secret_name("coding-helper") == "GH_TOKEN_coding-helper"
     assert gh_token_secret_name("Hopper") != gh_token_secret_name("hopper")  # case-distinct
 
-    vault = {"GH_TOKEN_hopper": "hopper-token"}
+    vault = {"GH_TOKEN_hopper": "hopper-token", "SHARED_PAT": "shared-token"}
     resolve = vault.get  # Callable[[str], str | None]
 
     # No persona → system token, no profile.
@@ -329,6 +339,10 @@ if __name__ == "__main__":
     # gh enabled but no own token stored → no token (never borrows the owner's).
     atlas = Persona(name="atlas", tool_config={"gh": {"enabled": True}})
     assert "GH_TOKEN" not in effective_tool_env(cfg, atlas, resolve)
+
+    # token_secret reuses an existing vault secret instead of the namespaced one.
+    ref = Persona(name="atlas", tool_config={"gh": {"enabled": True, "token_secret": "SHARED_PAT"}})
+    assert effective_tool_env(cfg, ref, resolve)["GH_TOKEN"] == "shared-token"
 
     # gh explicitly disabled → GH_TOKEN removed.
     lingua = Persona(name="lingua", tool_config={"gh": {"enabled": False}})

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -16,7 +16,8 @@ A persona is exactly these things:
 - a **skill allowlist** — which skills it may load (empty = all);
 - a **tool scope** — which function-tools are advertised (empty = all; `load_skill` is always available);
 - a **voice** — a TTS voice override (empty = the configured default);
-- a **secret scope** — which [vault](/docs/secrets) secrets it may use, enforced as a reference-only ACL (a persona may use a secret only if it is shared or named in this scope).
+- a **secret scope** — which [vault](/docs/secrets) secrets it may use, enforced as a reference-only ACL (a persona may use a secret only if it is shared or named in this scope);
+- **tool identities** — its own credentials and sessions for the external CLI tools (its own GitHub token, its own browser profile), so each persona acts as a distinct identity (see [Tool identities](#tool-identities)).
 
 When **no** persona is active, the agent uses the configured `character` / `personalia` from
 the **Assistant** tab — so first-run behaviour is unchanged. The default identity *is* the
@@ -47,6 +48,9 @@ voice: en-US-GuyNeural
 skills: [scheduling, memory, weather]
 tools: [send_message, create_calendar_event, manage_jobs, web_search]
 secrets: []
+tool_config:
+  gh: {enabled: true}            # uses this persona's own GitHub token
+  browser: {enabled: true, profile: forge}
 personalia: |
   You are a strength & conditioning coach…
 character: |
@@ -138,6 +142,45 @@ topic's `message_thread_id` is folded into the `chat_id`, so every topic gets is
 history and its own persona binding; the group's General topic maps to the default context.
 Name a topic after a persona (its name, agent name, or role) and it auto-binds when the topic
 is created or renamed; rebind any topic from the Chats tab.
+
+## Tool identities
+
+By default every persona shares the system-wide tool configuration set in the **Tools**
+tab — the same `GH_TOKEN`, the same browser sessions. So actions from *Hopper* (a coding
+helper) and *Atlas* (a travel planner) all appear as the **owner's** GitHub user, and a
+login one persona makes is visible to all of them.
+
+**Tool identities** give each persona its own credentials and sessions for the external
+CLI tools, so it acts as a distinct identity. In the persona editor, the **Tool identities**
+card lists every system-enabled external tool with three states:
+
+- **Inherit** — use the system-wide config (shared with the owner). This is the default and
+  matches pre-existing behaviour, so nothing changes until you opt a persona in.
+- **Enabled** — use *this persona's* own credentials/profile (configured below the toggle).
+- **Disabled** — this tool is off for this persona; its credential is stripped from the
+  command environment, so the persona can never fall back to the owner's.
+
+Supported tools:
+
+| Tool | Per-persona identity |
+|------|----------------------|
+| `gh` (GitHub) | The persona's own **Personal Access Token**, injected as `GH_TOKEN` so every `gh`/`git` action runs as that GitHub user. Stored encrypted in the **infra vault** (machine-key, so it works headless and in [scheduled jobs](/docs/scheduler)), namespaced `GH_TOKEN_<SLUG>`. |
+| `browser` | The persona's own **profile** — an isolated Chromium session dir, so its logged-in sessions don't leak to other personae. Used by default (the agent need not pass `--profile`). Blank = the persona slug. |
+
+How it flows into the agent: when a persona runs `run_command`, its tool environment is
+swapped in for that call, and the `<tools>` section of the system prompt notes which
+identity is active (*"`gh` is authenticated with this persona's own token"*). A persona
+with **no** `tool_config` entry for a tool inherits the system config unchanged, so existing
+setups keep working.
+
+In raw markdown the field is `tool_config` (a map of `{tool: {enabled, …}}`); the GitHub
+token itself is **never** stored in the persona doc — it lives only in the vault. Setting a
+per-persona token requires a master key (configure one in the **Secrets** tab first).
+
+> **Note:** per-persona tokens live in the infra vault, which has the same on-disk posture
+> as the system `GH_TOKEN` (a machine key on the data volume), not the password-gated persona
+> vault. That is a deliberate trade-off so the tokens are available headlessly; treat the
+> data volume accordingly.
 
 ## Bot-per-persona
 

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -157,8 +157,9 @@ card lists every system-enabled external tool with three states:
 - **Inherit** — use the system-wide config (shared with the owner). This is the default and
   matches pre-existing behaviour, so nothing changes until you opt a persona in.
 - **Enabled** — use *this persona's* own credentials/profile (configured below the toggle).
-- **Disabled** — this tool is off for this persona; its credential is stripped from the
-  command environment, so the persona can never fall back to the owner's.
+- **Disabled** — the tool is hidden from this persona's prompt and its credentials are
+  stripped from the command environment (every `GH_TOKEN`/`GITHUB_TOKEN` variant), so the
+  persona can never fall back to the owner's.
 
 Supported tools:
 
@@ -181,6 +182,10 @@ per-persona token requires a master key (configure one in the **Secrets** tab fi
 > as the system `GH_TOKEN` (a machine key on the data volume), not the password-gated persona
 > vault. That is a deliberate trade-off so the tokens are available headlessly; treat the
 > data volume accordingly.
+>
+> Per-persona `gh` isolation assumes **token-based** auth. A shared `gh auth login` writes
+> credentials to `~/.config/gh` (a shared HOME), which token env vars can't override — so
+> authenticate `gh` via per-persona tokens here, not an interactive login.
 
 ## Bot-per-persona
 

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -165,7 +165,7 @@ Supported tools:
 
 | Tool | Per-persona identity |
 |------|----------------------|
-| `gh` (GitHub) | The persona's own **Personal Access Token**, injected as `GH_TOKEN` so every `gh`/`git` action runs as that GitHub user. Stored encrypted in the **infra vault** (machine-key, so it works headless and in [scheduled jobs](/docs/scheduler)), namespaced `GH_TOKEN_<SLUG>`. |
+| `gh` (GitHub) | The persona's own **Personal Access Token**, injected as `GH_TOKEN` so every `gh`/`git` action runs as that GitHub user. Either **type a new token** (stored encrypted in the **infra vault**, machine-key so it works headless and in [scheduled jobs](/docs/scheduler), namespaced `GH_TOKEN_<SLUG>`) **or pick an existing infra-vault secret to reuse** — raw frontmatter `gh: {enabled: true, token_secret: SOME_INFRA_SECRET}` — so no second copy is stored. |
 | `browser` | The persona's own **profile** — an isolated Chromium session dir, so its logged-in sessions don't leak to other personae. Used by default (the agent need not pass `--profile`). Blank = the persona slug. |
 
 How it flows into the agent: when a persona runs `run_command`, its tool environment is

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -33,6 +33,25 @@ async def test_run_command_allows_whitelisted_prefix(monkeypatch) -> None:
     mock_exec.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_persona_override_strips_leaked_managed_env(monkeypatch) -> None:
+    # A GH_TOKEN present in the process env (e.g. loaded from .env) must NOT leak
+    # to a persona-scoped run whose override doesn't set it — otherwise a persona
+    # that switched gh off could still act as the owner (#93 security boundary).
+    monkeypatch.setenv("GH_TOKEN", "owner-leaked")
+    executor = ToolExecutor(tool_env={"GH_TOKEN": "owner-leaked"})
+    cmd = "python3 -c \"import os,sys; sys.stdout.write(os.environ.get('GH_TOKEN','NONE'))\""
+    resolved = executor._resolve_command(cmd)
+
+    # persona-scoped override with no GH_TOKEN → stripped from the subprocess env.
+    res = await executor._exec(resolved, 30, tool_env={})
+    assert res["stdout"].strip() == "NONE", res
+
+    # default path (no override) still sees the configured token.
+    res2 = await executor._exec(resolved, 30)
+    assert res2["stdout"].strip() == "owner-leaked", res2
+
+
 def test_parse_json_output_handles_invalid_json() -> None:
     executor = ToolExecutor()
     output = executor.parse_json_output("not json")

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -38,18 +38,23 @@ async def test_persona_override_strips_leaked_managed_env(monkeypatch) -> None:
     # A GH_TOKEN present in the process env (e.g. loaded from .env) must NOT leak
     # to a persona-scoped run whose override doesn't set it — otherwise a persona
     # that switched gh off could still act as the owner (#93 security boundary).
+    # GITHUB_TOKEN is gh's fallback var — it must be stripped too, not just GH_TOKEN.
     monkeypatch.setenv("GH_TOKEN", "owner-leaked")
+    monkeypatch.setenv("GITHUB_TOKEN", "owner-leaked-2")
     executor = ToolExecutor(tool_env={"GH_TOKEN": "owner-leaked"})
-    cmd = "python3 -c \"import os,sys; sys.stdout.write(os.environ.get('GH_TOKEN','NONE'))\""
+    cmd = (
+        'python3 -c "import os,sys; '
+        "sys.stdout.write(os.environ.get('GH_TOKEN','NONE')+'|'+os.environ.get('GITHUB_TOKEN','NONE'))\""
+    )
     resolved = executor._resolve_command(cmd)
 
-    # persona-scoped override with no GH_TOKEN → stripped from the subprocess env.
+    # persona-scoped override with no token → both gh vars stripped from the env.
     res = await executor._exec(resolved, 30, tool_env={})
-    assert res["stdout"].strip() == "NONE", res
+    assert res["stdout"].strip() == "NONE|NONE", res
 
     # default path (no override) still sees the configured token.
     res2 = await executor._exec(resolved, 30)
-    assert res2["stdout"].strip() == "owner-leaked", res2
+    assert res2["stdout"].strip().startswith("owner-leaked|"), res2
 
 
 def test_parse_json_output_handles_invalid_json() -> None:

--- a/tests/test_persona_tool_identity.py
+++ b/tests/test_persona_tool_identity.py
@@ -1,0 +1,96 @@
+"""Per-persona tool identity (#93): the active persona's own credentials are
+injected into ``run_command``, and never the owner's when it opts out.
+
+These exercise the real dispatch path in ``AgentCore._execute_tool`` with a
+stubbed executor that captures the per-call ``tool_env`` override.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agent import AgentCore
+from core.config import Config
+from core.llm import LLMToolCall
+from core.permissions import PermissionLevel
+from core.personae import Persona
+from core.secret_store import SecretStore
+from core.tools import gh_token_secret_name
+from core.vault import InfraVault
+
+
+@pytest.fixture
+async def agent(tmp_path) -> AgentCore:
+    # Infra vault keyed so per-persona tokens are storable/resolvable headlessly.
+    store = SecretStore(db_path=str(tmp_path / "config.db"), infra_vault=InfraVault("machine-key"))
+    await store.set_infra_secret(gh_token_secret_name("hopper"), "hopper-token")
+    await store.load_infra_cache()
+    config = Config()
+    config.tools.gh.enabled = True
+    config.tools.gh.token = "owner-token"  # the system-wide default
+    config.tools.browser.enabled = True
+    a = AgentCore(config, secret_store=store)
+    # Refresh the executor's shared default to match the config above.
+    from core.tools import tool_env
+
+    a.executor.tool_env = tool_env(config)
+    return a
+
+
+async def _run(agent: AgentCore, persona: Persona | None, monkeypatch) -> dict:
+    captured: dict = {}
+
+    async def fake_exec(command, timeout, cwd=None, tool_env=None):
+        captured["tool_env"] = tool_env
+        return {"stdout": "", "stderr": "", "exit_code": 0}
+
+    monkeypatch.setattr(agent.executor, "_exec", fake_exec)
+    monkeypatch.setattr(agent.permissions, "check", lambda *a, **k: PermissionLevel.ALWAYS)
+    rs = agent._new_request_state(persona)
+    call = LLMToolCall(
+        id="1", name="run_command", arguments={"command": "gh issue list", "purpose": "p"}
+    )
+    await agent._execute_tool(call, "system", "u", rs)
+    return captured
+
+
+async def test_no_persona_uses_shared_default(agent: AgentCore, monkeypatch) -> None:
+    # No persona → no per-call override; the executor's shared default applies.
+    cap = await _run(agent, None, monkeypatch)
+    assert cap["tool_env"] is None
+
+
+async def test_persona_with_own_token(agent: AgentCore, monkeypatch) -> None:
+    hopper = Persona(name="hopper", tool_config={"gh": {"enabled": True}})
+    cap = await _run(agent, hopper, monkeypatch)
+    assert cap["tool_env"]["GH_TOKEN"] == "hopper-token"  # its own, not the owner's
+
+
+async def test_persona_gh_enabled_but_no_token_does_not_borrow_owner(
+    agent: AgentCore, monkeypatch
+) -> None:
+    # gh switched on but no token stored for this persona → no GH_TOKEN at all,
+    # rather than silently inheriting the owner's.
+    atlas = Persona(name="atlas", tool_config={"gh": {"enabled": True}})
+    cap = await _run(agent, atlas, monkeypatch)
+    assert "GH_TOKEN" not in cap["tool_env"]
+
+
+async def test_persona_gh_disabled_strips_owner_token(agent: AgentCore, monkeypatch) -> None:
+    lingua = Persona(name="lingua", tool_config={"gh": {"enabled": False}})
+    cap = await _run(agent, lingua, monkeypatch)
+    assert "GH_TOKEN" not in cap["tool_env"]
+
+
+async def test_persona_browser_profile_injected(agent: AgentCore, monkeypatch) -> None:
+    hopper = Persona(name="hopper", tool_config={"browser": {"enabled": True, "profile": "hop"}})
+    cap = await _run(agent, hopper, monkeypatch)
+    assert cap["tool_env"]["BROWSER_PROFILE"] == "hop"
+
+
+async def test_persona_without_tool_config_inherits(agent: AgentCore, monkeypatch) -> None:
+    # A persona that never configured tools still gets the owner token (migration:
+    # unchanged behaviour until you opt a persona in).
+    plain = Persona(name="plain")
+    cap = await _run(agent, plain, monkeypatch)
+    assert cap["tool_env"]["GH_TOKEN"] == "owner-token"

--- a/tests/test_persona_tool_identity.py
+++ b/tests/test_persona_tool_identity.py
@@ -94,3 +94,15 @@ async def test_persona_without_tool_config_inherits(agent: AgentCore, monkeypatc
     plain = Persona(name="plain")
     cap = await _run(agent, plain, monkeypatch)
     assert cap["tool_env"]["GH_TOKEN"] == "owner-token"
+
+
+async def test_subagent_keeps_persona_tool_identity(agent: AgentCore) -> None:
+    # A subagent spawned AS a persona must keep that persona's tool identity — else
+    # it falls back to the owner's token (the bleed #93 prevents). _narrow_persona
+    # narrows skills/tools/secrets but tool_config is identity, copied verbatim.
+    parent_state = agent._new_request_state(None)
+    enabled = Persona(name="hopper", tool_config={"gh": {"enabled": True}})
+    assert agent._narrow_persona(enabled, parent_state).tool_setting("gh") == {"enabled": True}
+    # A persona explicitly DENIED gh stays denied as a subagent.
+    denied = Persona(name="lingua", tool_config={"gh": {"enabled": False}})
+    assert agent._narrow_persona(denied, parent_state).tool_setting("gh") == {"enabled": False}

--- a/tests/test_persona_tool_identity.py
+++ b/tests/test_persona_tool_identity.py
@@ -96,6 +96,18 @@ async def test_persona_without_tool_config_inherits(agent: AgentCore, monkeypatc
     assert cap["tool_env"]["GH_TOKEN"] == "owner-token"
 
 
+async def test_persona_gh_token_secret_reference(agent: AgentCore, monkeypatch) -> None:
+    # token_secret reuses an existing infra-vault secret instead of a per-persona
+    # copy — e.g. a shared PAT the owner already stored.
+    await agent.secret_store.set_infra_secret("SHARED_PAT", "shared-token")
+    await agent.secret_store.load_infra_cache()
+    atlas = Persona(
+        name="atlas", tool_config={"gh": {"enabled": True, "token_secret": "SHARED_PAT"}}
+    )
+    cap = await _run(agent, atlas, monkeypatch)
+    assert cap["tool_env"]["GH_TOKEN"] == "shared-token"
+
+
 async def test_subagent_keeps_persona_tool_identity(agent: AgentCore) -> None:
     # A subagent spawned AS a persona must keep that persona's tool identity — else
     # it falls back to the owner's token (the bleed #93 prevents). _narrow_persona

--- a/tests/test_personae_admin.py
+++ b/tests/test_personae_admin.py
@@ -143,6 +143,65 @@ def test_persona_bot_fields_persist(tmp_path) -> None:
     assert got["allowed_user_ids"] == [111, 222]
 
 
+def test_persona_tool_config_persists(tmp_path) -> None:
+    # Per-persona tool identity config (#93) survives the round-trip.
+    client, _ = _client(tmp_path)
+    tc = {"gh": {"enabled": True}, "browser": {"enabled": True, "profile": "hop"}}
+    r = client.post(
+        "/personae", json={"name": "hopper", "role": "Coder", "tool_config": tc}, headers=AUTH
+    )
+    assert r.status_code == 200
+    got = client.get("/personae/hopper", headers=AUTH).json()
+    assert got["tool_config"] == tc
+
+
+def test_persona_gh_token_without_vault_errors(tmp_path) -> None:
+    # No infra vault configured → setting a per-persona token is refused, not
+    # silently dropped (so the user knows to configure a master key first).
+    client, _ = _client(tmp_path)
+    r = client.post("/personae", json={"name": "x", "gh_token": "ghp_abc"}, headers=AUTH)
+    assert r.status_code == 400
+    assert "master key" in r.text.lower()
+
+
+def test_persona_gh_token_written_to_infra_vault(tmp_path) -> None:
+    # With an infra vault wired, a per-persona token lands in it under the
+    # namespaced name and never appears in the persona record (#93).
+    import asyncio
+
+    from core.secret_store import SecretStore
+    from core.tools import gh_token_secret_name
+    from core.vault import InfraVault
+
+    store = SecretStore(db_path=str(tmp_path / "config.db"), infra_vault=InfraVault("machine-key"))
+    agent = _AgentStub()
+    app, _ = create_admin_app(
+        AgentState(agent=cast(Any, agent)),
+        cast(ConfigStore, _Store(tmp_path)),
+        secret_store=store,
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/personae",
+        json={"name": "hopper", "tool_config": {"gh": {"enabled": True}}, "gh_token": "ghp_xyz"},
+        headers=AUTH,
+    )
+    assert r.status_code == 200
+    stored = asyncio.run(store.get_infra_secret(gh_token_secret_name("hopper")))
+    assert stored == "ghp_xyz"
+    got = client.get("/personae/hopper", headers=AUTH).json()
+    assert "ghp_xyz" not in got["markdown"]  # token never in the persona doc
+
+
+def test_persona_editor_renders_tool_identities(tmp_path) -> None:
+    # The editor page renders the Tool identities card when a tool is enabled.
+    client, _ = _client(tmp_path)
+    client.post("/personae", json={"name": "hopper"}, headers=AUTH)
+    r = client.get("/admin/personae/hopper", headers=AUTH)
+    assert r.status_code == 200
+    assert "Tool identities" in r.text
+
+
 def test_activate_unknown_persona_404(tmp_path) -> None:
     client, _ = _client(tmp_path)
     assert (

--- a/tests/test_personae_admin.py
+++ b/tests/test_personae_admin.py
@@ -202,6 +202,29 @@ def test_persona_editor_renders_tool_identities(tmp_path) -> None:
     assert "Tool identities" in r.text
 
 
+def test_persona_editor_offers_vault_token_source(tmp_path) -> None:
+    # With gh enabled + an infra vault, the gh card offers reusing a vault secret
+    # as the persona's token (#93), seeded with existing infra secret names.
+    from core.secret_store import SecretStore
+    from core.vault import InfraVault
+
+    store = SecretStore(db_path=str(tmp_path / "config.db"), infra_vault=InfraVault("machine-key"))
+    asyncio_run = __import__("asyncio").run
+    asyncio_run(store.set_infra_secret("SHARED_PAT", "ghp_shared"))
+    backing = _Store(tmp_path)
+    backing._data["tools.gh.enabled"] = "true"
+    agent = _AgentStub()
+    app, _ = create_admin_app(
+        AgentState(agent=cast(Any, agent)), cast(ConfigStore, backing), secret_store=store
+    )
+    client = TestClient(app)
+    client.post("/personae", json={"name": "hopper"}, headers=AUTH)
+    r = client.get("/admin/personae/hopper", headers=AUTH)
+    assert r.status_code == 200
+    assert "Token source" in r.text
+    assert "SHARED_PAT" in r.text  # existing infra secret offered in the dropdown
+
+
 def test_activate_unknown_persona_404(tmp_path) -> None:
     client, _ = _client(tmp_path)
     assert (

--- a/tests/test_secrets_vault.py
+++ b/tests/test_secrets_vault.py
@@ -237,7 +237,7 @@ async def test_substitution_only_in_run_command(agent: AgentCore, monkeypatch) -
     placeholder in an email body is sent literally (no exfiltration)."""
     captured: dict[str, str] = {}
 
-    async def fake_exec(command, timeout):
+    async def fake_exec(command, timeout, cwd=None, tool_env=None):
         captured["cmd"] = command
         return {"stdout": "", "stderr": "", "exit_code": 0}
 
@@ -277,7 +277,7 @@ async def test_run_command_acl_denies_out_of_scope(agent: AgentCore, monkeypatch
     monkeypatch.setattr(agent.permissions, "check", lambda *a, **k: PermissionLevel.ALWAYS)
     ran = {"called": False}
 
-    async def fake_exec(command, timeout):
+    async def fake_exec(command, timeout, cwd=None, tool_env=None):
         ran["called"] = True
         return {"stdout": "", "stderr": "", "exit_code": 0}
 

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -782,6 +782,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Headless browser automation (Playwright).")
     # Default headless from the env injected by core/tools.py (config.tools.browser).
     headless_default = os.environ.get("BROWSER_HEADLESS", "1") != "0"
+    # Default profile from the env injected per active persona (#93): when an agent
+    # omits --profile, it still gets its OWN isolated session dir, not a shared one.
+    profile_default = os.environ.get("BROWSER_PROFILE", "default") or "default"
     parser.add_argument(
         "--headless", dest="headless", action="store_true", default=headless_default
     )
@@ -791,24 +794,24 @@ def main() -> None:
 
     p_read = sub.add_parser("read", help="Load a page, return readable text")
     p_read.add_argument("--url", required=True)
-    p_read.add_argument("--profile", default="default")
+    p_read.add_argument("--profile", default=profile_default)
 
     p_shot = sub.add_parser("screenshot", help="Load a page, save a PNG")
     p_shot.add_argument("--url", required=True)
-    p_shot.add_argument("--profile", default="default")
+    p_shot.add_argument("--profile", default=profile_default)
     p_shot.add_argument("-o", "--output", help="output PNG path")
     p_shot.add_argument("--full-page", action="store_true", default=True)
     p_shot.add_argument("--viewport-only", dest="full_page", action="store_false")
 
     p_act = sub.add_parser("act", help="Load a page and run ordered steps")
     p_act.add_argument("--url", required=True)
-    p_act.add_argument("--profile", default="default")
+    p_act.add_argument("--profile", default=profile_default)
     p_act.add_argument("--steps", required=True, help="JSON array of single-key step objects")
 
     p_exp = sub.add_parser("explore", help="LLM-driven loop: one live browser, act until done")
     p_exp.add_argument("--url", required=True)
     p_exp.add_argument("--task", required=True, help="what to accomplish on the site")
-    p_exp.add_argument("--profile", default="default")
+    p_exp.add_argument("--profile", default=profile_default)
     p_exp.add_argument("--max-steps", type=int, default=35, dest="max_steps")
 
     sub.add_parser("profiles", help="List saved profiles + auth hint")


### PR DESCRIPTION
Closes #93.

## What

Each persona can now use its **own tool credentials and sessions** instead of everyone sharing the owner's. A coding persona and a travel persona running `gh` no longer both appear as the owner's GitHub user; a login one persona makes in the browser no longer leaks to the others.

Scope: the two external CLI tools that have a `tool_env` — **`gh`** and **`browser`**. Built on the existing tool registry, persona store, and infra vault.

## How it works

- **Persona model** gains a `tool_config` JSON field: `{tool_key: {enabled, ...cfg}}`. Empty = inherit the system-wide config (so existing setups are unchanged — migration §6).
- **`run_command`** injects the active persona's tool env for that call: its own `GH_TOKEN` and its own browser `--profile`. The override is authoritative over managed keys, so a persona that switches `gh` **off** has `GH_TOKEN` stripped from the subprocess env (even one leaked in via `.env`) and can never act as the owner. A persona with `gh` on but no own token gets **no** token rather than silently borrowing the owner's.
- **System prompt** advertises each tool with the persona's identity (e.g. *"`gh` is authenticated with this persona's own token"*).
- **Per-persona GitHub tokens** live in the **infra vault** (machine-key, boot-unsealed) namespaced `GH_TOKEN_<SLUG>`, so they work headless and in scheduled jobs — same on-disk posture as the existing system `GH_TOKEN`. Confirmed with the owner.
- **Admin UI**: the persona editor gets a *Tool identities* card (Inherit / Enabled / Disabled per tool, plus token/profile fields). The Tools tab notes its `gh` token is the system-wide default a persona can override.

## Deliberate scope cuts (flagged for review)

- **Tab rename** *Personae → Agents* — skipped (cosmetic nav/test churn).
- **himalaya-email / voice** per-tool config — skipped; voice is already a persona field and email already multi-account. Only `gh` + `browser` (the tools with a real `tool_env`).
- **System creds kept in the Tools tab** as the documented fallback rather than fully stripped — required by the issue's own migration spec.
- Out of scope per the issue: credential rotation, per-persona audit log, usage quotas.

## Tests

- `test_persona_tool_identity.py` — agent injects the persona's own token/profile; gh-disabled and gh-without-own-token never borrow the owner's; no-config inherits.
- `test_executor.py` — a leaked `GH_TOKEN` in the process env is stripped for a persona-scoped override that doesn't set it.
- `test_personae_admin.py` — `tool_config` round-trip, token written to the infra vault (never into the persona doc), refusal without a master key, editor render.
- Self-checks in `core/personae.py` and `core/tools.py`. Full suite: 712 passing.

## Docs

`docs/content/docs/personae.mdx` — new *Tool identities* section, facet list, markdown example.
