### PR TITLE
fix(personae): renaming/deleting a starter persona no longer duplicates or resurrects it (#102)

### DIFF
--- a/core/personae.py
+++ b/core/personae.py
@@ -43,6 +43,13 @@ CREATE TABLE IF NOT EXISTS personae (
     created_at DATETIME DEFAULT (datetime('now')),
     updated_at DATETIME DEFAULT (datetime('now'))
 );
+-- Slugs deliberately removed (deleted, or renamed away from) so seeding does not
+-- resurrect them from their markdown file on the next list (#102). Re-creating a
+-- slug via upsert/rename clears its tombstone.
+CREATE TABLE IF NOT EXISTS persona_tombstones (
+    name TEXT PRIMARY KEY,
+    created_at DATETIME DEFAULT (datetime('now'))
+);
 """
 
 # Columns added after the table first shipped — applied to existing DBs on open.
@@ -227,9 +234,11 @@ class PersonaStore:
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute("SELECT name FROM personae")
             existing = {row[0] for row in await cursor.fetchall()}
+            cursor = await db.execute("SELECT name FROM persona_tombstones")
+            tombstoned = {row[0] for row in await cursor.fetchall()}
             for f in sorted(self.seed_dir.glob("*.md")):
                 content = f.read_text().strip()
-                if not content or f.stem in existing:
+                if not content or f.stem in existing or f.stem in tombstoned:
                     continue
                 await self._upsert(db, parse_markdown(content, name=f.stem))
                 inserted += 1
@@ -305,12 +314,19 @@ class PersonaStore:
         await self._ensure_schema()
         async with aiosqlite.connect(self.db_path) as db:
             await self._upsert(db, p)
+            # Deliberately (re)creating a slug clears any tombstone on it (#102).
+            await db.execute("DELETE FROM persona_tombstones WHERE name = ?", (p.name,))
             await db.commit()
 
     async def delete(self, name: str) -> bool:
         await self._ensure_schema()
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute("DELETE FROM personae WHERE name = ?", (name,))
+            if cursor.rowcount > 0:
+                # Tombstone so seeding doesn't resurrect a deleted seed persona (#102).
+                await db.execute(
+                    "INSERT OR IGNORE INTO persona_tombstones(name) VALUES (?)", (name,)
+                )
             await db.commit()
             return cursor.rowcount > 0
 
@@ -332,6 +348,13 @@ class PersonaStore:
                 "UPDATE personae SET name = ?, updated_at = datetime('now') WHERE name = ?",
                 (new, old),
             )
+            if cursor.rowcount > 0:
+                # Old slug must not resurrect from its seed file; new slug is now
+                # live, so clear any tombstone it carried (#102).
+                await db.execute(
+                    "INSERT OR IGNORE INTO persona_tombstones(name) VALUES (?)", (old,)
+                )
+                await db.execute("DELETE FROM persona_tombstones WHERE name = ?", (new,))
             await db.commit()
             return cursor.rowcount > 0
 

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -85,11 +85,10 @@ Six ready-made personae ship seeded and ready to use or customise: fitness coach
 assistant, travel planner, coding helper, writing editor, and language tutor. They are normal
 rows — edit them in place, or activate one as-is.
 
-Seeding is by file stem: a gallery slug is (re)seeded whenever no row by that name exists. So
-**renaming or deleting a starter persona leaves its original slug to be re-seeded** — the
-renamed copy lives under the new slug, and the pristine starter reappears. Personae you create
-yourself have no seed file, so renaming them is clean. To retire a starter for good, also remove
-its `personae/<slug>.md` file.
+Seeding is by file stem: a gallery slug is seeded whenever no row by that name exists. Deleting
+or renaming a starter persona **tombstones its old slug**, so the gallery file no longer
+re-seeds it — a delete stays deleted and a rename moves the persona cleanly instead of leaving a
+duplicate copy behind. Re-creating a slug (saving a new persona under it) clears the tombstone.
 
 ## Setup wizard
 

--- a/tests/test_personae.py
+++ b/tests/test_personae.py
@@ -182,11 +182,10 @@ async def test_store_rename(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rename_seeded_persona_reseeds_old_slug(tmp_path) -> None:
-    """Characterise (not endorse) the gallery seam: seeding keys off the file
-    stem, so renaming a *seeded* persona leaves the old slug to be re-seeded on
-    the next list. User-created personae have no seed file, so they rename clean.
-    """
+async def test_rename_seeded_persona_does_not_reseed_old_slug(tmp_path) -> None:
+    """Renaming a *seeded* persona must not leave the old slug to be re-seeded
+    from its gallery file: that resurrected it as a duplicate copy (#102). A
+    tombstone on the old slug suppresses the re-seed."""
     seed = tmp_path / "seed"
     seed.mkdir()
     (seed / "fitness-coach.md").write_text("---\nrole: Fitness coach\n---\n")
@@ -194,5 +193,24 @@ async def test_rename_seeded_persona_reseeds_old_slug(tmp_path) -> None:
     assert [p.name for p in await store.list_personae()] == ["fitness-coach"]
 
     await store.rename("fitness-coach", "my-coach")
-    # list_personae re-seeds the now-missing gallery stem alongside the renamed row.
-    assert {p.name for p in await store.list_personae()} == {"fitness-coach", "my-coach"}
+    # Only the renamed row survives — the old stem is not re-seeded.
+    assert {p.name for p in await store.list_personae()} == {"my-coach"}
+
+
+@pytest.mark.asyncio
+async def test_delete_seeded_persona_does_not_reseed(tmp_path) -> None:
+    """Deleting a *seeded* persona must actually remove it, not have it re-seeded
+    from its gallery file on the next list (#102)."""
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "fitness-coach.md").write_text("---\nrole: Fitness coach\n---\n")
+    store = PersonaStore(db_path=str(tmp_path / "p.db"), seed_dir=seed)
+    assert [p.name for p in await store.list_personae()] == ["fitness-coach"]
+
+    assert await store.delete("fitness-coach") is True
+    assert [p.name for p in await store.list_personae()] == []
+
+    # Re-creating the slug deliberately clears the tombstone, so a later edit sticks.
+    await store.upsert(Persona(name="fitness-coach", role="Back"))
+    assert (await store.get("fitness-coach")).role == "Back"
+    assert [p.name for p in await store.list_personae()] == ["fitness-coach"]


### PR DESCRIPTION
Fixes #102.

## Root cause

Both reported bugs were one bug in `PersonaStore.ensure_seeded`: it re-inserts any gallery `personae/*.md` whose file-stem has no matching row. Deleting or renaming a **seeded** persona leaves the original slug rowless, so the very next list (e.g. the partial returned by `/personae/delete`) re-seeds it from its markdown file.

- **Bug 1 (rename → copy):** the editor already renames the row correctly, then the old slug is re-seeded alongside the new one → two personae.
- **Bug 2 (delete → no-op):** the row is deleted, then re-seeded before the page even re-renders → looks like delete did nothing.

## Fix

A `persona_tombstones` table records slugs that were deliberately removed:

- `delete()` and `rename()` tombstone the gone slug → `ensure_seeded()` skips it, so it never resurrects.
- `upsert()` and `rename()` clear the tombstone of any slug brought (back) to life, so re-creating a retired slug works.

Fixed once at the shared store layer, so every caller (admin routes, future callers) is covered. The tombstone table is `CREATE TABLE IF NOT EXISTS` in the schema — no separate migration, safe on existing DBs.

## Tests

- Flipped `test_rename_seeded_persona_*` (which characterised the buggy re-seed) to assert the old slug stays gone.
- Added `test_delete_seeded_persona_does_not_reseed`, including that re-creating the slug clears the tombstone.

## Docs

Updated `docs/content/docs/personae.mdx` starter-gallery section to describe tombstoning instead of the old re-seed footgun.
