### PR TITLE
Replace Chats tab with developer Inspect tab (last-sent LLM payload per context) (#99)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -106,6 +106,51 @@ def _render_partial(template_name: str, **ctx: object) -> HTMLResponse:
     return HTMLResponse(tmpl.render(**ctx))
 
 
+def _humanize_ts(ts_utc: str, now: datetime, tz: str = "UTC") -> str:
+    """Relative "last active" label from a SQLite ``datetime('now')`` UTC string.
+
+    Recent times read as just now / Nm / Nh / Nd ago; older than a week falls
+    back to a date in the agent's timezone. "" in, "" out (a never-messaged chat).
+    """
+    if not ts_utc:
+        return ""
+    try:
+        dt = datetime.strptime(ts_utc, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
+    except ValueError:
+        return ts_utc
+    delta = max(0.0, (now - dt).total_seconds())
+    if delta < 60:
+        return "just now"
+    if delta < 3600:
+        return f"{int(delta // 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta // 3600)}h ago"
+    if delta < 7 * 86400:
+        return f"{int(delta // 86400)}d ago"
+    try:
+        return dt.astimezone(ZoneInfo(tz)).strftime("%Y-%m-%d")
+    except ZoneInfoNotFoundError:
+        return dt.strftime("%Y-%m-%d")
+
+
+def _elide_image_data(value: object) -> object:
+    """Return a copy of ``value`` with long base64 ``data`` fields replaced by a
+    short placeholder, so a captured image payload doesn't bloat the Inspect view.
+    Recurses through the message/block dict+list structure; leaves all else as-is.
+    """
+    if isinstance(value, dict):
+        out: dict = {}
+        for k, v in value.items():
+            if k == "data" and isinstance(v, str) and len(v) > 256:
+                out[k] = f"<{len(v)} base64 chars elided>"
+            else:
+                out[k] = _elide_image_data(v)
+        return out
+    if isinstance(value, list):
+        return [_elide_image_data(v) for v in value]
+    return value
+
+
 def _is_vault_ref(value: str | None) -> bool:
     """True if a stored config value points at the infra vault (issue #35).
 
@@ -2857,19 +2902,21 @@ def create_admin_app(
         await _set_active_persona(name)
         return await _personae_partial()
 
-    # ── Inspect API (active contexts, per-chat bindings, last-sent payload) ──
+    # ── Inspect API (active contexts + last-sent LLM payload) ──────────────
 
     async def _inspect_partial() -> HTMLResponse:
         history = await _history_from_config(config_store)
         chats = await history.list_chats()
-        store = await _persona_store_from_config(config_store)
-        personae = await store.list_personae()
-        return _render_partial("partials/inspect.html", chats=chats, personae=personae)
+        tz = await config_store.get("agent.timezone") or "UTC"
+        now = datetime.now(UTC)
+        for c in chats:
+            c["last_active_h"] = _humanize_ts(c.get("last_active", ""), now, tz)
+        return _render_partial("partials/inspect.html", chats=chats)
 
     @app.get("/partials/inspect", dependencies=[Depends(auth)])
     async def partial_inspect() -> HTMLResponse:
-        """Inspect tab partial — active contexts, their bound persona, and a
-        per-context view of the exact payload last sent to the LLM (#99)."""
+        """Inspect tab partial — active contexts (most-recently-active first) and
+        a master/detail view of the exact payload last sent to the LLM (#99)."""
         return await _inspect_partial()
 
     @app.get("/inspect/payload", dependencies=[Depends(auth)])
@@ -2883,6 +2930,9 @@ def create_admin_app(
         the context has had a turn since the agent started."""
         payload = get_sent_payload((channel, user_id, chat_id))
         meta: dict[str, object] | None = None
+        system = ""
+        messages: list = []
+        tools: list = []
         pretty: str | None = None
         if payload:
             ts = payload.get("captured_at")
@@ -2893,9 +2943,13 @@ def create_admin_app(
                     captured = datetime.fromtimestamp(float(ts), ZoneInfo(tz)).strftime(
                         "%Y-%m-%d %H:%M:%S %Z"
                     )
-                except ValueError, ZoneInfoNotFoundError:
+                except ZoneInfoNotFoundError:
                     captured = datetime.fromtimestamp(float(ts), UTC).isoformat()
-            messages = payload.get("messages") or []
+            system = payload.get("system") or ""
+            # Elide base64 image data so the detail pane never ships megabytes of
+            # base64 (a sent photo) — the transcript shows "[image]" and the raw
+            # view shows a placeholder, while every other field stays verbatim.
+            messages = _elide_image_data(payload.get("messages") or [])
             tools = payload.get("tools") or []
             meta = {
                 "provider": payload.get("provider", ""),
@@ -2909,7 +2963,7 @@ def create_admin_app(
                 {
                     "model": payload.get("model"),
                     "max_tokens": payload.get("max_tokens"),
-                    "system": payload.get("system"),
+                    "system": system,
                     "tools": tools,
                     "messages": messages,
                 },
@@ -2918,32 +2972,13 @@ def create_admin_app(
                 default=str,
             )
         return _render_partial(
-            "partials/inspect_payload.html", payload=payload, meta=meta, pretty=pretty
+            "partials/inspect_payload.html",
+            meta=meta,
+            system=system,
+            messages=messages,
+            tools=tools,
+            pretty=pretty,
         )
-
-    @app.post("/chats/bind", dependencies=[Depends(auth)])
-    async def bind_chat(request: Request) -> HTMLResponse:
-        content_type = request.headers.get("content-type", "")
-        if "application/x-www-form-urlencoded" in content_type:
-            body = await request.form()
-        else:
-            body = await request.json()
-        channel = str(body.get("channel", "")).strip()
-        user_id = str(body.get("user_id", "")).strip()
-        chat_id = str(body.get("chat_id", "")).strip()
-        persona = str(body.get("persona", "")).strip()  # "" = unbind (default identity)
-        if not channel or not user_id:
-            raise HTTPException(400, "Missing 'channel' or 'user_id' in request body")
-        if persona:
-            store = await _persona_store_from_config(config_store)
-            if not await store.get(persona):
-                raise HTTPException(404, f"Persona not found: {persona}")
-        # Use the running agent's history instance so its in-memory session cache
-        # is the one cleared; fall back to a config-built store when not running.
-        agent = agent_state.agent
-        history = agent.history if agent else await _history_from_config(config_store)
-        await history.bind_chat_persona(channel, user_id, chat_id, persona)
-        return await _inspect_partial()
 
     # ── Memory API ─────────────────────────────────────────────────────
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -23,6 +23,7 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests as http_requests
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -35,7 +36,7 @@ from pydantic import BaseModel, Field
 from core.artifacts import ARTIFACT_CSP, NOT_FOUND_HTML, resolve, serving_base, valid_id
 from core.config_store import ConfigStore
 from core.goal_decomposition import classify_complexity, decompose_goal
-from core.llm import LLMClient
+from core.llm import LLMClient, get_sent_payload
 from core.log_streams import current_stream, current_subagent
 from core.prompt_builder import (
     DEFAULT_HISTORY_HANDLING_BLOCK,
@@ -2856,19 +2857,69 @@ def create_admin_app(
         await _set_active_persona(name)
         return await _personae_partial()
 
-    # ── Chats API (per-chat persona bindings) ──────────────────────────
+    # ── Inspect API (active contexts, per-chat bindings, last-sent payload) ──
 
-    async def _chats_partial() -> HTMLResponse:
+    async def _inspect_partial() -> HTMLResponse:
         history = await _history_from_config(config_store)
         chats = await history.list_chats()
         store = await _persona_store_from_config(config_store)
         personae = await store.list_personae()
-        return _render_partial("partials/chats.html", chats=chats, personae=personae)
+        return _render_partial("partials/inspect.html", chats=chats, personae=personae)
 
-    @app.get("/partials/chats", dependencies=[Depends(auth)])
-    async def partial_chats() -> HTMLResponse:
-        """Chats tab partial — active contexts and their bound persona."""
-        return await _chats_partial()
+    @app.get("/partials/inspect", dependencies=[Depends(auth)])
+    async def partial_inspect() -> HTMLResponse:
+        """Inspect tab partial — active contexts, their bound persona, and a
+        per-context view of the exact payload last sent to the LLM (#99)."""
+        return await _inspect_partial()
+
+    @app.get("/inspect/payload", dependencies=[Depends(auth)])
+    async def inspect_payload(
+        channel: str = "", user_id: str = "", chat_id: str = ""
+    ) -> HTMLResponse:
+        """Render the last-sent inference payload for one context (#99).
+
+        Reads the in-memory capture keyed by (channel, user_id, chat_id) — the
+        exact system/messages/tools/model that generate() last sent. Empty until
+        the context has had a turn since the agent started."""
+        payload = get_sent_payload((channel, user_id, chat_id))
+        meta: dict[str, object] | None = None
+        pretty: str | None = None
+        if payload:
+            ts = payload.get("captured_at")
+            captured = ""
+            if ts:
+                tz = await config_store.get("agent.timezone") or "UTC"
+                try:
+                    captured = datetime.fromtimestamp(float(ts), ZoneInfo(tz)).strftime(
+                        "%Y-%m-%d %H:%M:%S %Z"
+                    )
+                except ValueError, ZoneInfoNotFoundError:
+                    captured = datetime.fromtimestamp(float(ts), UTC).isoformat()
+            messages = payload.get("messages") or []
+            tools = payload.get("tools") or []
+            meta = {
+                "provider": payload.get("provider", ""),
+                "model": payload.get("model", ""),
+                "max_tokens": payload.get("max_tokens", ""),
+                "n_messages": len(messages),
+                "n_tools": len(tools),
+                "captured_at": captured,
+            }
+            pretty = json.dumps(
+                {
+                    "model": payload.get("model"),
+                    "max_tokens": payload.get("max_tokens"),
+                    "system": payload.get("system"),
+                    "tools": tools,
+                    "messages": messages,
+                },
+                indent=2,
+                ensure_ascii=False,
+                default=str,
+            )
+        return _render_partial(
+            "partials/inspect_payload.html", payload=payload, meta=meta, pretty=pretty
+        )
 
     @app.post("/chats/bind", dependencies=[Depends(auth)])
     async def bind_chat(request: Request) -> HTMLResponse:
@@ -2892,7 +2943,7 @@ def create_admin_app(
         agent = agent_state.agent
         history = agent.history if agent else await _history_from_config(config_store)
         await history.bind_chat_persona(channel, user_id, chat_id, persona)
-        return await _chats_partial()
+        return await _inspect_partial()
 
     # ── Memory API ─────────────────────────────────────────────────────
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -2971,6 +2971,8 @@ def create_admin_app(
                 ensure_ascii=False,
                 default=str,
             )
+        safe = re.sub(r"[^A-Za-z0-9._-]+", "_", f"{channel}-{chat_id or 'default'}").strip("_")
+        download_name = f"inspect-{safe or 'payload'}.json"
         return _render_partial(
             "partials/inspect_payload.html",
             meta=meta,
@@ -2978,6 +2980,7 @@ def create_admin_app(
             messages=messages,
             tools=tools,
             pretty=pretty,
+            download_name=download_name,
         )
 
     # ── Memory API ─────────────────────────────────────────────────────

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -76,10 +76,6 @@
             @click="select('personae')">
       Personae
     </button>
-    <button class="tab-link" :class="tab === 'chats' && 'tab-link-active'"
-            @click="select('chats')">
-      Chats
-    </button>
     <button class="tab-link" :class="tab === 'llm' && 'tab-link-active'"
             @click="select('llm')">
       LLM
@@ -143,6 +139,10 @@
     <button class="tab-link" :class="tab === 'logs' && 'tab-link-active'"
             @click="select('logs')">
       Logs
+    </button>
+    <button class="tab-link" :class="tab === 'inspect' && 'tab-link-active'"
+            @click="select('inspect')">
+      Inspect
     </button>
   </div>
 
@@ -724,7 +724,6 @@
       identity: '/partials/identity',
       you: '/partials/you',
       personae: '/partials/personae',
-      chats: '/partials/chats',
       llm: '/partials/llm',
       memory: '/partials/memory',
       history: '/partials/history',
@@ -740,7 +739,8 @@
       email: '/partials/email',
       secrets: '/partials/secrets',
       admin: '/partials/admin',
-      logs: '/partials/logs'
+      logs: '/partials/logs',
+      inspect: '/partials/inspect'
     };
 
     return {

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -162,6 +162,49 @@
     script.async = true;
     document.head.appendChild(script);
   })();
+
+  // Inspect tab — copy/download the raw last-sent payload (#99). Read the text
+  // straight from the rendered <pre> so there's no second copy to keep in sync.
+  function inspectRawText(btn) {
+    const pre = btn.closest('details').querySelector('[data-raw]');
+    return pre ? pre.textContent : '';
+  }
+  function inspectFlash(btn, msg) {
+    const orig = btn.dataset.orig || btn.textContent;
+    btn.dataset.orig = orig;
+    btn.textContent = msg;
+    setTimeout(() => { btn.textContent = orig; }, 1200);
+  }
+  function inspectCopyJSON(btn) {
+    const text = inspectRawText(btn);
+    const ok = () => inspectFlash(btn, 'Copied!');
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(ok).catch(() => inspectCopyFallback(text, ok));
+    } else {
+      inspectCopyFallback(text, ok);
+    }
+  }
+  function inspectCopyFallback(text, ok) {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand('copy'); ok(); } catch (e) { /* clipboard blocked */ }
+    ta.remove();
+  }
+  function inspectDownloadJSON(btn) {
+    const blob = new Blob([inspectRawText(btn)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = btn.dataset.filename || 'inspect-payload.json';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
   function agentControl() {
     return {
       busy: false,

--- a/api/templates/partials/inspect.html
+++ b/api/templates/partials/inspect.html
@@ -1,79 +1,58 @@
-{# Inspect tab partial — every active context + the exact payload last sent to
-   the LLM for it (#99). Keeps the per-chat persona binding from the old Chats
-   tab; adds a developer payload inspector. #}
-<div x-data="{ filter: '' }">
-  {# Intro #}
+{# Inspect tab — master/detail view of active contexts and the exact payload
+   last sent to the LLM for each (#99). Master lists contexts newest-active
+   first; selecting one loads its last-sent context into the detail pane. #}
+<div x-data="{ filter: '', selected: 0 }">
   <div class="card mb-4">
     <h2 class="text-base mb-0.5">Inspect</h2>
     <p class="text-muted text-xs">
-      Every active context, by <code>channel · user · chat</code>. For developers:
-      open <strong>Last-sent payload</strong> to see exactly what was assembled and
-      sent to the model — system prompt/identity, history window, and tool
-      definitions — the last time this context ran.
-    </p>
-    <p class="text-muted text-xs mt-2">
-      Bind a persona to a chat to override the global active persona there; the
-      change applies on the next turn. Payloads are captured in memory while the
-      agent runs, so a context shows nothing until it has had a turn since startup.
+      Every active context, most recently used first. Select one to see the exact
+      payload last sent to the model — system prompt/identity, history window, and
+      tool definitions — the last time it ran. Admin-only; captured in memory while
+      the agent runs, so a context is blank until it has had a turn since startup.
     </p>
   </div>
 
-  {# Toolbar #}
-  <div class="flex items-center gap-2 mb-4 flex-wrap">
-    <input type="text" class="input-sm flex-1" style="max-width:280px"
-           placeholder="Filter contexts..." x-model="filter">
-    <span class="text-muted text-xs">{{ chats|length }} total</span>
-  </div>
-
-  {# Card grid — 1 col on phone, 2 on large #}
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
-    {% for c in chats %}
-    <div class="card flex flex-col gap-2 {% if c.persona %}border-accent{% endif %}"
-         x-show="!filter
-                 || {{ c.channel|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
-                 || {{ c.user_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
-                 || {{ c.chat_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())">
-      <div class="flex items-start gap-2 min-w-0">
-        <span class="badge-ok whitespace-nowrap">{{ c.channel }}</span>
-        <div class="min-w-0 flex-1">
-          <div class="text-sm font-semibold break-all">{{ c.chat_id or '(default)' }}</div>
-          <div class="text-muted text-xs break-all">user {{ c.user_id }}</div>
-        </div>
-      </div>
-
-      <form class="flex items-center gap-1.5">
-        <input type="hidden" name="channel" value="{{ c.channel }}">
-        <input type="hidden" name="user_id" value="{{ c.user_id }}">
-        <input type="hidden" name="chat_id" value="{{ c.chat_id }}">
-        <label class="text-muted text-xs whitespace-nowrap">Persona</label>
-        <select name="persona" class="input-sm flex-1"
-                hx-post="/chats/bind" hx-trigger="change"
-                hx-include="closest form"
-                hx-target="#tab-content" hx-swap="innerHTML">
-          <option value="" {% if not c.persona %}selected{% endif %}>Default</option>
-          {% for p in personae %}
-          <option value="{{ p.name }}" {% if p.name == c.persona %}selected{% endif %}>
-            {{ p.emoji or '🧩' }} {{ p.role or p.name }}
-          </option>
-          {% endfor %}
-        </select>
-      </form>
-
-      {# Payload inspector — clicking (re)loads the latest captured request. #}
-      <div class="mt-auto pt-1">
-        <button type="button" class="btn-sm"
+  <div class="flex flex-col lg:flex-row gap-3">
+    {# Master — context list, newest-active first #}
+    <div class="lg:w-80 lg:shrink-0 flex flex-col gap-2">
+      <input type="text" class="input-sm" placeholder="Filter contexts..." x-model="filter">
+      <span class="text-muted text-xs">{{ chats|length }} context{{ '' if chats|length == 1 else 's' }}</span>
+      <div class="flex flex-col gap-1 overflow-y-auto" style="max-height: 32rem">
+        {% for c in chats %}
+        <button type="button"
+                class="card text-left flex flex-col gap-0.5 py-2"
+                :class="selected === {{ loop.index0 }} ? 'border-accent' : ''"
+                @click="selected = {{ loop.index0 }}"
+                x-show="!filter
+                        || {{ c.channel|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                        || {{ c.user_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                        || {{ c.chat_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())"
                 hx-get="/inspect/payload?channel={{ c.channel|urlencode }}&user_id={{ c.user_id|urlencode }}&chat_id={{ c.chat_id|urlencode }}"
-                hx-target="#payload-{{ loop.index0 }}" hx-swap="innerHTML">
-          Last-sent payload
+                hx-target="#inspect-detail" hx-swap="innerHTML"
+                hx-trigger="click{% if loop.first %}, load{% endif %}">
+          <div class="flex items-center gap-1.5 min-w-0">
+            <span class="badge-ok whitespace-nowrap">{{ c.channel }}</span>
+            <span class="text-sm font-semibold break-all flex-1 min-w-0">{{ c.chat_id or '(default)' }}</span>
+          </div>
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-muted text-xs break-all">user {{ c.user_id }}</span>
+            {% if c.last_active_h %}
+            <span class="text-muted text-xs whitespace-nowrap">{{ c.last_active_h }}</span>
+            {% endif %}
+          </div>
         </button>
-        <div id="payload-{{ loop.index0 }}" class="mt-2"></div>
+        {% endfor %}
+        {% if not chats %}
+        <div class="text-muted text-xs text-center py-6">
+          No contexts yet. They appear here once a conversation has started.
+        </div>
+        {% endif %}
       </div>
     </div>
-    {% endfor %}
-    {% if not chats %}
-    <div class="text-muted text-xs text-center py-6 col-span-full">
-      No contexts yet. They appear here once a conversation has started.
+
+    {# Detail — last-sent payload for the selected context #}
+    <div id="inspect-detail" class="flex-1 min-w-0">
+      <div class="text-muted text-xs">Select a context to inspect its last-sent payload.</div>
     </div>
-    {% endif %}
   </div>
 </div>

--- a/api/templates/partials/inspect.html
+++ b/api/templates/partials/inspect.html
@@ -1,23 +1,27 @@
-{# Chats tab partial — active contexts and the persona bound to each #}
+{# Inspect tab partial — every active context + the exact payload last sent to
+   the LLM for it (#99). Keeps the per-chat persona binding from the old Chats
+   tab; adds a developer payload inspector. #}
 <div x-data="{ filter: '' }">
   {# Intro #}
   <div class="card mb-4">
-    <h2 class="text-base mb-0.5">Chats</h2>
+    <h2 class="text-base mb-0.5">Inspect</h2>
     <p class="text-muted text-xs">
-      Every active conversation, by <code>channel · user · chat</code>. Bind a
-      persona to a single chat — it overrides the global active persona there.
-      Telegram topics show as <code>chat:topic</code> when topic mode is on.
+      Every active context, by <code>channel · user · chat</code>. For developers:
+      open <strong>Last-sent payload</strong> to see exactly what was assembled and
+      sent to the model — system prompt/identity, history window, and tool
+      definitions — the last time this context ran.
     </p>
     <p class="text-muted text-xs mt-2">
-      A change applies on the next turn; the open chat keeps its current identity
-      until then (its messages are preserved).
+      Bind a persona to a chat to override the global active persona there; the
+      change applies on the next turn. Payloads are captured in memory while the
+      agent runs, so a context shows nothing until it has had a turn since startup.
     </p>
   </div>
 
   {# Toolbar #}
   <div class="flex items-center gap-2 mb-4 flex-wrap">
     <input type="text" class="input-sm flex-1" style="max-width:280px"
-           placeholder="Filter chats..." x-model="filter">
+           placeholder="Filter contexts..." x-model="filter">
     <span class="text-muted text-xs">{{ chats|length }} total</span>
   </div>
 
@@ -37,7 +41,7 @@
         </div>
       </div>
 
-      <form class="flex items-center gap-1.5 mt-auto pt-1">
+      <form class="flex items-center gap-1.5">
         <input type="hidden" name="channel" value="{{ c.channel }}">
         <input type="hidden" name="user_id" value="{{ c.user_id }}">
         <input type="hidden" name="chat_id" value="{{ c.chat_id }}">
@@ -54,11 +58,21 @@
           {% endfor %}
         </select>
       </form>
+
+      {# Payload inspector — clicking (re)loads the latest captured request. #}
+      <div class="mt-auto pt-1">
+        <button type="button" class="btn-sm"
+                hx-get="/inspect/payload?channel={{ c.channel|urlencode }}&user_id={{ c.user_id|urlencode }}&chat_id={{ c.chat_id|urlencode }}"
+                hx-target="#payload-{{ loop.index0 }}" hx-swap="innerHTML">
+          Last-sent payload
+        </button>
+        <div id="payload-{{ loop.index0 }}" class="mt-2"></div>
+      </div>
     </div>
     {% endfor %}
     {% if not chats %}
     <div class="text-muted text-xs text-center py-6 col-span-full">
-      No chats yet. They appear here once a conversation has started.
+      No contexts yet. They appear here once a conversation has started.
     </div>
     {% endif %}
   </div>

--- a/api/templates/partials/inspect_payload.html
+++ b/api/templates/partials/inspect_payload.html
@@ -1,22 +1,108 @@
-{# Last-sent LLM payload for one context (#99). Loaded into the Inspect card on
-   demand. `pretty` is the serialized request; `meta` summarises it. #}
-{%- if not payload %}
-<div class="text-muted text-xs border border-border rounded-md p-2">
+{# Last-sent LLM payload for one context (#99), rendered as a readable transcript:
+   system prompt, tool defs, and the message window, plus a raw-JSON fallback.
+   `meta` summarises; `system`/`messages`/`tools` are the (image-elided) request. #}
+
+{%- macro render_block(b) -%}
+  {%- if b is string -%}
+    <div class="whitespace-pre-wrap break-words">{{ b }}</div>
+  {%- elif b is mapping -%}
+    {%- set t = b.get('type') -%}
+    {%- if t == 'text' -%}
+      <div class="whitespace-pre-wrap break-words">{{ b.get('text', '') }}</div>
+    {%- elif t == 'image' -%}
+      <div class="text-muted italic">[image{% if b.get('source') and b['source'].get('media_type') %}: {{ b['source']['media_type'] }}{% endif %}]</div>
+    {%- elif t == 'tool_use' -%}
+      <div><span class="badge-warn">tool_use</span> <code>{{ b.get('name', '') }}</code>
+        <pre class="log-viewer mt-1" style="max-height:14rem">{{ b.get('input') | tojson(indent=2) }}</pre></div>
+    {%- elif t == 'tool_result' -%}
+      <div><span class="badge-warn">tool_result</span>
+        <div class="mt-1">{{ render_content(b.get('content')) }}</div></div>
+    {%- elif t in ('thinking', 'redacted_thinking') -%}
+      <div class="text-muted italic">[thinking]</div>
+    {%- else -%}
+      <pre class="log-viewer" style="max-height:14rem">{{ b | tojson(indent=2) }}</pre>
+    {%- endif -%}
+  {%- else -%}
+    <div class="whitespace-pre-wrap break-words">{{ b }}</div>
+  {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_content(c) -%}
+  {%- if c is string -%}
+    <div class="whitespace-pre-wrap break-words">{{ c }}</div>
+  {%- elif c is iterable and c is not mapping -%}
+    {%- for b in c %}{{ render_block(b) }}{% endfor -%}
+  {%- else -%}
+    {{ render_block(c) }}
+  {%- endif -%}
+{%- endmacro -%}
+
+{%- if not meta -%}
+<div class="text-muted text-xs border border-border rounded-md p-3">
   No payload captured yet for this context. Send it a message while the agent is
-  running, then reopen this.
+  running, then reselect it here.
 </div>
-{%- else %}
-<div class="text-xs text-muted mb-1 break-all">
+{%- else -%}
+<div class="text-xs text-muted mb-2 break-all">
   <span class="badge-ok">{{ meta.provider }}</span>
   <code>{{ meta.model }}</code> ·
   max_tokens {{ meta.max_tokens }} ·
   {{ meta.n_messages }} message{{ '' if meta.n_messages == 1 else 's' }} ·
   {{ meta.n_tools }} tool{{ '' if meta.n_tools == 1 else 's' }}
   {%- if meta.captured_at %} · captured {{ meta.captured_at }}{% endif %}
+  <div class="mt-0.5" style="font-size:0.65rem">
+    The exact request the model last received. Admin-only; the prompt references
+    secrets by name, not value.
+  </div>
 </div>
-<div class="text-muted mb-1" style="font-size:0.65rem">
-  Shown verbatim (admin-only). The assembled prompt references secrets by name,
-  not value.
+
+{# System prompt / identity #}
+<details class="card mb-2" open>
+  <summary class="cursor-pointer text-sm font-semibold">System prompt
+    <span class="text-muted text-xs">({{ system|length }} chars)</span></summary>
+  <pre class="log-viewer mt-2">{{ system }}</pre>
+</details>
+
+{# Tool definitions offered this turn #}
+<details class="card mb-2">
+  <summary class="cursor-pointer text-sm font-semibold">Tool definitions
+    <span class="text-muted text-xs">({{ tools|length }})</span></summary>
+  <div class="mt-2 flex flex-col gap-1">
+    {% for t in tools %}
+    <details>
+      <summary class="cursor-pointer text-xs"><code>{{ t.get('name', '?') }}</code>
+        <span class="text-muted">— {{ (t.get('description') or '') | truncate(90) }}</span></summary>
+      <pre class="log-viewer mt-1" style="max-height:16rem">{{ t | tojson(indent=2) }}</pre>
+    </details>
+    {% endfor %}
+    {% if not tools %}<div class="text-muted text-xs">No tools offered.</div>{% endif %}
+  </div>
+</details>
+
+{# The history window, as a transcript #}
+<div class="card mb-2">
+  <div class="text-sm font-semibold mb-2">Context window
+    <span class="text-muted text-xs">({{ messages|length }} message{{ '' if messages|length == 1 else 's' }})</span></div>
+  <div class="flex flex-col gap-2">
+    {% for m in messages %}
+    {% set role = m.get('role', '?') %}
+    <div class="border-l-2 pl-2 {% if role == 'assistant' %}border-accent{% else %}border-border{% endif %}">
+      <div class="mb-1">
+        {% if role == 'assistant' %}<span class="badge-ok">{{ role }}</span>
+        {% elif role == 'user' %}<span class="badge-off">{{ role }}</span>
+        {% else %}<span class="badge-warn">{{ role }}</span>{% endif %}
+      </div>
+      <div class="text-xs">{{ render_content(m.get('content')) }}</div>
+    </div>
+    {% endfor %}
+    {% if not messages %}<div class="text-muted text-xs">Empty window.</div>{% endif %}
+  </div>
 </div>
-<pre class="log-viewer">{{ pretty }}</pre>
-{%- endif %}
+
+{# Exact serialized request, for power users #}
+<details class="card">
+  <summary class="cursor-pointer text-sm font-semibold">Raw JSON
+    <span class="text-muted text-xs">(image bytes elided)</span></summary>
+  <pre class="log-viewer mt-2">{{ pretty }}</pre>
+</details>
+{%- endif -%}

--- a/api/templates/partials/inspect_payload.html
+++ b/api/templates/partials/inspect_payload.html
@@ -1,0 +1,22 @@
+{# Last-sent LLM payload for one context (#99). Loaded into the Inspect card on
+   demand. `pretty` is the serialized request; `meta` summarises it. #}
+{%- if not payload %}
+<div class="text-muted text-xs border border-border rounded-md p-2">
+  No payload captured yet for this context. Send it a message while the agent is
+  running, then reopen this.
+</div>
+{%- else %}
+<div class="text-xs text-muted mb-1 break-all">
+  <span class="badge-ok">{{ meta.provider }}</span>
+  <code>{{ meta.model }}</code> ·
+  max_tokens {{ meta.max_tokens }} ·
+  {{ meta.n_messages }} message{{ '' if meta.n_messages == 1 else 's' }} ·
+  {{ meta.n_tools }} tool{{ '' if meta.n_tools == 1 else 's' }}
+  {%- if meta.captured_at %} · captured {{ meta.captured_at }}{% endif %}
+</div>
+<div class="text-muted mb-1" style="font-size:0.65rem">
+  Shown verbatim (admin-only). The assembled prompt references secrets by name,
+  not value.
+</div>
+<pre class="log-viewer">{{ pretty }}</pre>
+{%- endif %}

--- a/api/templates/partials/inspect_payload.html
+++ b/api/templates/partials/inspect_payload.html
@@ -103,6 +103,11 @@
 <details class="card">
   <summary class="cursor-pointer text-sm font-semibold">Raw JSON
     <span class="text-muted text-xs">(image bytes elided)</span></summary>
-  <pre class="log-viewer mt-2">{{ pretty }}</pre>
+  <div class="flex gap-2 mt-2">
+    <button type="button" class="btn-sm" onclick="inspectCopyJSON(this)">Copy JSON</button>
+    <button type="button" class="btn-sm" data-filename="{{ download_name }}"
+            onclick="inspectDownloadJSON(this)">Download</button>
+  </div>
+  <pre data-raw class="log-viewer mt-2">{{ pretty }}</pre>
 </details>
 {%- endif -%}

--- a/core/agent.py
+++ b/core/agent.py
@@ -28,7 +28,13 @@ from core.goal_decomposition import DecomposedGoal, classify_complexity, decompo
 from core.history import ConversationHistory
 from core.imagegen import ImageBudget
 from core.job_store import JobStore
-from core.llm import LLMClient, LLMToolCall, model_supports_vision
+from core.llm import (
+    LLMClient,
+    LLMToolCall,
+    model_supports_vision,
+    reset_capture_context,
+    set_capture_context,
+)
 from core.log_streams import set_stream, subagent_stream
 from core.memory import MemoryStore
 from core.models import IMAGE_MIME_TYPES, AgentResponse, Attachment
@@ -1129,8 +1135,25 @@ class AgentCore:
                 prompt=system,
             )
 
-        if self.history_mode == "session":
-            return await self._process_session(
+        # Record every generate() this turn under this context so the admin
+        # Inspect tab can show the exact last-sent payload (#99). Reset in finally
+        # so a context never leaks onto an unrelated later turn on the same task.
+        cap_token = set_capture_context((channel, user_id, chat_id))
+        try:
+            if self.history_mode == "session":
+                return await self._process_session(
+                    system,
+                    preamble,
+                    message,
+                    channel,
+                    user_id,
+                    attachments,
+                    chat_id,
+                    tools,
+                    persona,
+                    message_id,
+                )
+            return await self._process_injection(
                 system,
                 preamble,
                 message,
@@ -1142,18 +1165,8 @@ class AgentCore:
                 persona,
                 message_id,
             )
-        return await self._process_injection(
-            system,
-            preamble,
-            message,
-            channel,
-            user_id,
-            attachments,
-            chat_id,
-            tools,
-            persona,
-            message_id,
-        )
+        finally:
+            reset_capture_context(cap_token)
 
     async def _resolve_persona(self, channel: str, user_id: str, chat_id: str) -> Persona | None:
         """Resolve the active persona for this request, in precedence order:
@@ -2920,8 +2933,15 @@ class AgentCore:
         ``[subagent:<label>]`` so it filters out of the shared stream; ``fallback``
         names the stream for a top-level scheduled run that inherited none.
         """
-        with subagent_stream(run.persona or run.run_id, fallback=run.persona):
-            return await self._run_subagent_loop_inner(task, child_persona, child_state, run)
+        # Suppress Inspect capture (#99): a subagent runs inside the spawner's
+        # contextvar but is a different conversation — don't clobber the parent's
+        # last-sent payload with the child's.
+        cap_token = set_capture_context(None)
+        try:
+            with subagent_stream(run.persona or run.run_id, fallback=run.persona):
+                return await self._run_subagent_loop_inner(task, child_persona, child_state, run)
+        finally:
+            reset_capture_context(cap_token)
 
     async def _run_subagent_loop_inner(
         self, task: str, child_persona: Persona | None, child_state: dict, run: SubagentRun

--- a/core/history.py
+++ b/core/history.py
@@ -534,18 +534,21 @@ class ConversationHistory:
         # in-memory _session_system cache (keyed by the old channel) is moot here.
 
     async def list_chats(self) -> list[dict[str, str]]:
-        """List every known (channel, user_id, chat_id) with its bound persona.
+        """List every known (channel, user_id, chat_id), most-recently-active first.
 
-        Drives the admin Chats page. Unions the turn/session/binding tables so a
+        Drives the admin Inspect tab. Unions the turn/session/binding tables so a
         chat appears whichever history mode produced it (and even when it is only
-        bound, e.g. a topic auto-bound before its first message). LEFT JOIN
-        surfaces the binding; ``persona`` is "" when unbound.
+        bound, e.g. a topic auto-bound before its first message). ``last_active``
+        is the most recent turn/message timestamp (UTC ``datetime('now')`` text,
+        so lexically sortable), or "" for a chat that is only bound. ``persona``
+        is the bound persona ("" when unbound). Ordered newest-active first so the
+        chat you just messaged floats to the top.
         """
         await self._ensure_schema()
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
                 """
-                SELECT c.channel, c.user_id, c.chat_id, p.persona
+                SELECT c.channel, c.user_id, c.chat_id, p.persona, a.last_active
                 FROM (
                     SELECT DISTINCT channel, user_id, chat_id FROM conversation_turns
                     UNION
@@ -556,11 +559,29 @@ class ConversationHistory:
                 LEFT JOIN chat_persona AS p
                   ON p.channel = c.channel AND p.user_id = c.user_id
                   AND p.chat_id = c.chat_id
-                ORDER BY c.channel, c.user_id, c.chat_id
+                LEFT JOIN (
+                    SELECT channel, user_id, chat_id, MAX(created_at) AS last_active
+                    FROM (
+                        SELECT channel, user_id, chat_id, created_at FROM conversation_turns
+                        UNION ALL
+                        SELECT channel, user_id, chat_id, created_at FROM session_messages
+                    )
+                    GROUP BY channel, user_id, chat_id
+                ) AS a
+                  ON a.channel = c.channel AND a.user_id = c.user_id
+                  AND a.chat_id = c.chat_id
+                ORDER BY a.last_active IS NULL, a.last_active DESC,
+                         c.channel, c.user_id, c.chat_id
                 """
             )
             rows = await cursor.fetchall()
         return [
-            {"channel": ch, "user_id": uid, "chat_id": cid, "persona": persona or ""}
-            for ch, uid, cid, persona in rows
+            {
+                "channel": ch,
+                "user_id": uid,
+                "chat_id": cid,
+                "persona": persona or "",
+                "last_active": last_active or "",
+            }
+            for ch, uid, cid, persona, last_active in rows
         ]

--- a/core/llm.py
+++ b/core/llm.py
@@ -24,7 +24,7 @@ reasoning_log.setLevel(logging.WARNING)
 # the agent sets the context for a turn, generate() records the payload, the
 # admin Inspect tab reads it back. ponytail: process-global dict, fine for one
 # agent process; move onto the agent instance if multi-tenant ever lands.
-_CtxKey = "tuple[str, str, str]"  # (channel, user_id, chat_id)
+# Context key = (channel, user_id, chat_id) — same triple as ConversationHistory.
 _capture_ctx: contextvars.ContextVar = contextvars.ContextVar("mpa_llm_capture_ctx", default=None)
 _LAST_SENT: OrderedDict[tuple[str, str, str], dict[str, Any]] = OrderedDict()
 _CAPTURE_CAP = 100  # ponytail: LRU cap; bump if you watch >100 live chats

--- a/core/llm.py
+++ b/core/llm.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import contextvars
 import importlib
 import json
 import logging
+import time
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -14,6 +17,50 @@ from anthropic import AsyncAnthropic
 # the REPL bumps it to INFO to stream reasoning live without spamming server logs.
 reasoning_log = logging.getLogger("core.llm.reasoning")
 reasoning_log.setLevel(logging.WARNING)
+
+# ── Inference-payload capture (admin Inspect tab, #99) ─────────────────────
+# Last full request sent to the model, per conversation context — the exact
+# system prompt + history window + tool defs that ran. In-memory only, bounded;
+# the agent sets the context for a turn, generate() records the payload, the
+# admin Inspect tab reads it back. ponytail: process-global dict, fine for one
+# agent process; move onto the agent instance if multi-tenant ever lands.
+_CtxKey = "tuple[str, str, str]"  # (channel, user_id, chat_id)
+_capture_ctx: contextvars.ContextVar = contextvars.ContextVar("mpa_llm_capture_ctx", default=None)
+_LAST_SENT: OrderedDict[tuple[str, str, str], dict[str, Any]] = OrderedDict()
+_CAPTURE_CAP = 100  # ponytail: LRU cap; bump if you watch >100 live chats
+
+
+def set_capture_context(ctx: tuple[str, str, str] | None) -> Any:
+    """Bind the conversation context that generate() should record under.
+
+    Pass ``None`` to suppress capture (e.g. subagents, which run inside the
+    spawner's context but must not overwrite its captured payload). Returns a
+    token for :func:`reset_capture_context`."""
+    return _capture_ctx.set(ctx)
+
+
+def reset_capture_context(token: Any) -> None:
+    _capture_ctx.reset(token)
+
+
+def record_sent_payload(ctx: tuple[str, str, str] | None, payload: dict[str, Any]) -> None:
+    """Store ``payload`` as the last-sent request for ``ctx`` (no-op if None)."""
+    if ctx is None:
+        return
+    _LAST_SENT[ctx] = payload
+    _LAST_SENT.move_to_end(ctx)
+    while len(_LAST_SENT) > _CAPTURE_CAP:
+        _LAST_SENT.popitem(last=False)
+
+
+def get_sent_payload(ctx: tuple[str, str, str]) -> dict[str, Any] | None:
+    return _LAST_SENT.get(ctx)
+
+
+def clear_captured() -> None:
+    """Drop all captured payloads (used by tests)."""
+    _LAST_SENT.clear()
+
 
 _DEFAULT_BASE_URLS = {
     "google": "https://generativelanguage.googleapis.com/v1beta/openai",
@@ -271,6 +318,21 @@ class LLMClient:
         # Collapse any run of consecutive user turns (group rooms record silent
         # turns between replies, #30) so the array honours strict alternation.
         messages = _coalesce_user_messages(messages)
+        # Snapshot the exact request for the Inspect tab (#99). Shallow-copy the
+        # lists so the caller's later mutations (tool-result ping-pong) don't edit
+        # what we stored; each generate() overwrites, so the slot holds last-sent.
+        record_sent_payload(
+            _capture_ctx.get(),
+            {
+                "captured_at": time.time(),
+                "provider": self.provider,
+                "model": resolved_model,
+                "max_tokens": max_tokens,
+                "system": system,
+                "messages": list(messages),
+                "tools": list(tools),
+            },
+        )
         if self.provider == "anthropic":
             client_any = cast(Any, self._client)
             messages_client = cast(Any, getattr(client_any, "messages"))  # type: ignore[attr-defined]

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -38,7 +38,7 @@ Edit agent settings without touching config files:
 
 - **Assistant** — the default identity (agent name, character, personalia), used when no persona is active
 - **Personae** — create, edit, and switch swappable agent identities (see below)
-- **Chats** — list active conversations and bind a persona to each (see below)
+- **Inspect** — list active conversations, bind a persona to each, and view the exact payload last sent to the LLM per context (see below)
 - **LLM** — provider, model, and API key configuration. The model field is free-text (enter any model id the provider supports); a **Fetch models** button on each provider card loads the live model list from the provider API into the field's autocomplete, and **Copy list** copies all available ids. Also configures the background models for memory, goal decomposition, task reflection, and **history compaction** (the model used to summarize old conversation turns — see the History tab for the trigger threshold)
 - **Channels** — enable/disable Telegram and WhatsApp
 - **Calendar** — manage CalDAV providers
@@ -62,9 +62,13 @@ Built-in skill editor for creating, editing, and deleting skill files. Changes t
 
 Manage swappable agent identities — each with its own character, skill allowlist, tool scope, voice, and secret scope. Cards show every persona and the active one; **Use** activates one (applied live to new turns) or revert to **Default** (the Assistant-tab identity). The editor offers a **guided form** (identity, agent name, voice with a **Preview** button and Edge/Kokoro suggestions, skill + tool checkboxes, secret scope) and a **raw markdown** toggle for power users. Six starter personae ship seeded. The page is responsive at phone width. See [Personae](/docs/personae) for the full model.
 
-### Chats
+### Inspect
 
-Lists every active conversation by `channel · user · chat` and lets you bind a persona to a single chat — it overrides the global active persona **there only** (the resolution ladder is per-chat binding → global persona → default identity). Works for any channel (Telegram, WhatsApp, REPL). Pick a persona from the per-chat dropdown to bind, or **Default** to unbind; the change applies on the next turn and the conversation is preserved. With Telegram `topics_enabled`, each forum topic appears as its own `chat:topic` context. The page is responsive at phone width. See [Per-chat personae](/docs/personae#per-chat-personae) for the model.
+The last tab — a developer view of every active context. Lists each conversation by `channel · user · chat` and does two things:
+
+**Bind a persona to a chat.** Pick a persona from the per-chat dropdown to override the global active persona **there only** (the resolution ladder is per-chat binding → global persona → default identity), or **Default** to unbind. Works for any channel (Telegram, WhatsApp, REPL); the change applies on the next turn and the conversation is preserved. With Telegram `topics_enabled`, each forum topic appears as its own `chat:topic` context. See [Per-chat personae](/docs/personae#per-chat-personae) for the model.
+
+**See the exact LLM payload.** Click **Last-sent payload** to view the precise request the agent last sent to the model for that context — the assembled system prompt/identity, the history window, and the full tool definitions, plus the model and `max_tokens`. This is the real inference payload, captured in memory at send time, so it shows exactly what ran (no guessing). It is empty until a context has had a turn since the agent started, and re-clicking refreshes to the latest. Subagent turns are not captured here — only the conversation's own requests. The view is admin-only and shows the payload verbatim; the assembled prompt references secrets by name, not value. The page is responsive at phone width.
 
 ### Memory
 

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -38,7 +38,7 @@ Edit agent settings without touching config files:
 
 - **Assistant** — the default identity (agent name, character, personalia), used when no persona is active
 - **Personae** — create, edit, and switch swappable agent identities (see below)
-- **Inspect** — list active conversations, bind a persona to each, and view the exact payload last sent to the LLM per context (see below)
+- **Inspect** — developer view: a master/detail list of every active context showing the exact payload last sent to the LLM for each (see below)
 - **LLM** — provider, model, and API key configuration. The model field is free-text (enter any model id the provider supports); a **Fetch models** button on each provider card loads the live model list from the provider API into the field's autocomplete, and **Copy list** copies all available ids. Also configures the background models for memory, goal decomposition, task reflection, and **history compaction** (the model used to summarize old conversation turns — see the History tab for the trigger threshold)
 - **Channels** — enable/disable Telegram and WhatsApp
 - **Calendar** — manage CalDAV providers
@@ -64,11 +64,11 @@ Manage swappable agent identities — each with its own character, skill allowli
 
 ### Inspect
 
-The last tab — a developer view of every active context. Lists each conversation by `channel · user · chat` and does two things:
+The last tab — a developer view of every active context, laid out **master/detail**. The left pane lists each conversation by `channel · user · chat`, **most recently used first**, with a relative "last active" time; the one you just messaged floats to the top. Filter the list by channel, user, or chat. Selecting a context loads its detail on the right (the most recent context is selected automatically).
 
-**Bind a persona to a chat.** Pick a persona from the per-chat dropdown to override the global active persona **there only** (the resolution ladder is per-chat binding → global persona → default identity), or **Default** to unbind. Works for any channel (Telegram, WhatsApp, REPL); the change applies on the next turn and the conversation is preserved. With Telegram `topics_enabled`, each forum topic appears as its own `chat:topic` context. See [Per-chat personae](/docs/personae#per-chat-personae) for the model.
+The detail pane shows the **exact payload the agent last sent to the model** for that context — the assembled system prompt/identity, the full tool definitions, and the history window rendered as a transcript (user / assistant / tool-use / tool-result blocks), plus the model and `max_tokens`. A **Raw JSON** section gives the verbatim serialized request for power users (base64 image bytes are elided so the view stays light).
 
-**See the exact LLM payload.** Click **Last-sent payload** to view the precise request the agent last sent to the model for that context — the assembled system prompt/identity, the history window, and the full tool definitions, plus the model and `max_tokens`. This is the real inference payload, captured in memory at send time, so it shows exactly what ran (no guessing). It is empty until a context has had a turn since the agent started, and re-clicking refreshes to the latest. Subagent turns are not captured here — only the conversation's own requests. The view is admin-only and shows the payload verbatim; the assembled prompt references secrets by name, not value. The page is responsive at phone width.
+This is the real inference payload, captured in memory at send time, so it shows exactly what ran — no guessing. It is empty until a context has had a turn since the agent started, and reselecting a context refreshes to the latest. Subagent turns are not captured here, only the conversation's own requests. The view is admin-only and shows the payload verbatim; the assembled prompt references secrets by name, not value. With Telegram `topics_enabled`, each forum topic appears as its own `chat:topic` context. The page is responsive at phone width.
 
 ### Memory
 

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -126,9 +126,11 @@ conversation — it overrides the global one **only there**. Resolution runs a l
 3. the default identity.
 
 Bindings live in the `chat_persona` table and work on **any** channel (Telegram, WhatsApp,
-REPL). Manage them on the **Inspect** tab of the admin UI: it lists every active context and
-lets you pick a persona per chat. A change applies on the next turn; the open chat keeps its
-current identity until then (its messages are preserved).
+REPL). They are set programmatically — by **bot-per-persona** routing and by Telegram
+**topic auto-bind** (below) — rather than hand-picked per chat; the project is moving toward
+**one persona = one agent** (a dedicated `telegram:<persona>` bot per identity), so the admin
+UI no longer offers a per-chat persona dropdown. A binding applies on the next turn; the open
+chat keeps its current identity until then (its messages are preserved).
 
 ### Telegram forum topics (optional)
 
@@ -137,7 +139,7 @@ the Telegram channel setup) to treat each forum topic in a group as its own cont
 topic's `message_thread_id` is folded into the `chat_id`, so every topic gets isolated
 history and its own persona binding; the group's General topic maps to the default context.
 Name a topic after a persona (its name, agent name, or role) and it auto-binds when the topic
-is created or renamed; rebind any topic from the Inspect tab.
+is created or renamed.
 
 ## Bot-per-persona
 

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -126,7 +126,7 @@ conversation — it overrides the global one **only there**. Resolution runs a l
 3. the default identity.
 
 Bindings live in the `chat_persona` table and work on **any** channel (Telegram, WhatsApp,
-REPL). Manage them on the **Chats** tab of the admin UI: it lists every active context and
+REPL). Manage them on the **Inspect** tab of the admin UI: it lists every active context and
 lets you pick a persona per chat. A change applies on the next turn; the open chat keeps its
 current identity until then (its messages are preserved).
 
@@ -137,7 +137,7 @@ the Telegram channel setup) to treat each forum topic in a group as its own cont
 topic's `message_thread_id` is folded into the `chat_id`, so every topic gets isolated
 history and its own persona binding; the group's General topic maps to the default context.
 Name a topic after a persona (its name, agent name, or role) and it auto-binds when the topic
-is created or renamed; rebind any topic from the Chats tab.
+is created or renamed; rebind any topic from the Inspect tab.
 
 ## Bot-per-persona
 

--- a/tests/test_inspect_admin.py
+++ b/tests/test_inspect_admin.py
@@ -12,7 +12,6 @@ from api.admin import AgentState, create_admin_app
 from core import llm
 from core.config_store import ConfigStore
 from core.history import ConversationHistory
-from core.personae import PersonaStore
 
 AUTH = {"Authorization": "Bearer secret"}
 
@@ -51,24 +50,13 @@ class _Store:
 
 
 def _client(tmp_path) -> TestClient:
-    # agent=None so /chats/bind exercises the config-store fallback write path.
     app, _ = create_admin_app(AgentState(agent=None), cast(ConfigStore, _Store(tmp_path)))
     return TestClient(app)
 
 
 async def _seed(tmp_path) -> None:
-    seed = tmp_path / "seed"
-    seed.mkdir()
-    (seed / "coach.md").write_text("---\nrole: Fitness coach\n---\n")
-    store = PersonaStore(db_path=str(tmp_path / "personae.db"), seed_dir=str(seed))
-    await store.ensure_seeded()
     h = ConversationHistory(db_path=str(tmp_path / "history.db"))
     await h.add_turn("telegram", "u1", "user", "hi", "c1")
-
-
-def _binding(tmp_path) -> str | None:
-    h = ConversationHistory(db_path=str(tmp_path / "history.db"))
-    return asyncio.run(h.get_chat_persona("telegram", "u1", "c1"))
 
 
 def test_inspect_partial_lists_active_contexts(tmp_path) -> None:
@@ -77,42 +65,10 @@ def test_inspect_partial_lists_active_contexts(tmp_path) -> None:
     r = client.get("/partials/inspect", headers=AUTH)
     assert r.status_code == 200
     assert "Inspect" in r.text
-    assert "c1" in r.text  # the active chat shows up
-    assert "Fitness coach" in r.text  # persona option available
-    assert "Last-sent payload" in r.text  # payload inspector wired per context
-
-
-def test_bind_and_unbind_persona(tmp_path) -> None:
-    asyncio.run(_seed(tmp_path))
-    client = _client(tmp_path)
-
-    r = client.post(
-        "/chats/bind",
-        json={"channel": "telegram", "user_id": "u1", "chat_id": "c1", "persona": "coach"},
-        headers=AUTH,
-    )
-    assert r.status_code == 200
-    assert _binding(tmp_path) == "coach"
-
-    r = client.post(
-        "/chats/bind",
-        json={"channel": "telegram", "user_id": "u1", "chat_id": "c1", "persona": ""},
-        headers=AUTH,
-    )
-    assert r.status_code == 200
-    assert _binding(tmp_path) is None
-
-
-def test_bind_unknown_persona_404(tmp_path) -> None:
-    asyncio.run(_seed(tmp_path))
-    client = _client(tmp_path)
-    r = client.post(
-        "/chats/bind",
-        json={"channel": "telegram", "user_id": "u1", "chat_id": "c1", "persona": "ghost"},
-        headers=AUTH,
-    )
-    assert r.status_code == 404
-    assert _binding(tmp_path) is None
+    assert "c1" in r.text  # the active chat shows up in the master list
+    assert 'id="inspect-detail"' in r.text  # master/detail layout present
+    # The persona dropdown was removed (one persona = one agent); no bind form.
+    assert "/chats/bind" not in r.text
 
 
 # ── Last-sent payload capture (#99) ─────────────────────────────────────────

--- a/tests/test_inspect_admin.py
+++ b/tests/test_inspect_admin.py
@@ -1,4 +1,5 @@
-"""Admin route tests for the Chats tab: list active contexts + per-chat bind."""
+"""Admin route tests for the Inspect tab: list active contexts, per-chat bind,
+and the last-sent LLM payload view (#99)."""
 
 from __future__ import annotations
 
@@ -8,6 +9,7 @@ from typing import cast
 from fastapi.testclient import TestClient
 
 from api.admin import AgentState, create_admin_app
+from core import llm
 from core.config_store import ConfigStore
 from core.history import ConversationHistory
 from core.personae import PersonaStore
@@ -69,14 +71,15 @@ def _binding(tmp_path) -> str | None:
     return asyncio.run(h.get_chat_persona("telegram", "u1", "c1"))
 
 
-def test_chats_partial_lists_active_contexts(tmp_path) -> None:
+def test_inspect_partial_lists_active_contexts(tmp_path) -> None:
     asyncio.run(_seed(tmp_path))
     client = _client(tmp_path)
-    r = client.get("/partials/chats", headers=AUTH)
+    r = client.get("/partials/inspect", headers=AUTH)
     assert r.status_code == 200
-    assert "Chats" in r.text
+    assert "Inspect" in r.text
     assert "c1" in r.text  # the active chat shows up
     assert "Fitness coach" in r.text  # persona option available
+    assert "Last-sent payload" in r.text  # payload inspector wired per context
 
 
 def test_bind_and_unbind_persona(tmp_path) -> None:
@@ -110,6 +113,76 @@ def test_bind_unknown_persona_404(tmp_path) -> None:
     )
     assert r.status_code == 404
     assert _binding(tmp_path) is None
+
+
+# ── Last-sent payload capture (#99) ─────────────────────────────────────────
+
+
+def test_capture_records_per_context_and_suppresses_when_unset() -> None:
+    llm.clear_captured()
+    ctx = ("telegram", "u1", "c1")
+    tok = llm.set_capture_context(ctx)
+    try:
+        llm.record_sent_payload(llm._capture_ctx.get(), {"model": "m", "messages": [], "tools": []})
+    finally:
+        llm.set_capture_context(None)  # mimic a subagent nulling the context
+        llm.record_sent_payload(llm._capture_ctx.get(), {"model": "child"})
+        llm.reset_capture_context(tok)
+    got = llm.get_sent_payload(ctx)
+    assert got is not None and got["model"] == "m"  # child write was a no-op
+    llm.clear_captured()
+
+
+def test_capture_lru_evicts_oldest() -> None:
+    llm.clear_captured()
+    cap = llm._CAPTURE_CAP
+    for i in range(cap + 5):
+        llm.record_sent_payload(("c", "u", str(i)), {"model": str(i)})
+    assert len(llm._LAST_SENT) == cap
+    assert llm.get_sent_payload(("c", "u", "0")) is None  # oldest evicted
+    assert llm.get_sent_payload(("c", "u", str(cap + 4))) is not None
+    llm.clear_captured()
+
+
+def test_inspect_payload_renders_captured_request(tmp_path) -> None:
+    asyncio.run(_seed(tmp_path))
+    client = _client(tmp_path)
+    llm.clear_captured()
+    llm.record_sent_payload(
+        ("telegram", "u1", "c1"),
+        {
+            "captured_at": 1_700_000_000.0,
+            "provider": "anthropic",
+            "model": "claude-test",
+            "max_tokens": 8192,
+            "system": "SYSTEM_PROMPT_MARKER",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"name": "send_message"}],
+        },
+    )
+    r = client.get(
+        "/inspect/payload",
+        params={"channel": "telegram", "user_id": "u1", "chat_id": "c1"},
+        headers=AUTH,
+    )
+    assert r.status_code == 200
+    assert "claude-test" in r.text
+    assert "SYSTEM_PROMPT_MARKER" in r.text  # the exact system prompt is shown
+    assert "send_message" in r.text  # tool defs included
+    llm.clear_captured()
+
+
+def test_inspect_payload_empty_for_uncaptured_context(tmp_path) -> None:
+    asyncio.run(_seed(tmp_path))
+    client = _client(tmp_path)
+    llm.clear_captured()
+    r = client.get(
+        "/inspect/payload",
+        params={"channel": "telegram", "user_id": "nobody", "chat_id": "none"},
+        headers=AUTH,
+    )
+    assert r.status_code == 200
+    assert "No payload captured yet" in r.text
 
 
 def _wizard(tmp_path, **preset) -> str:

--- a/tests/test_inspect_admin.py
+++ b/tests/test_inspect_admin.py
@@ -125,6 +125,9 @@ def test_inspect_payload_renders_captured_request(tmp_path) -> None:
     assert "claude-test" in r.text
     assert "SYSTEM_PROMPT_MARKER" in r.text  # the exact system prompt is shown
     assert "send_message" in r.text  # tool defs included
+    # Copy + download controls for the raw JSON, with a context-named file.
+    assert "inspectCopyJSON(this)" in r.text
+    assert 'data-filename="inspect-telegram-c1.json"' in r.text
     llm.clear_captured()
 
 

--- a/tests/test_per_chat_persona.py
+++ b/tests/test_per_chat_persona.py
@@ -45,6 +45,27 @@ async def test_list_chats_unions_history_and_bindings(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_chats_orders_most_recent_first(tmp_path) -> None:
+    import aiosqlite
+
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    await h.add_turn("telegram", "u1", "user", "old", "old_chat")
+    await h.add_turn("telegram", "u1", "user", "new", "new_chat")
+    # Force distinct timestamps (datetime('now') is whole-second, so same-second
+    # inserts would tie) — make new_chat unambiguously the most recent.
+    sql = "UPDATE conversation_turns SET created_at=? WHERE chat_id=?"
+    async with aiosqlite.connect(h.db_path) as db:
+        await db.execute(sql, ("2020-01-01 00:00:00", "old_chat"))
+        await db.execute(sql, ("2026-01-01 00:00:00", "new_chat"))
+        await db.commit()
+    chats = await h.list_chats()
+    order = [c["chat_id"] for c in chats]
+    assert order.index("new_chat") < order.index("old_chat")  # newest first
+    by_chat = {c["chat_id"]: c for c in chats}
+    assert by_chat["new_chat"]["last_active"] == "2026-01-01 00:00:00"
+
+
+@pytest.mark.asyncio
 async def test_clear_session_system_keeps_messages(tmp_path) -> None:
     h = ConversationHistory(db_path=str(tmp_path / "h.db"))
     await h.append_session_message("telegram", "u1", {"role": "user", "content": "hi"}, "c1")


### PR DESCRIPTION
Closes #99.

## What

Replaces the **Chats** tab with an **Inspect** tab, moved to the very end of the
nav (after **Logs**). Inspect is aimed at developers: it lists every active
context and lets you see *exactly what was sent to the model for inference* —
the assembled system prompt/identity, the history window, and the full tool
definitions — for that context.

The per-chat persona binding from the old Chats tab is kept (it was already
per-context and still useful), so Inspect does both: bind a persona, and inspect
the payload.

## How

- **Capture (`core/llm.py`).** A single hook in `LLMClient.generate()` — the one
  chokepoint every inference call routes through — snapshots the exact
  `system` / `messages` / `tools` / `model` / `max_tokens` it is about to send,
  keyed by the conversation context. The context is bound by a `contextvars`
  token that `Agent.process()` sets per turn (and resets in `finally`). In-memory
  only, LRU-bounded. This mirrors the existing per-turn contextvar pattern used
  for log streams (#75).
- **No clobbering.** Background helpers (memory extraction, compaction, task
  reflection, goal decomposition) all use `generate_text()`, which is *not*
  hooked. Vision captioning runs before the main call and is overwritten by it.
  Subagents null the capture context so their inference never overwrites the
  spawner's payload.
- **Last-sent, not re-rendered.** This is the real request that ran, captured at
  send time — the simplest, most accurate option from the issue's open question.
- **UI (`api/templates/…`).** `partials/chats.html` → `partials/inspect.html`
  (persona binding kept, payload inspector added); new `partials/inspect_payload.html`
  renders the serialized request on demand via HTMX. `dashboard.html` drops the
  Chats button/route and adds **Inspect** after **Logs**.
- **Routes (`api/admin.py`).** `GET /partials/inspect` and
  `GET /inspect/payload?channel&user_id&chat_id`. The persona-bind endpoint stays
  `POST /chats/bind` (internal API, unchanged — renaming it buys nothing).

## Notes / scope

- The payload view is admin-only (same `Bearer` gate as the rest of the
  dashboard, which already exposes history and redacted secrets). The assembled
  prompt references secrets *by name*, not value, so there is nothing secret in
  system/messages/tool-defs to redact; deeper redaction is deferred (issue's open
  question) and noted in the UI.
- Payloads are captured in memory while the agent runs, so a context shows
  nothing until it has had a turn since startup; re-clicking refreshes to latest.

## Tests

`tests/test_chats_admin.py` → `tests/test_inspect_admin.py`: keeps the bind
coverage and adds capture (per-context record + suppression when unset), LRU
eviction, and the `/inspect/payload` route (renders the captured request; empty
state for an uncaptured context). Full suite green (`uv run pytest`, 738 passed).

## Docs

`docs/.../admin-ui.mdx` and `docs/.../personae.mdx` updated to describe the
Inspect tab and point persona-binding instructions at it.
