### PR TITLE
feat(jobs): scope jobs per persona — show + filter in UI (#101)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1729,8 +1729,9 @@ def create_admin_app(
             raise HTTPException(400, f"Invalid job type: {job_type}")
         if job_type != "memory_consolidation" and not task:
             raise HTTPException(400, "Task is required for agent/system/subagent jobs")
-        # Persona only applies to subagent jobs — don't persist a stray value on others.
-        if job_type != "subagent":
+        # Persona scopes who an agent job runs as (#101); meaningless for a raw
+        # system command or memory consolidation, so don't persist a stray value.
+        if job_type in ("system", "memory_consolidation"):
             persona = ""
 
         if schedule == "cron":

--- a/api/templates/partials/jobs.html
+++ b/api/templates/partials/jobs.html
@@ -1,4 +1,5 @@
 {# Jobs tab partial #}
+{% set job_personas = jobs | map(attribute='persona') | reject('equalto', '') | unique | sort %}
 <div x-data="jobsTab()">
   <div class="flex items-center gap-2 mb-4 flex-wrap">
     <button class="btn btn-sm" hx-get="/partials/jobs" hx-target="#tab-content" hx-swap="innerHTML"
@@ -6,6 +7,15 @@
       Refresh
     </button>
     <span class="text-muted text-xs">{{ jobs|length }} job{{ 's' if jobs|length != 1 else '' }}</span>
+    {% if job_personas %}
+    <select class="input-sm" style="max-width:200px" x-model="personaFilter"
+            title="Filter jobs by the persona they run as">
+      <option value="">All personae</option>
+      {% for p in job_personas %}
+      <option value="{{ p }}">{{ p }}</option>
+      {% endfor %}
+    </select>
+    {% endif %}
     {% if not agent_running %}
     <span class="badge-off text-[0.65rem]">agent stopped — jobs won't run</span>
     {% endif %}
@@ -34,6 +44,7 @@
           <th class="min-w-[120px]">ID</th>
           <th>Schedule</th>
           <th>Type</th>
+          <th>Persona</th>
           <th>Task / Command</th>
           <th class="w-16">Status</th>
           <th class="w-20">Channel</th>
@@ -43,7 +54,7 @@
       </thead>
       <tbody>
         {% for job in jobs %}
-        <tr>
+        <tr x-show="!personaFilter || personaFilter === {{ job.persona|tojson|forceescape }}">
           <td class="text-xs break-all font-medium">
             {{ job.id }}
             {% if job.description %}
@@ -58,6 +69,7 @@
               {{ job.type }}
             </span>
           </td>
+          <td class="text-xs">{{ job.persona or '—' }}</td>
           <td class="text-xs break-all" style="max-width: 320px;">
             <span class="block truncate" title="{{ job.task }}">{{ job.task }}</span>
           </td>
@@ -89,7 +101,7 @@
         </tr>
         {% endfor %}
         {% if not jobs %}
-        <tr><td colspan="8" class="text-muted text-xs text-center py-4">No jobs configured</td></tr>
+        <tr><td colspan="9" class="text-muted text-xs text-center py-4">No jobs configured</td></tr>
         {% endif %}
       </tbody>
     </table>
@@ -141,11 +153,11 @@
           <option value="memory_consolidation">memory_consolidation</option>
         </select>
       </div>
-      <div x-show="form.type === 'subagent'">
+      <div x-show="['agent', 'agent_silent', 'subagent'].includes(form.type)">
         <label class="label">Persona</label>
         <input type="text" class="input-sm" name="persona" x-model="form.persona"
                placeholder="coding-helper">
-        <span class="hint">Persona the subagent adopts (blank = default identity)</span>
+        <span class="hint">Persona this job runs as (blank = default identity)</span>
       </div>
       <div>
         <label class="label">Channel</label>
@@ -199,6 +211,7 @@
 function jobsTab() {
   return {
     editing: false,
+    personaFilter: '',
     form: {
       id: '',
       schedule: 'cron',

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -86,8 +86,9 @@ View, add, edit, and delete permission rules. See current glob patterns and thei
 
 Manage scheduled tasks:
 
-- View all registered jobs with their cron expressions
-- Create new jobs
+- View all registered jobs with their cron expressions and the **persona** each runs as
+- Filter the list by persona to focus on one agent's jobs
+- Create new jobs (optionally scoped to a persona for `agent`/`agent_silent`/`subagent` types)
 - Pause/resume jobs
 - Delete jobs
 - View job execution history

--- a/docs/content/docs/scheduler.mdx
+++ b/docs/content/docs/scheduler.mdx
@@ -137,6 +137,8 @@ Navigate to Jobs in the admin UI to view, create, edit, pause, and delete schedu
 
 By default the list shows only live jobs (`active` and `paused`). Completed and cancelled jobs — including one-time jobs whose time has already passed — are hidden to keep the view clean. Flip the **Show completed** switch to reveal them.
 
+Each row shows the **persona** the job runs as (or `—` for the default identity), and a dropdown narrows the list to a single persona. An `agent`, `agent_silent`, or `subagent` job can be scoped to a persona at create/edit time so it runs under that identity.
+
 ### Via chat
 
 Ask the agent to schedule tasks:

--- a/tests/test_job_store.py
+++ b/tests/test_job_store.py
@@ -24,3 +24,15 @@ def test_list_jobs_sync_filters_by_status(tmp_path) -> None:
 
     only_done = {j["id"] for j in store.list_jobs_sync(status="done")}
     assert only_done == {"d"}
+
+
+def test_persona_persists_and_survives_omitting_edit(tmp_path) -> None:
+    """A job's owning persona round-trips and is sticky across a re-upsert that
+    omits it — the contract the admin/CLI 'edit' path relies on (issue #101)."""
+    store = JobStore(db_path=str(tmp_path / "jobs.db"))
+    store.upsert_job_sync("brief", cron="0 7 * * *", task="t", persona="coach")
+    assert store.get_job_sync("brief")["persona"] == "coach"
+
+    # Re-upsert (e.g. status change) without persona must not wipe it.
+    store.upsert_job_sync("brief", cron="0 7 * * *", task="t", status="paused")
+    assert store.get_job_sync("brief")["persona"] == "coach"

--- a/tools/jobs.py
+++ b/tools/jobs.py
@@ -134,6 +134,7 @@ def cmd_create(args) -> None:
         status="active",
         created_by=args.created_by,
         description=args.description or "",
+        persona=args.persona or "",
     )
     _output(job, args.output)
 
@@ -173,6 +174,8 @@ def cmd_edit(args) -> None:
         updates["status"] = args.status
     if args.description is not None:
         updates["description"] = args.description
+    if args.persona is not None:
+        updates["persona"] = args.persona
 
     if not updates:
         print(json.dumps({"error": "No updates specified"}))
@@ -189,6 +192,7 @@ def cmd_edit(args) -> None:
         "status": updates.get("status", existing["status"]),
         "created_by": existing["created_by"],
         "description": updates.get("description", existing["description"]),
+        "persona": updates.get("persona", existing.get("persona", "")),
     }
 
     job = store.upsert_job_sync(job_id=args.job_id, **merged)
@@ -270,6 +274,7 @@ def main() -> None:
         "--channel", default="telegram", help="Delivery channel (default: telegram)"
     )
     p_create.add_argument("--description", help="Human-readable description of the job")
+    p_create.add_argument("--persona", help="Persona this job runs as (blank = default identity)")
     p_create.add_argument("--created-by", default="agent", help="Who created this job")
     p_create.set_defaults(func=cmd_create)
 
@@ -283,6 +288,7 @@ def main() -> None:
     p_edit.add_argument("--channel", help="New delivery channel")
     p_edit.add_argument("--status", choices=list(VALID_STATUSES), help="New status")
     p_edit.add_argument("--description", help="New description")
+    p_edit.add_argument("--persona", help="New persona this job runs as")
     p_edit.set_defaults(func=cmd_edit)
 
     # -- remove --


### PR DESCRIPTION
Closes #101.

## What

Make the owning persona/agent of a scheduled job a first-class, visible, filterable thing — and stop dropping it on the floor for non-`subagent` jobs.

The `jobs` table already carries a `persona` column (#71). This surfaces it in the UI and ensures every creation path persists it.

## Changes

**Enforcement / scoping**
- `api/admin.py` (`POST /jobs`): persona is no longer wiped for every non-`subagent` type. It's now kept for `agent` / `agent_silent` / `subagent` and only cleared for `system` / `memory_consolidation`, where it's meaningless.
- `tools/jobs.py`: `create` and `edit` gain `--persona`. `edit` carries the existing persona through the merge (so a status-only edit keeps it).
- The agent/chat path (`core/agent.py`, #71) already stamped persona from the originating context — unchanged. The scheduler already runs each job under `job.persona`, so scoping is enforced at run time.

**UI (`api/templates/partials/jobs.html`)**
- New **Persona** column on each job row (`—` for the default identity).
- A persona **filter dropdown** (client-side Alpine, same pattern as the Chats tab) to narrow the list to one persona; only rendered when at least one job has a persona.
- The add/edit form's persona field now shows for `agent` / `agent_silent` / `subagent` (was `subagent`-only), with a generalized hint.

**Docs**
- `admin-ui.mdx` + `scheduler.mdx`: note the persona column, filter, and per-job scoping.

**Tests**
- `tests/test_job_store.py`: persona round-trips and stays sticky across an edit that omits it (the contract admin/CLI edits rely on).

## Verification
- `uv run pytest` → 749 passed.
- Jinja render check of the partial (column, dropdown, escaped row filter, empty-state colspan).
- CLI exercised end-to-end: `create --persona` → `edit --persona` → status-only `edit` keeps persona.