### PR TITLE
feat: scope permissions per agent/persona (#100)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1104,17 +1104,28 @@ def create_admin_app(
             you_personalia=you_personalia,
         )
 
-    @app.get("/partials/permissions", dependencies=[Depends(auth)])
-    async def partial_permissions() -> HTMLResponse:
-        """Permissions tab partial."""
+    async def _render_permissions(scope: str = "") -> HTMLResponse:
+        """Render the permissions tab for one scope (#100): "" = global default,
+        else a persona slug whose own overrides are shown."""
         agent = agent_state.agent
+        store = await _persona_store_from_config(config_store)
+        personae = [p.name for p in await store.list_personae()]
         if agent:
-            rules = agent.permissions.rules
+            rules = agent.permissions.rules_for_scope(scope)
+        elif scope:
+            rules = {}
         else:
             from core.permissions import DEFAULT_RULES
 
             rules = dict(DEFAULT_RULES)
-        return _render_partial("partials/permissions.html", rules=rules)
+        return _render_partial(
+            "partials/permissions.html", rules=rules, scope=scope, personae=personae
+        )
+
+    @app.get("/partials/permissions", dependencies=[Depends(auth)])
+    async def partial_permissions(scope: str = "") -> HTMLResponse:
+        """Permissions tab partial."""
+        return await _render_permissions(scope)
 
     @app.get("/partials/skills", dependencies=[Depends(auth)])
     async def partial_skills() -> HTMLResponse:
@@ -2473,11 +2484,11 @@ def create_admin_app(
     # ── Permissions API ────────────────────────────────────────────────
 
     @app.get("/permissions", dependencies=[Depends(auth)])
-    async def list_permissions() -> dict:
+    async def list_permissions(scope: str = "") -> dict:
         agent = agent_state.agent
         if not agent:
             raise HTTPException(503, "Agent not running")
-        return {"rules": agent.permissions.rules}
+        return {"scope": scope, "rules": agent.permissions.rules_for_scope(scope)}
 
     @app.post("/permissions", dependencies=[Depends(auth)])
     async def upsert_permission(request: Request) -> HTMLResponse:
@@ -2488,10 +2499,10 @@ def create_admin_app(
         body = await request.form()
         pattern = body.get("pattern", "")
         level = body.get("level", "ASK")
+        scope = str(body.get("scope", ""))
         if pattern:
-            agent.permissions.add_rule(str(pattern), str(level))
-        rules = agent.permissions.rules
-        return _render_partial("partials/permissions.html", rules=rules)
+            agent.permissions.add_rule(str(pattern), str(level), scope)
+        return await _render_permissions(scope)
 
     @app.post("/permissions/delete", dependencies=[Depends(auth)])
     async def delete_permission(request: Request) -> HTMLResponse:
@@ -2505,10 +2516,10 @@ def create_admin_app(
         else:
             body = await request.json()
         pattern = str(body.get("pattern", ""))
-        if pattern and pattern in agent.permissions.rules:
-            del agent.permissions.rules[pattern]
-        rules = agent.permissions.rules
-        return _render_partial("partials/permissions.html", rules=rules)
+        scope = str(body.get("scope", ""))
+        if pattern:
+            agent.permissions.remove_rule(pattern, scope)
+        return await _render_permissions(scope)
 
     # ── Skills API ────────────────────────────────────────────────────────
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -1539,6 +1539,8 @@ def create_admin_app(
             return {"ok": False, "error": "Domain is required."}
         if level not in ("ALWAYS", "ASK", "NEVER"):
             level = "ASK"
+        # Global default scope on purpose: a per-domain browser trust toggle applies
+        # to every persona, not just one (#100 scoping is opt-in via the perms tab).
         agent.permissions.add_rule(f"run_command:*browser.py act*{domain}*", level)
         return {"ok": True, "rules": _browser_rules()}
 

--- a/api/templates/partials/permissions.html
+++ b/api/templates/partials/permissions.html
@@ -1,14 +1,34 @@
 {# Permissions tab partial #}
 <div>
-  <div class="flex items-center gap-2 mb-4">
-    <button class="btn btn-sm" hx-get="/partials/permissions" hx-target="#tab-content" hx-swap="innerHTML">
+  <div class="flex items-center gap-2 mb-4 flex-wrap">
+    <button class="btn btn-sm" hx-get="/partials/permissions" hx-target="#tab-content" hx-swap="innerHTML"
+            hx-vals='{"scope": {{ scope|tojson }} }'>
       Refresh
     </button>
+    {# Per-persona scope picker (#100). "" = the default ruleset every persona inherits. #}
+    <div class="flex items-center gap-1.5 ml-auto">
+      <label class="label mb-0">Editing rules for</label>
+      <select class="select" name="scope" style="padding: 0.375rem 2rem 0.375rem 0.5rem; font-size: 0.75rem;"
+              hx-get="/partials/permissions" hx-target="#tab-content" hx-swap="innerHTML" hx-trigger="change">
+        <option value="" {% if not scope %}selected{% endif %}>Default (all personae)</option>
+        {% for p in personae %}
+        <option value="{{ p }}" {% if p == scope %}selected{% endif %}>{{ p }}</option>
+        {% endfor %}
+      </select>
+    </div>
   </div>
+
+  {% if scope %}
+  <p class="text-xs text-muted mb-2">
+    Rules below apply only to <strong>{{ scope }}</strong>. Any action without a rule here
+    falls back to the <em>Default</em> ruleset.
+  </p>
+  {% endif %}
 
   {# Add / update rule #}
   <h3 class="text-xs text-muted uppercase tracking-wider mt-5 mb-2">Add / update rule</h3>
   <form hx-post="/permissions" hx-target="#tab-content" hx-swap="innerHTML">
+    <input type="hidden" name="scope" value="{{ scope }}">
     <div class="flex gap-2 items-end flex-wrap">
       <div class="flex-[2] min-w-[200px]">
         <label class="label">Pattern</label>
@@ -56,7 +76,7 @@
             </button>
             <button class="btn-danger btn-sm ml-0.5"
                     hx-post="/permissions/delete" hx-target="#tab-content" hx-swap="innerHTML"
-                    hx-vals='{"pattern": {{ pattern|tojson }} }'
+                    hx-vals='{"pattern": {{ pattern|tojson }}, "scope": {{ scope|tojson }} }'
                     hx-confirm="Delete permission rule &quot;{{ pattern }}&quot;?">
               x
             </button>
@@ -64,7 +84,9 @@
         </tr>
         {% endfor %}
         {% if not rules %}
-        <tr><td colspan="3" class="text-muted text-xs text-center py-4">No permission rules configured</td></tr>
+        <tr><td colspan="3" class="text-muted text-xs text-center py-4">
+          {% if scope %}No rules for {{ scope }} — it uses the Default ruleset.{% else %}No permission rules configured{% endif %}
+        </td></tr>
         {% endif %}
       </tbody>
     </table>

--- a/core/agent.py
+++ b/core/agent.py
@@ -1996,6 +1996,9 @@ class AgentCore:
         if request_state is None:
             request_state = self._new_request_state()
 
+        # Permission rules are scoped to the active persona (#100); "" = default.
+        persona_scope = request_state.get("persona_name") or ""
+
         is_write_action = self.permissions.is_write_action(name, params)
         # Write-state is tracked per distinct action (tool + params), so a
         # failure, skip, or completion of one write never blocks a different one.
@@ -2030,7 +2033,7 @@ class AgentCore:
             }
 
         # --- Permission check ---
-        level = self.permissions.check(name, params)
+        level = self.permissions.check(name, params, scope=persona_scope)
 
         if level == PermissionLevel.NEVER:
             log.warning("Permission DENIED (NEVER): %s — %s", name, params)
@@ -2055,7 +2058,9 @@ class AgentCore:
             elif not is_write_action and isinstance(approvals, dict) and match_key in approvals:
                 decision = approvals[match_key]
             else:
-                decision = await self._request_approval(name, params, channel, user_id)
+                decision = await self._request_approval(
+                    name, params, channel, user_id, scope=persona_scope
+                )
                 if is_write_action:
                     write_decisions[write_sig] = decision
                 elif isinstance(approvals, dict):
@@ -2081,7 +2086,9 @@ class AgentCore:
                 # command and nullify the allowlist (#79); learn_always_rule
                 # refuses those and keeps asking.
                 self.permissions.learn_always_rule(
-                    self.permissions.match_key(name, params), generalize=False
+                    self.permissions.match_key(name, params),
+                    generalize=False,
+                    scope=persona_scope,
                 )
 
         # --- Dispatch ---
@@ -3327,7 +3334,7 @@ class AgentCore:
         return result
 
     async def _request_approval(
-        self, tool_name: str, params: dict, channel: str, user_id: str
+        self, tool_name: str, params: dict, channel: str, user_id: str, scope: str = ""
     ) -> str:
         """Ask the user to approve a single tool call via their channel.
 
@@ -3339,6 +3346,7 @@ class AgentCore:
             user_id,
             tool_name,
             params,
+            scope=scope,
         )
 
     async def _batch_approve_writes(
@@ -3361,13 +3369,16 @@ class AgentCore:
         """
         if channel == "system" or request_state.get("yolo"):
             return  # YOLO: writes fall through to _execute_tool's auto-approve
+        scope = request_state.get("persona_name") or ""  # per-persona rules (#100)
         write_decisions = request_state.setdefault("write_decisions", {})
         pending: list[tuple[str, str]] = []  # (signature, description)
         seen: set[str] = set()
         for call in tool_calls:
             if not self.permissions.is_write_action(call.name, call.arguments):
                 continue
-            if self.permissions.check(call.name, call.arguments) != PermissionLevel.ASK:
+            if self.permissions.check(call.name, call.arguments, scope=scope) != (
+                PermissionLevel.ASK
+            ):
                 continue
             sig = self._write_signature(call.name, call.arguments)
             if sig in write_decisions or sig in seen:
@@ -3412,6 +3423,7 @@ class AgentCore:
         user_id: str,
         tool_name: str | None = None,
         params: dict | None = None,
+        scope: str = "",
     ) -> str:
         """Send an approval prompt to the channel and wait for the response.
 
@@ -3424,7 +3436,7 @@ class AgentCore:
             log.warning("No channel %r for approval, auto-approving", channel)
             return "approved"
 
-        request_id, future = self.permissions.create_approval_request(tool_name, params)
+        request_id, future = self.permissions.create_approval_request(tool_name, params, scope)
 
         # Send the approval prompt via the channel
         try:

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -274,6 +274,9 @@ class PermissionEngine:
             if cols and "scope" not in cols:
                 # Pre-#100 table keyed by pattern only → rebuild with the composite
                 # key, existing rules becoming the global default scope ("").
+                # Drop any orphan from a prior interrupted migration so the rename
+                # can't fail on startup.
+                db.execute("DROP TABLE IF EXISTS permissions_legacy")
                 db.execute("ALTER TABLE permissions RENAME TO permissions_legacy")
                 db.execute(_CREATE_PERMISSIONS)
                 db.execute(

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -230,12 +230,33 @@ DEFAULT_RULES: dict[str, str] = {
 }
 
 
+# Rules are keyed by (scope, pattern): scope = persona/agent slug, "" = the
+# global default every persona falls back to (#100). SQLite can't add a column
+# to an existing primary key, so the migration in _ensure_schema rebuilds the
+# old single-scope table into this shape with existing rules as the default.
+_CREATE_PERMISSIONS = (
+    "CREATE TABLE IF NOT EXISTS permissions ("
+    "scope TEXT NOT NULL DEFAULT '', pattern TEXT NOT NULL, level TEXT NOT NULL, "
+    "created_at DATETIME DEFAULT (datetime('now')), "
+    "PRIMARY KEY (scope, pattern))"
+)
+
+
 class PermissionEngine:
-    """Check tool actions against permission rules using glob patterns."""
+    """Check tool actions against permission rules using glob patterns.
+
+    Rules are scoped per persona/agent (#100): each persona slug has its own
+    ruleset layered over the global default scope (``""``). ``self.rules`` is the
+    default set (seeded from :data:`DEFAULT_RULES` + persisted ``scope=''`` rows);
+    ``self.scoped`` holds each persona's overrides. A persona-specific rule wins
+    over a default rule of the same pattern; everything else falls back.
+    """
 
     def __init__(self, db_path: str = "data/config.db") -> None:
         self.db_path = db_path
         self.rules: dict[str, str] = dict(DEFAULT_RULES)
+        # persona/agent slug → its own {pattern: level} overrides (#100).
+        self.scoped: dict[str, dict[str, str]] = {}
         self._ready = False
         # Pending approval requests: request_id → PendingApproval
         self._pending: dict[str, PendingApproval] = {}
@@ -249,32 +270,60 @@ class PermissionEngine:
             return
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
         with sqlite3.connect(self.db_path) as db:
-            db.execute(
-                "CREATE TABLE IF NOT EXISTS permissions ("
-                "pattern TEXT PRIMARY KEY, level TEXT NOT NULL, "
-                "created_at DATETIME DEFAULT (datetime('now'))"
-                ")"
-            )
+            cols = {row[1] for row in db.execute("PRAGMA table_info(permissions)").fetchall()}
+            if cols and "scope" not in cols:
+                # Pre-#100 table keyed by pattern only → rebuild with the composite
+                # key, existing rules becoming the global default scope ("").
+                db.execute("ALTER TABLE permissions RENAME TO permissions_legacy")
+                db.execute(_CREATE_PERMISSIONS)
+                db.execute(
+                    "INSERT INTO permissions (scope, pattern, level, created_at) "
+                    "SELECT '', pattern, level, created_at FROM permissions_legacy"
+                )
+                db.execute("DROP TABLE permissions_legacy")
+            else:
+                db.execute(_CREATE_PERMISSIONS)
             db.execute("CREATE TABLE IF NOT EXISTS yolo (scope TEXT PRIMARY KEY)")
         self._ready = True
 
     def _load_persisted_rules(self) -> None:
         self._ensure_schema()
         with sqlite3.connect(self.db_path) as db:
-            rows = db.execute("SELECT pattern, level FROM permissions").fetchall()
-        for pattern, level in rows:
-            if level in (PermissionLevel.ALWAYS, PermissionLevel.ASK, PermissionLevel.NEVER):
+            rows = db.execute("SELECT scope, pattern, level FROM permissions").fetchall()
+        valid = (PermissionLevel.ALWAYS, PermissionLevel.ASK, PermissionLevel.NEVER)
+        for scope, pattern, level in rows:
+            if level not in valid:
+                continue
+            if scope:
+                self.scoped.setdefault(scope, {})[pattern] = level
+            else:
                 self.rules[pattern] = level
 
-    def _persist_rule(self, pattern: str, level: str) -> None:
+    def _persist_rule(self, pattern: str, level: str, scope: str = "") -> None:
         self._ensure_schema()
         with sqlite3.connect(self.db_path) as db:
             db.execute(
-                "INSERT INTO permissions (pattern, level) VALUES (?, ?) "
-                "ON CONFLICT(pattern) DO UPDATE SET level = excluded.level",
-                (pattern, level),
+                "INSERT INTO permissions (scope, pattern, level) VALUES (?, ?, ?) "
+                "ON CONFLICT(scope, pattern) DO UPDATE SET level = excluded.level",
+                (scope, pattern, level),
             )
             db.commit()
+
+    def _effective_rules(self, scope: str = "") -> dict[str, str]:
+        """The rules seen by ``scope``: persona overrides layered over the default.
+
+        No scope (or a persona with no own rules) → the default set unchanged, so
+        the hot ``check()`` path allocates nothing for the common case.
+        """
+        own = self.scoped.get(scope)
+        if not scope or not own:
+            return self.rules
+        return {**self.rules, **own}
+
+    def rules_for_scope(self, scope: str = "") -> dict[str, str]:
+        """Rules OWNED by a scope (for the admin editor): the default set for
+        ``""``, else just that persona's own overrides."""
+        return self.rules if not scope else self.scoped.get(scope, {})
 
     def _load_yolo(self) -> None:
         self._ensure_schema()
@@ -426,14 +475,19 @@ class PermissionEngine:
 
         return False
 
-    def check(self, tool_name: str, params: dict | None = None) -> str:
+    def check(self, tool_name: str, params: dict | None = None, scope: str = "") -> str:
         """Return the permission level for a tool call.
 
         Builds a match key like "run_command:himalaya envelope list ..."
         and checks it against all rules. First match wins, with more
         specific (longer) patterns tried first.
+
+        ``scope`` selects the persona/agent ruleset (#100): its own rules layer
+        over the global default, so a persona can tighten or loosen an action
+        without affecting others. Empty scope = the global default set.
         """
         match_key = self._build_match_key(tool_name, params)
+        rules = self._effective_rules(scope)
 
         # A run_command carrying shell control chars (; | & $() ` < > newline) can
         # chain a SECOND, unapproved command through /bin/sh -c. Such a command may
@@ -445,9 +499,9 @@ class PermissionEngine:
         )
 
         # Sort rules by pattern length descending so more specific rules match first
-        for pattern in sorted(self.rules, key=len, reverse=True):
+        for pattern in sorted(rules, key=len, reverse=True):
             if fnmatch.fnmatch(match_key, pattern):
-                level = self.rules[pattern]
+                level = rules[pattern]
                 if guard_wildcard_allow and level == PermissionLevel.ALWAYS and "*" in pattern:
                     continue  # a wildcard must not auto-approve a chained command
                 return level
@@ -455,15 +509,20 @@ class PermissionEngine:
         # Default: ASK for unknown actions (safe fallback)
         return PermissionLevel.ASK
 
-    def add_rule(self, pattern: str, level: str) -> None:
-        """Add or update a permission rule."""
+    def add_rule(self, pattern: str, level: str, scope: str = "") -> None:
+        """Add or update a permission rule in ``scope`` (default = global)."""
         if level not in (PermissionLevel.ALWAYS, PermissionLevel.ASK, PermissionLevel.NEVER):
             raise ValueError(f"Invalid permission level: {level!r}")
-        self.rules[pattern] = level
-        self._persist_rule(pattern, level)
-        log.info("Permission rule added: %s → %s", pattern, level)
+        if scope:
+            self.scoped.setdefault(scope, {})[pattern] = level
+        else:
+            self.rules[pattern] = level
+        self._persist_rule(pattern, level, scope)
+        log.info("Permission rule added [%s]: %s → %s", scope or "default", pattern, level)
 
-    def learn_always_rule(self, match_key: str, *, generalize: bool = True) -> None:
+    def learn_always_rule(
+        self, match_key: str, *, generalize: bool = True, scope: str = ""
+    ) -> None:
         """Persist an ALWAYS rule learned from a single user approval — but only
         when the key is specific enough to be safe (see :meth:`_may_autolearn`).
 
@@ -471,33 +530,43 @@ class PermissionEngine:
         (the "always allow" button); leave it False to learn the exact command
         (read-action auto-approve). A degenerate/over-broad key is skipped so the
         action keeps asking instead of blanket-whitelisting the whole tool (#79).
+
+        The rule is learned into ``scope`` (the approving persona), so its
+        approval doesn't silently widen other personae. Skipped if the effective
+        ruleset for that scope already covers it.
         """
         pattern = self._rule_pattern(match_key) if generalize else match_key
         if not self._may_autolearn(pattern):
             log.warning("Refusing to auto-learn over-broad ALWAYS rule from %r", match_key)
             return
-        if pattern not in self.rules:
-            self.add_rule(pattern, PermissionLevel.ALWAYS)
+        if pattern not in self._effective_rules(scope):
+            self.add_rule(pattern, PermissionLevel.ALWAYS, scope)
 
-    def remove_rule(self, pattern: str) -> bool:
-        """Remove a permission rule if it exists."""
-        existed = pattern in self.rules
+    def remove_rule(self, pattern: str, scope: str = "") -> bool:
+        """Remove a permission rule from ``scope`` if it exists."""
+        target = self.rules if not scope else self.scoped.get(scope, {})
+        existed = pattern in target
         if existed:
-            del self.rules[pattern]
+            del target[pattern]
             self._ensure_schema()
             with sqlite3.connect(self.db_path) as db:
-                db.execute("DELETE FROM permissions WHERE pattern = ?", (pattern,))
+                db.execute(
+                    "DELETE FROM permissions WHERE scope = ? AND pattern = ?", (scope, pattern)
+                )
                 db.commit()
         return existed
 
     def create_approval_request(
-        self, tool_name: str | None = None, params: dict | None = None
+        self, tool_name: str | None = None, params: dict | None = None, scope: str = ""
     ) -> tuple[str, asyncio.Future[str]]:
         """Create a pending approval request. Returns (request_id, future).
 
         The caller awaits the future. When the user approves/denies via
         a channel callback, resolve_approval() completes the future with
         one of ``"approved"``, ``"denied"``, or ``"skipped"``.
+
+        ``scope`` is the persona that asked, so an "always allow" learns the rule
+        into that persona's ruleset rather than the global default (#100).
         """
         request_id = uuid.uuid4().hex[:12]
         loop = asyncio.get_running_loop()
@@ -509,6 +578,7 @@ class PermissionEngine:
         self._pending[request_id] = {
             "future": future,
             "match_key": self._build_match_key(tool_name, params),
+            "scope": scope,
         }
         return request_id, future
 
@@ -542,7 +612,7 @@ class PermissionEngine:
                 # next (different --url/--task/args) prompts again. See _rule_pattern.
                 # A degenerate key (bare run_command/generate_image) is refused so
                 # one click can't whitelist the whole tool (#79).
-                self.learn_always_rule(match_key, generalize=True)
+                self.learn_always_rule(match_key, generalize=True, scope=entry.get("scope", ""))
         if skipped:
             future.set_result("skipped")
         elif approved:
@@ -555,6 +625,7 @@ class PermissionEngine:
 class PendingApproval(TypedDict):
     future: asyncio.Future[str]
     match_key: str
+    scope: str
 
 
 def _preview(text: str, limit: int = 200) -> str:

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -84,7 +84,7 @@ Both panels include a plain-language "How it works (the science)" explainer.
 
 ### Permissions
 
-View, add, edit, and delete permission rules. See current glob patterns and their levels (ALWAYS / ASK / NEVER).
+View, add, edit, and delete permission rules. See current glob patterns and their levels (ALWAYS / ASK / NEVER). A scope picker switches between the global **Default** ruleset and a specific persona's own [scoped overrides](/docs/permissions#per-persona-scoping).
 
 ### Jobs
 

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -76,6 +76,22 @@ For `run_command` actions, the full CLI command is included after the colon. Thi
 "run_command:sqlite3*/app/data/memory.db*SELECT*": "ALWAYS"
 ```
 
+## Per-persona scoping
+
+Rules are scoped per [persona](/docs/personae). Each persona/agent has its own ruleset layered over a global **Default** scope that every persona falls back to:
+
+- A persona-specific rule **overrides** a Default rule for the same action — so a `coach` persona can be allowed to `git push` while `finance` still has to ask.
+- Any action a persona has **no** rule for resolves through the Default ruleset (which is where the shipped defaults live). Personae without explicit rules behave exactly as before.
+- The hard `NEVER` rails and the wildcard/shell-injection guards apply within whichever ruleset is in effect.
+
+When the agent runs under a persona, its approvals are learned into that persona's scope only — approving a command for `coach` never silently widens it for everyone.
+
+```
+Default scope:   "run_command:git*push*"  → ASK     (shipped default)
+coach scope:     "run_command:git*push*"  → ALWAYS  (override; coach only)
+finance scope:   (no rule)                → falls back to Default → ASK
+```
+
 ## Approval flow
 
 When the agent wants to perform an action with `ASK` permission, it sends a message through the originating channel (typically Telegram) with inline keyboard buttons:
@@ -104,7 +120,7 @@ Agent: Added rule: send_email to simge@example.com → ALWAYS
 
 ### Via admin UI
 
-Navigate to Permissions in the admin UI to view, add, edit, and delete rules.
+Navigate to Permissions in the admin UI to view, add, edit, and delete rules. The scope picker at the top selects which ruleset you're editing — **Default** (every persona's fallback) or a specific persona's own overrides.
 
 ### Via config
 

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -102,9 +102,12 @@ class _AgentStub:
     def __init__(self):
         self.channels = {"telegram": object()}
         self.scheduler = SimpleNamespace(scheduler=SimpleNamespace(get_jobs=lambda: [1, 2]))
+        perm_rules = {"run_command:jq*": "ALWAYS"}
         self.permissions = SimpleNamespace(
-            rules={"run_command:jq*": "ALWAYS"},
-            add_rule=lambda pattern, level: None,
+            rules=perm_rules,
+            add_rule=lambda pattern, level, scope="": perm_rules.__setitem__(pattern, level),
+            remove_rule=lambda pattern, scope="": perm_rules.pop(pattern, None) is not None,
+            rules_for_scope=lambda scope="": perm_rules if not scope else {},
         )
 
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 
 import pytest
 
@@ -222,6 +223,113 @@ async def test_always_allow_button_never_creates_bare_rule(tmp_path) -> None:
     engine.resolve_approval(request_id, True, always_allow=True)
     assert await future == "approved"
     assert "run_command" not in engine.rules
+
+
+# ── Per-persona scoping (#100) ──────────────────────────────────────────────
+
+
+def test_scoped_rule_overrides_default() -> None:
+    # A persona rule wins over a default rule for the same action; other personae
+    # and the default scope are unaffected.
+    engine = PermissionEngine()
+    assert engine.check("send_message", {}) == PermissionLevel.ASK  # default
+    engine.add_rule("send_message", PermissionLevel.ALWAYS, scope="coach")
+    assert engine.check("send_message", {}, scope="coach") == PermissionLevel.ALWAYS
+    assert engine.check("send_message", {}, scope="finance") == PermissionLevel.ASK
+    assert engine.check("send_message", {}) == PermissionLevel.ASK
+
+
+def test_scoped_scope_falls_back_to_default() -> None:
+    # An action with no persona-specific rule resolves through the default set.
+    engine = PermissionEngine()
+    engine.add_rule("send_message", PermissionLevel.ALWAYS, scope="coach")
+    # web_search has no coach rule → default ALWAYS still applies in the scope.
+    assert engine.check("web_search", {}, scope="coach") == PermissionLevel.ALWAYS
+    # Unknown action still defaults to ASK within a scope.
+    assert engine.check("send_fax", {}, scope="coach") == PermissionLevel.ASK
+
+
+def test_scoped_rule_persists_and_isolates(tmp_path) -> None:
+    db = str(tmp_path / "config.db")
+    engine = PermissionEngine(db_path=db)
+    engine.add_rule("run_command:deploy*", PermissionLevel.ALWAYS, scope="coach")
+    engine.add_rule("run_command:deploy*", PermissionLevel.NEVER, scope="finance")
+
+    reloaded = PermissionEngine(db_path=db)
+    assert reloaded.check("run_command", {"command": "deploy now"}, scope="coach") == (
+        PermissionLevel.ALWAYS
+    )
+    assert reloaded.check("run_command", {"command": "deploy now"}, scope="finance") == (
+        PermissionLevel.NEVER
+    )
+    # Same pattern under different scopes coexists (composite key), and the default
+    # scope is untouched by either.
+    assert reloaded.rules_for_scope("coach") == {"run_command:deploy*": "ALWAYS"}
+    assert "run_command:deploy*" not in reloaded.rules
+
+
+def test_remove_scoped_rule_leaves_other_scopes(tmp_path) -> None:
+    db = str(tmp_path / "config.db")
+    engine = PermissionEngine(db_path=db)
+    engine.add_rule("send_message", PermissionLevel.ALWAYS, scope="coach")
+    engine.add_rule("send_message", PermissionLevel.ALWAYS, scope="finance")
+
+    assert engine.remove_rule("send_message", scope="coach") is True
+    assert engine.check("send_message", {}, scope="coach") == PermissionLevel.ASK
+    assert engine.check("send_message", {}, scope="finance") == PermissionLevel.ALWAYS
+    # Gone after a restart too.
+    assert PermissionEngine(db_path=db).check("send_message", {}, scope="finance") == (
+        PermissionLevel.ALWAYS
+    )
+    assert PermissionEngine(db_path=db).rules_for_scope("coach") == {}
+
+
+def test_learn_always_rule_scoped_does_not_widen_default(tmp_path) -> None:
+    db = str(tmp_path / "config.db")
+    engine = PermissionEngine(db_path=db)
+    engine.learn_always_rule("run_command:customtool foo", generalize=False, scope="coach")
+    assert engine.check("run_command", {"command": "customtool foo"}, scope="coach") == (
+        PermissionLevel.ALWAYS
+    )
+    # The default scope (and other personae) keep asking — the approval was scoped.
+    assert "run_command:customtool foo" not in engine.rules
+    assert (
+        engine.check("run_command", {"command": "customtool foo"}, scope="other")
+        == PermissionLevel.ASK
+    )
+
+
+def test_legacy_table_migrates_to_default_scope(tmp_path) -> None:
+    # Pre-#100 DBs key permissions by pattern only. The engine must rebuild that
+    # into the composite-key table with existing rules as the default scope.
+    db = str(tmp_path / "config.db")
+    with sqlite3.connect(db) as raw:
+        raw.execute(
+            "CREATE TABLE permissions ("
+            "pattern TEXT PRIMARY KEY, level TEXT NOT NULL, "
+            "created_at DATETIME DEFAULT (datetime('now')))"
+        )
+        raw.execute(
+            "INSERT INTO permissions (pattern, level) VALUES (?, ?)",
+            ("run_command:legacytool*", "ALWAYS"),
+        )
+        raw.commit()
+
+    engine = PermissionEngine(db_path=db)
+    assert engine.rules.get("run_command:legacytool*") == "ALWAYS"
+    assert engine.check("run_command", {"command": "legacytool go"}) == PermissionLevel.ALWAYS
+    # The composite schema is now in place — a scoped rule reusing the pattern coexists.
+    engine.add_rule("run_command:legacytool*", PermissionLevel.NEVER, scope="coach")
+    assert (
+        PermissionEngine(db_path=db).check(
+            "run_command", {"command": "legacytool go"}, scope="coach"
+        )
+        == PermissionLevel.NEVER
+    )
+    # Migration is one-shot and idempotent: a second open doesn't choke or duplicate.
+    with sqlite3.connect(db) as raw:
+        cols = {row[1] for row in raw.execute("PRAGMA table_info(permissions)").fetchall()}
+    assert "scope" in cols
 
 
 def test_format_approval_message_run_command_includes_purpose() -> None:

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -332,6 +332,27 @@ def test_legacy_table_migrates_to_default_scope(tmp_path) -> None:
     assert "scope" in cols
 
 
+def test_migration_survives_orphan_legacy_table(tmp_path) -> None:
+    # A prior migration that died mid-way can leave a `permissions_legacy` table.
+    # The rename must not crash on the next startup.
+    db = str(tmp_path / "config.db")
+    with sqlite3.connect(db) as raw:
+        raw.execute(
+            "CREATE TABLE permissions ("
+            "pattern TEXT PRIMARY KEY, level TEXT NOT NULL, "
+            "created_at DATETIME DEFAULT (datetime('now')))"
+        )
+        raw.execute(
+            "INSERT INTO permissions (pattern, level) VALUES (?, ?)",
+            ("run_command:legacytool*", "ALWAYS"),
+        )
+        raw.execute("CREATE TABLE permissions_legacy (junk TEXT)")  # orphan
+        raw.commit()
+
+    engine = PermissionEngine(db_path=db)  # must not raise
+    assert engine.rules.get("run_command:legacytool*") == "ALWAYS"
+
+
 def test_format_approval_message_run_command_includes_purpose() -> None:
     engine = PermissionEngine()
     text = engine.format_approval_message(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -513,7 +513,7 @@ def _job_call(call_id: str, **params):
     return LLMToolCall(id=call_id, name="manage_jobs", arguments={"action": "create", **params})
 
 
-async def _approve(name, params, channel, user_id):
+async def _approve(name, params, channel, user_id, scope=""):
     return "approved"
 
 
@@ -747,7 +747,7 @@ async def test_skipping_one_write_does_not_block_a_different_one(agent, monkeypa
     """Skipping a write blocks only that exact action, not other writes."""
     decisions = {"ping mum": "skipped", "ping dad": "approved"}
 
-    async def fake_approval(name, params, channel, user_id):
+    async def fake_approval(name, params, channel, user_id, scope=""):
         return decisions.get(params.get("task"), "approved")
 
     monkeypatch.setattr(agent, "_request_approval", fake_approval)


### PR DESCRIPTION
Closes #100.

## What

Permission rules are now **scoped per persona/agent**, with a global **Default** scope every persona falls back to. A persona-specific rule overrides a Default rule for the same action; any action a persona has no rule for resolves through Default. Personae without explicit rules behave exactly as before.

## How

- **Schema** (`core/permissions.py`): the `permissions` table gains a `scope` column and a composite `(scope, pattern)` primary key. `""` = the global default. A one-shot migration rebuilds the old pattern-only table, moving existing rules into the default scope (SQLite can't add a column to a PK, so it renames → recreates → copies → drops; guarded against an orphan `permissions_legacy` from an interrupted prior run).
- **Engine**: `check()`, `add_rule()`, `remove_rule()`, `learn_always_rule()`, and `create_approval_request()` take a `scope`. `_effective_rules(scope)` layers a persona's own rules over the default, then the existing longest-pattern-wins match runs unchanged — so hard `NEVER` rails and the wildcard/shell-injection guards still hold within whichever ruleset is in effect.
- **Agent** (`core/agent.py`): the active persona (`request_state["persona_name"]`) is threaded into every permission decision — per-call check, batch-write check, read auto-learn, and the "always allow" approval path. An approval is learned into the *approving* persona's scope only, so it never silently widens others.
- **Admin UI** (`api/templates/partials/permissions.html`, `api/admin.py`): a scope picker switches between **Default** and a specific persona's own overrides; add/update/delete operate on the selected scope. Delete now also removes the persisted row (previously memory-only, so user-added rules resurrected on restart).
- **Docs**: new "Per-persona scoping" section in the permissions guide + admin-UI note.

## Tests

`tests/test_permissions.py` covers scoped override, fallback, persistence, cross-persona isolation, scoped auto-learn, the legacy-table migration, and the orphan-legacy guard. Full suite green (757 passed).

## Notes

- The per-domain browser trust toggle stays on the global Default scope on purpose (it's an admin-wide setting); scoping is opt-in via the permissions tab.
- Out of scope: cascading scoped rows when a persona is deleted/renamed — orphan rows are harmless (never matched, since no persona with that slug runs) and can be left for a follow-up if desired.