### PR TITLE
Per-persona email & calendar accounts with delegated access (#110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 ## Features
 
 - **Messaging** — Telegram channel with text and voice messages; WhatsApp as an agent tool (read/send via wacli)
-- **Email** — Read, compose, and manage emails via [Himalaya](https://github.com/pimalaya/himalaya) CLI
-- **Calendar** — CalDAV integration (Google Calendar, iCloud, etc.)
+- **Email** — Read, compose, and manage emails via [Himalaya](https://github.com/pimalaya/himalaya) CLI. Each persona can own a dedicated mailbox or be granted read / read-write access to your inbox; credentials resolve from the vault, never the model's context
+- **Calendar** — CalDAV integration (Google Calendar, iCloud, etc.), bindable per-persona with read / read-write access levels
 - **Contacts** — CardDAV providers via the built-in contacts CLI
-- **Personae** — Swappable agent identities (own character, skill/tool scope, voice). Bind one per chat — and, on Telegram, per forum topic — so several run concurrently, each with its own isolated context. Give a persona its own bot token and it becomes a separate Telegram contact (bot-per-persona); add several persona-bots to one Telegram group and they take turns — each replies only when addressed, ignores other bots so they never loop, and tags who said what in the shared history
+- **Personae** — Swappable agent identities (own character, skill/tool scope, voice, and its own email/calendar accounts). Bind one per chat — and, on Telegram, per forum topic — so several run concurrently, each with its own isolated context. Give a persona its own bot token and it becomes a separate Telegram contact (bot-per-persona); add several persona-bots to one Telegram group and they take turns — each replies only when addressed, ignores other bots so they never loop, and tags who said what in the shared history
 - **Reply decision** — In shared/group chats the agent decides per message whether to reply at all, staying quiet for messages aimed at another bot or caught in a bot-to-bot reaction loop, with a hard rate cap that guarantees runaway loops end (off by default)
 - **Memory** — Two-tier system: permanent long-term facts and expiring short-term context, both extracted automatically from conversations
 - **Scheduled tasks** — Cron-based jobs for morning briefings, email checks, contact sync, and custom tasks

--- a/api/admin.py
+++ b/api/admin.py
@@ -374,6 +374,24 @@ async def _calendar_providers_context(config_store: ConfigStore) -> list[dict[st
     return cleaned
 
 
+async def _email_account_names(config_store: ConfigStore) -> list[str]:
+    """Names of the configured email accounts, for persona-binding UIs (#110)."""
+    raw = await config_store.get("email.providers")
+    if not raw:
+        return []
+    try:
+        providers = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(providers, list):
+        return []
+    return [
+        str(p.get("name", "")).strip()
+        for p in providers
+        if isinstance(p, dict) and str(p.get("name", "")).strip()
+    ]
+
+
 async def _contact_providers_context(config_store: ConfigStore) -> list[dict[str, str]]:
     raw = await config_store.get("contacts.providers")
     if not raw:
@@ -614,6 +632,8 @@ class PersonaUpsertIn(BaseModel):
     bot_token: str = ""  # per-persona Telegram bot (#29); empty = no own bot
     allowed_user_ids: str = ""  # comma/newline-separated; empty = inherit global
     tool_config: dict = {}  # per-persona external-tool config (gh/browser) — #93
+    email_accounts: list[dict] = []  # [{account, access_level, is_sender_identity}] — #110
+    calendar_accounts: list[dict] = []  # [{account, access_level}] — #110
     gh_token: str = ""  # this persona's GitHub PAT → infra vault; empty = leave unchanged
     raw: str = ""  # when set, the markdown doc is parsed instead of the fields above
 
@@ -642,6 +662,26 @@ class ContactProvidersIn(BaseModel):
 
 class EmailProvidersIn(BaseModel):
     providers: list[dict[str, str]]
+
+
+class EmailTestIn(BaseModel):
+    """One email account to probe for IMAP + SMTP reachability (#110)."""
+
+    imap_host: str = ""
+    imap_port: str = "993"
+    smtp_host: str = ""
+    smtp_port: str = "465"
+    login: str = ""
+    email: str = ""
+    password: str = ""
+
+
+class CalendarTestIn(BaseModel):
+    """One CalDAV account to probe for reachability (#110)."""
+
+    url: str = ""
+    username: str = ""
+    password: str = ""
 
 
 class PromptPreviewIn(BaseModel):
@@ -984,6 +1024,12 @@ def create_admin_app(
                 if secret_store and secret_store.infra.available
                 else []
             ),
+            # Email/calendar accounts a persona can be bound to (#110). Names only —
+            # the account registry (Email/Calendar tabs) is the source of truth.
+            "available_email_accounts": await _email_account_names(config_store),
+            "available_calendar_accounts": [
+                p["name"] for p in await _calendar_providers_context(config_store) if p["name"]
+            ],
         }
 
     async def _persona_gh_token_set(name: str) -> bool:
@@ -2328,6 +2374,74 @@ def create_admin_app(
         await config_store.set("email.providers", json.dumps(providers))
         return {"ok": True}
 
+    def _resolve_secret_ref(value: str) -> str:
+        """Expand a ${vault:NAME} reference for a connection test, so a vault-backed
+        password can be verified without ever revealing it to the client (#110)."""
+        if secret_store is None or "${vault:" not in value:
+            return value
+        from core.config import resolve_vault_vars
+
+        return resolve_vault_vars(value, secret_store.infra_resolve)
+
+    @app.post("/email/test", dependencies=[Depends(auth)])
+    async def test_email_account(body: EmailTestIn) -> dict:
+        """Probe IMAP + SMTP login for one account (#110). Returns per-protocol
+        status; the password is resolved from the vault if it is a reference and
+        is never echoed back."""
+        import asyncio
+
+        password = _resolve_secret_ref(body.password.strip())
+        login = body.login.strip() or body.email.strip()
+
+        def _probe() -> dict:
+            import imaplib
+            import smtplib
+
+            out: dict = {"imap": None, "smtp": None}
+            if body.imap_host.strip():
+                try:
+                    port = int(body.imap_port or 993)
+                    with imaplib.IMAP4_SSL(body.imap_host.strip(), port, timeout=10) as m:
+                        m.login(login, password)
+                    out["imap"] = "ok"
+                except Exception as exc:  # noqa: BLE001 — surface the reason to the admin
+                    out["imap"] = f"error: {exc}"
+            if body.smtp_host.strip():
+                try:
+                    port = int(body.smtp_port or 465)
+                    with smtplib.SMTP_SSL(body.smtp_host.strip(), port, timeout=10) as s:
+                        s.login(login, password)
+                    out["smtp"] = "ok"
+                except Exception as exc:  # noqa: BLE001
+                    out["smtp"] = f"error: {exc}"
+            return out
+
+        result = await asyncio.to_thread(_probe)
+        result["ok"] = all(v == "ok" for v in (result["imap"], result["smtp"]) if v is not None)
+        return result
+
+    @app.post("/calendar/test", dependencies=[Depends(auth)])
+    async def test_calendar_account(body: CalendarTestIn) -> dict:
+        """Probe CalDAV reachability for one account (#110): connect and count the
+        calendars found. Vault-backed passwords resolve server-side."""
+        import asyncio
+
+        password = _resolve_secret_ref(body.password.strip())
+
+        def _probe() -> dict:
+            import caldav
+
+            try:
+                client = caldav.DAVClient(
+                    url=body.url.strip(), username=body.username.strip(), password=password
+                )
+                cals = client.principal().calendars()
+                return {"ok": True, "calendars": len(cals)}
+            except Exception as exc:  # noqa: BLE001 — surface the reason to the admin
+                return {"ok": False, "error": str(exc)}
+
+        return await asyncio.to_thread(_probe)
+
     # ── Google Calendar OAuth 2.0 flow ─────────────────────────────────
 
     @app.post("/calendar/google/oauth/save-credentials", dependencies=[Depends(auth)])
@@ -2718,7 +2832,13 @@ def create_admin_app(
 
     @app.post("/personae", dependencies=[Depends(auth)])
     async def upsert_persona(body: PersonaUpsertIn) -> HTMLResponse:
-        from core.personae import Persona, _as_int_list, _as_tool_config, parse_markdown
+        from core.personae import (
+            Persona,
+            _as_account_list,
+            _as_int_list,
+            _as_tool_config,
+            parse_markdown,
+        )
 
         name = body.name.strip()
         if not name:
@@ -2742,6 +2862,8 @@ def create_admin_app(
                 bot_token=body.bot_token.strip(),
                 allowed_user_ids=_as_int_list(body.allowed_user_ids),
                 tool_config=_as_tool_config(body.tool_config),
+                email_accounts=_as_account_list(body.email_accounts, sender=True),
+                calendar_accounts=_as_account_list(body.calendar_accounts),
             )
         # A per-persona GitHub token goes into the infra vault (machine-key,
         # boot-unsealed so it works headless), namespaced per persona (#93). Empty

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -629,7 +629,8 @@
           name: p.name || '',
           url: p.url || '',
           username: p.username || '',
-          password: p.password || ''
+          password: p.password || '',
+          testing: false, testOk: false, testResult: ''
         })),
         status: '',
         result: '',
@@ -649,11 +650,34 @@
             name: '',
             url: '',
             username: '',
-            password: ''
+            password: '',
+            testing: false, testOk: false, testResult: ''
           });
         },
         removeProvider(index) {
           this.providers.splice(index, 1);
+        },
+
+        testProvider(provider) {
+          provider.testing = true; provider.testResult = ''; provider.testOk = false;
+          fetch('/calendar/test', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+            },
+            credentials: 'same-origin',
+            body: JSON.stringify({url: provider.url, username: provider.username, password: provider.password})
+          })
+            .then(async r => { const t = await r.text(); let d = {}; try { d = t ? JSON.parse(t) : {}; } catch (e) { d = {error: t}; } return {ok: r.ok, d}; })
+            .then(({ok, d}) => {
+              provider.testing = false;
+              provider.testOk = ok && !!d.ok;
+              provider.testResult = provider.testOk
+                ? ('Connected — ' + (d.calendars ?? 0) + ' calendar(s)')
+                : (d.error || d.detail || 'Test failed');
+            })
+            .catch(e => { provider.testing = false; provider.testResult = e.message || 'Network error'; });
         },
 
         saveOAuthCreds() {
@@ -931,11 +955,52 @@
           smtp_host: p.smtp_host || '',
           smtp_port: p.smtp_port || '465',
           login: p.login || '',
-          password: p.password || ''
+          password: p.password || '',
+          testing: false, testOk: false, testResult: ''
         })),
         status: '',
         result: '',
         resultOk: false,
+
+        // Common-provider presets so a phone setup is a name + password, nothing
+        // else to look up (#110).
+        presets: {
+          purelymail: {imap_host: 'imap.purelymail.com', imap_port: '993', smtp_host: 'smtp.purelymail.com', smtp_port: '465'},
+          gmail: {imap_host: 'imap.gmail.com', imap_port: '993', smtp_host: 'smtp.gmail.com', smtp_port: '465'},
+          fastmail: {imap_host: 'imap.fastmail.com', imap_port: '993', smtp_host: 'smtp.fastmail.com', smtp_port: '465'}
+        },
+        applyPreset(provider, key) {
+          const p = this.presets[key];
+          if (p) Object.assign(provider, p);
+        },
+
+        testProvider(provider) {
+          provider.testing = true; provider.testResult = ''; provider.testOk = false;
+          fetch('/email/test', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+            },
+            credentials: 'same-origin',
+            body: JSON.stringify({
+              imap_host: provider.imap_host, imap_port: (provider.imap_port || '993').toString(),
+              smtp_host: provider.smtp_host, smtp_port: (provider.smtp_port || '465').toString(),
+              login: provider.login, email: provider.email, password: provider.password
+            })
+          })
+            .then(async r => { const t = await r.text(); let d = {}; try { d = t ? JSON.parse(t) : {}; } catch (e) { d = {error: t}; } return {ok: r.ok, d}; })
+            .then(({ok, d}) => {
+              provider.testing = false;
+              if (!ok) { provider.testResult = d.error || d.detail || 'Test failed'; return; }
+              provider.testOk = !!d.ok;
+              const parts = [];
+              if (d.imap != null) parts.push('IMAP ' + d.imap);
+              if (d.smtp != null) parts.push('SMTP ' + d.smtp);
+              provider.testResult = parts.length ? parts.join(' · ') : 'Nothing to test';
+            })
+            .catch(e => { provider.testing = false; provider.testResult = e.message || 'Network error'; });
+        },
 
         addProvider() {
           this.providers.push({
@@ -948,7 +1013,8 @@
             smtp_host: '',
             smtp_port: '465',
             login: '',
-            password: ''
+            password: '',
+            testing: false, testOk: false, testResult: ''
           });
         },
         removeProvider(index) {

--- a/api/templates/partials/calendars.html
+++ b/api/templates/partials/calendars.html
@@ -101,6 +101,15 @@
             <li>iCloud: Apple ID &gt; App-Specific Passwords, then use the CalDAV URL from iCloud Calendar settings.</li>
             <li>Fastmail/Outlook: find CalDAV URL in account settings, use an app password if available.</li>
           </ul>
+          <p class="mt-1">The app password may be a <code>${vault:NAME}</code> reference to an infra-vault secret.</p>
+        </div>
+
+        <div class="flex items-center gap-2 mt-3 flex-wrap">
+          <button class="btn btn-sm" type="button" @click="testProvider(provider)" :disabled="provider.testing">
+            <span x-show="!provider.testing">Test connection</span>
+            <span x-show="provider.testing">Testing…</span>
+          </button>
+          <span class="text-xs" :class="provider.testOk ? 'text-accent' : 'text-warn'" x-text="provider.testResult"></span>
         </div>
       </div>
     </template>

--- a/api/templates/partials/email.html
+++ b/api/templates/partials/email.html
@@ -17,7 +17,15 @@
             <h4 class="text-sm">Account <span x-text="idx + 1"></span></h4>
             <p class="text-muted text-xs">Give each account a unique name, e.g. personal, work.</p>
           </div>
-          <button class="btn-danger btn-sm" type="button" @click="removeProvider(idx)">Remove</button>
+          <div class="flex items-center gap-2 shrink-0">
+            <select class="select input-sm" style="max-width:150px" @change="applyPreset(provider, $event.target.value); $event.target.value=''">
+              <option value="">Preset…</option>
+              <option value="purelymail">Purelymail</option>
+              <option value="gmail">Gmail</option>
+              <option value="fastmail">Fastmail</option>
+            </select>
+            <button class="btn-danger btn-sm" type="button" @click="removeProvider(idx)">Remove</button>
+          </div>
         </div>
 
         <div class="grid gap-3" style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));">
@@ -67,8 +75,16 @@
           <div>
             <label class="label">App password</label>
             <input type="password" class="input-sm" x-model="provider.password" placeholder="xxxx-xxxx-xxxx-xxxx" autocomplete="new-password">
-            <p class="text-muted text-xs mt-1">Use an app-specific password, not your main login password.</p>
+            <p class="text-muted text-xs mt-1">Use an app-specific password, not your main login password. May be a <code>${vault:NAME}</code> reference to an infra-vault secret.</p>
           </div>
+        </div>
+
+        <div class="flex items-center gap-2 mt-3 flex-wrap">
+          <button class="btn btn-sm" type="button" @click="testProvider(provider)" :disabled="provider.testing">
+            <span x-show="!provider.testing">Test connection</span>
+            <span x-show="provider.testing">Testing…</span>
+          </button>
+          <span class="text-xs" :class="provider.testOk ? 'text-accent' : 'text-warn'" x-text="provider.testResult"></span>
         </div>
 
       </div>

--- a/api/templates/persona_editor.html
+++ b/api/templates/persona_editor.html
@@ -128,6 +128,61 @@
                   placeholder="persona:fitness-coach:*"></textarea>
       </div>
 
+      {# ── Email & calendar accounts (#110) ── #}
+      <div class="card">
+        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Email &amp; calendar accounts</h3>
+        <p class="text-xs text-muted mb-3">
+          Which accounts this persona may use, and at what level. <strong>None</strong> = no access
+          (safe default). <strong>Read</strong> = read only. <strong>Read &amp; write</strong> = also
+          send / create events. Pick one email account as the <strong>sender</strong> identity.
+          Add or edit the accounts themselves in the <strong>Email</strong> / <strong>Calendar</strong> tabs.
+        </p>
+
+        <template x-if="availableEmail.length">
+          <div class="mb-3">
+            <label class="label mb-1">Email</label>
+            <template x-for="acc in availableEmail" :key="acc">
+              <div class="flex items-center justify-between gap-2 mb-1">
+                <span class="text-xs break-all" x-text="acc"></span>
+                <div class="flex items-center gap-2 shrink-0">
+                  <select class="select input-sm" style="max-width:128px" x-model="emailAccess[acc]">
+                    <option value="none">None</option>
+                    <option value="read">Read</option>
+                    <option value="read_write">Read &amp; write</option>
+                  </select>
+                  <label class="flex items-center gap-1 text-xs" :class="emailAccess[acc] === 'none' && 'opacity-40'">
+                    <input type="radio" name="sender-identity" :value="acc" x-model="senderIdentity"
+                           :disabled="emailAccess[acc] === 'none'"> sender
+                  </label>
+                </div>
+              </div>
+            </template>
+          </div>
+        </template>
+        <template x-if="!availableEmail.length">
+          <p class="text-xs text-muted mb-2">No email accounts configured yet — add one in the Email tab.</p>
+        </template>
+
+        <template x-if="availableCalendar.length">
+          <div>
+            <label class="label mb-1">Calendar</label>
+            <template x-for="acc in availableCalendar" :key="acc">
+              <div class="flex items-center justify-between gap-2 mb-1">
+                <span class="text-xs break-all" x-text="acc"></span>
+                <select class="select input-sm" style="max-width:128px" x-model="calAccess[acc]">
+                  <option value="none">None</option>
+                  <option value="read">Read</option>
+                  <option value="read_write">Read &amp; write</option>
+                </select>
+              </div>
+            </template>
+          </div>
+        </template>
+        <template x-if="!availableCalendar.length">
+          <p class="text-xs text-muted">No calendar accounts configured yet — add one in the Calendar tab.</p>
+        </template>
+      </div>
+
       {# ── Tool identities (#93) ── #}
       <div class="card">
         <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Tool identities</h3>
@@ -200,7 +255,7 @@
   <div x-show="mode === 'raw'" class="card">
     <label class="label">Markdown (YAML frontmatter)</label>
     <textarea class="textarea" x-model="raw" style="min-height:460px; font-size:0.8rem; line-height:1.5; tab-size:2"></textarea>
-    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, emoji, voice, bot_token, allowed_user_ids, skills, tools, secrets, character).</p>
+    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, emoji, voice, bot_token, allowed_user_ids, skills, tools, secrets, email_accounts, calendar_accounts, character).</p>
   </div>
 
   <div class="flex items-center gap-2 mt-3">
@@ -243,6 +298,15 @@
       modes: {},
       profiles: {},
 
+      // Per-persona email/calendar account bindings (#110).
+      availableEmail: {{ available_email_accounts|tojson }},
+      availableCalendar: {{ available_calendar_accounts|tojson }},
+      emailBindings: {{ persona.email_accounts|tojson }},
+      calendarBindings: {{ persona.calendar_accounts|tojson }},
+      emailAccess: {},
+      calAccess: {},
+      senderIdentity: '',
+
       init() {
         for (const k of this.toolKeys) {
           const e = this.toolConfig[k];
@@ -250,6 +314,43 @@
           this.profiles[k] = (e && e.profile) || '';
         }
         this.ghTokenSecret = (this.toolConfig.gh && this.toolConfig.gh.token_secret) || '';
+
+        // Seed the account selectors: every known account starts at 'none', then
+        // existing bindings override. A binding to an account no longer in the
+        // registry still shows (so it can be cleaned up).
+        for (const acc of this.availableEmail) this.emailAccess[acc] = 'none';
+        for (const acc of this.availableCalendar) this.calAccess[acc] = 'none';
+        for (const e of this.emailBindings) {
+          if (!(e.account in this.emailAccess)) this.availableEmail.push(e.account);
+          this.emailAccess[e.account] = e.access_level || 'read';
+          if (e.is_sender_identity) this.senderIdentity = e.account;
+        }
+        for (const c of this.calendarBindings) {
+          if (!(c.account in this.calAccess)) this.availableCalendar.push(c.account);
+          this.calAccess[c.account] = c.access_level || 'read';
+        }
+      },
+
+      // Emit the account bindings the API expects; skip 'none'. The sender
+      // identity is always read_write (you cannot send from a read-only account).
+      buildEmailAccounts() {
+        const out = [];
+        for (const acc of this.availableEmail) {
+          const lvl = this.emailAccess[acc];
+          if (!lvl || lvl === 'none') continue;
+          const isSender = this.senderIdentity === acc;
+          out.push({ account: acc, access_level: isSender ? 'read_write' : lvl, is_sender_identity: isSender });
+        }
+        return out;
+      },
+      buildCalendarAccounts() {
+        const out = [];
+        for (const acc of this.availableCalendar) {
+          const lvl = this.calAccess[acc];
+          if (!lvl || lvl === 'none') continue;
+          out.push({ account: acc, access_level: lvl });
+        }
+        return out;
       },
 
       // Only configured tools get an entry; 'inherit' leaves them out so the
@@ -286,6 +387,8 @@
           'tools: ' + list(this.tools) + '\n' +
           'secrets: ' + list(secrets) + '\n' +
           'tool_config: ' + JSON.stringify(this.buildToolConfig()) + '\n' +
+          'email_accounts: ' + JSON.stringify(this.buildEmailAccounts()) + '\n' +
+          'calendar_accounts: ' + JSON.stringify(this.buildCalendarAccounts()) + '\n' +
           'character: |\n  ' + esc(this.character) + '\n' +
           '---\n';
       },
@@ -310,6 +413,8 @@
               secrets: this.secretsText.split('\n').map(s => s.trim()).filter(Boolean),
               bot_token: this.bot_token, allowed_user_ids: this.allowedUserIds,
               tool_config: this.buildToolConfig(), gh_token: ghToken,
+              email_accounts: this.buildEmailAccounts(),
+              calendar_accounts: this.buildCalendarAccounts(),
             };
         fetch('/personae', { method: 'POST', headers: this._headers(), body: JSON.stringify(body) })
           .then(r => { this.ok = r.ok; return r.text().then(t => ({ ok: r.ok, t })); })

--- a/config.yml.example
+++ b/config.yml.example
@@ -45,6 +45,11 @@ channels:
     bridge_url: "local-wacli"
     allowed_numbers: "${WHATSAPP_ALLOWED_NUMBERS}"
 
+# Each account below is a registry entry. Personae bind to accounts by name with a
+# read / read_write access level (Persona editor → "Email & calendar accounts", or the
+# email_accounts / calendar_accounts frontmatter keys). A persona with no bindings has no
+# email/calendar access. Passwords may be ${vault:NAME} references (infra vault) so the
+# credential never sits in config or the model's context. See /docs/personae.
 calendar:
   providers:
     - name: "google"

--- a/core/agent.py
+++ b/core/agent.py
@@ -51,6 +51,7 @@ from core.subagents import (
     SubagentRegistry,
     SubagentRun,
     fallback_summary,
+    narrow_accounts,
     narrow_scope,
     normalize_effort,
     resolve_cap,
@@ -242,7 +243,9 @@ TOOLS = [
             "properties": {
                 "account": {
                     "type": "string",
-                    "description": "Email account name (e.g. 'personal', 'work')",
+                    "description": "Email account name (e.g. 'personal', 'work'). Optional — "
+                    "defaults to the active persona's sender identity. Only accounts the "
+                    "persona is allowed to send from may be used.",
                 },
                 "from": {
                     "type": "string",
@@ -257,7 +260,7 @@ TOOLS = [
                 "subject": {"type": "string"},
                 "body": {"type": "string"},
             },
-            "required": ["account", "to", "subject", "body"],
+            "required": ["to", "subject", "body"],
         },
     },
     {
@@ -268,7 +271,8 @@ TOOLS = [
             "properties": {
                 "account": {
                     "type": "string",
-                    "description": "Email account name (e.g. 'personal', 'work')",
+                    "description": "Email account name (e.g. 'personal', 'work'). Optional — "
+                    "defaults to the active persona's sender identity.",
                 },
                 "message_id": {
                     "type": "string",
@@ -284,7 +288,7 @@ TOOLS = [
                     "description": "Folder the message is in (default: INBOX)",
                 },
             },
-            "required": ["account", "message_id", "body"],
+            "required": ["message_id", "body"],
         },
     },
     {
@@ -368,7 +372,9 @@ TOOLS = [
             "properties": {
                 "calendar": {
                     "type": "string",
-                    "description": "Calendar name (e.g. 'google', 'icloud')",
+                    "description": "Calendar name (e.g. 'google', 'icloud'). Optional — defaults "
+                    "to the active persona's writable calendar. Only calendars the persona "
+                    "has read_write access to may be used.",
                 },
                 "summary": {"type": "string", "description": "Event title"},
                 "start": {"type": "string", "description": "ISO datetime with timezone"},
@@ -379,7 +385,7 @@ TOOLS = [
                     "description": "Optional list of attendee email addresses",
                 },
             },
-            "required": ["calendar", "summary", "start", "end"],
+            "required": ["summary", "start", "end"],
         },
     },
     # Read-only / utility tools
@@ -1397,6 +1403,14 @@ class AgentCore:
             if roster:
                 preamble += f"\n\n{roster}"
 
+        # Which email/calendar accounts this persona may use, so send_email /
+        # create_calendar_event route without guessing account names (#110). Names
+        # and access levels only — credentials never enter the prompt.
+        if persona is not None:
+            note = self._account_note(persona)
+            if note:
+                preamble += f"\n\n{note}"
+
         if self.config.task_reflection.enabled:
             try:
                 reflections = await self.reflections.format_for_prompt()
@@ -2154,13 +2168,13 @@ class AgentCore:
             return await self.executor.run_command(command, tool_env=persona_env)
 
         if name == "send_email":
-            result = await self._tool_send_email(params)
+            result = await self._tool_send_email(params, request_state)
             if is_write_action and self._is_tool_success(result):
                 executed_writes.add(write_sig)
             return result
 
         if name == "reply_email":
-            result = await self._tool_reply_email(params)
+            result = await self._tool_reply_email(params, request_state)
             if is_write_action and self._is_tool_success(result):
                 executed_writes.add(write_sig)
             return result
@@ -2175,7 +2189,7 @@ class AgentCore:
             return await self._tool_set_reaction(params, request_state)
 
         if name == "create_calendar_event":
-            result = await self._tool_create_calendar_event(params)
+            result = await self._tool_create_calendar_event(params, request_state)
             if is_write_action and self._is_tool_success(result):
                 executed_writes.add(write_sig)
             return result
@@ -2349,9 +2363,111 @@ class AgentCore:
 
     # -- Structured tool implementations --
 
-    async def _tool_send_email(self, params: dict) -> dict:
+    @staticmethod
+    def _account_note(persona: Persona) -> str:
+        """Preamble block naming the persona's bound email/calendar accounts and
+        access levels (#110). Names + levels only — never credentials."""
+        lines: list[str] = []
+        if persona.email_accounts:
+            parts = []
+            for e in persona.email_accounts:
+                tag = e["access_level"] + (", sender" if e.get("is_sender_identity") else "")
+                parts.append(f"{e['account']} ({tag})")
+            lines.append("Email accounts: " + ", ".join(parts))
+        if persona.calendar_accounts:
+            parts = [f"{e['account']} ({e['access_level']})" for e in persona.calendar_accounts]
+            lines.append("Calendar accounts: " + ", ".join(parts))
+        if not lines:
+            return ""
+        body = "\n".join(lines)
+        return (
+            "<accounts>\n"
+            "The only email/calendar accounts you may use, with your access level. "
+            "read = read only; read_write = read plus send / create events. send_email "
+            "and reply_email default to your sender identity; create_calendar_event "
+            "defaults to your writable calendar.\n"
+            f"{body}\n"
+            "</accounts>"
+        )
+
+    @staticmethod
+    def _resolve_email_send(
+        persona: Persona | None, params: dict
+    ) -> tuple[str | None, dict | None]:
+        """Route + authorise an email account for a send/reply (#110).
+
+        Returns ``(account, error)``. With no active persona the agent runs
+        unscoped (legacy single-user behaviour) and the requested account is used
+        verbatim. With a persona, the email_accounts bindings are the allowlist:
+        the account defaults to the persona's send identity, an unbound account is
+        refused, and sending on a read-only binding is refused. Credentials are
+        never touched here — only the account *name* is resolved.
+        """
+        account = str(params.get("account") or "").strip()
+        if persona is None:
+            if not account:
+                return None, {"error": "The 'account' parameter is required."}
+            return account, None
+        if not account:
+            account = persona.sender_identity() or ""
+            if not account:
+                return None, {
+                    "error": "This persona has no send email identity. Bind an email "
+                    "account as its sender identity on the persona's admin page."
+                }
+        level = persona.email_access(account)
+        if level is None:
+            return None, {
+                "error": f"This persona is not allowed to use the '{account}' email "
+                "account. Grant it access on the persona's admin page."
+            }
+        if level != "read_write":
+            return None, {
+                "error": f"This persona has read-only access to '{account}' and cannot send email."
+            }
+        return account, None
+
+    @staticmethod
+    def _resolve_calendar_write(
+        persona: Persona | None, params: dict
+    ) -> tuple[str | None, dict | None]:
+        """Route + authorise a calendar for an event write, mirroring
+        :meth:`_resolve_email_send` (#110). Defaults to the persona's first
+        writable calendar; refuses unbound or read-only calendars."""
+        calendar = str(params.get("calendar") or "").strip()
+        if persona is None:
+            if not calendar:
+                return None, {"error": "The 'calendar' parameter is required."}
+            return calendar, None
+        if not calendar:
+            calendar = next(
+                (
+                    e["account"]
+                    for e in persona.calendar_accounts
+                    if e.get("access_level") == "read_write"
+                ),
+                "",
+            )
+            if not calendar:
+                return None, {
+                    "error": "This persona has no writable calendar. Grant it read_write "
+                    "on a calendar account on the persona's admin page."
+                }
+        level = persona.calendar_access(calendar)
+        if level is None:
+            return None, {"error": f"This persona is not allowed to use the '{calendar}' calendar."}
+        if level != "read_write":
+            return None, {
+                "error": f"This persona has read-only access to '{calendar}' and cannot "
+                "create events."
+            }
+        return calendar, None
+
+    async def _tool_send_email(self, params: dict, request_state: dict | None = None) -> dict:
         """Send an email via himalaya CLI."""
-        account = params["account"]
+        account, err = self._resolve_email_send((request_state or {}).get("persona_obj"), params)
+        if err:
+            return err
         to = params["to"]
         subject = params["subject"]
         body = params["body"]
@@ -2377,9 +2493,11 @@ class AgentCore:
         )
         return await self.executor.run_command_trusted(command)
 
-    async def _tool_reply_email(self, params: dict) -> dict:
+    async def _tool_reply_email(self, params: dict, request_state: dict | None = None) -> dict:
         """Reply to an email via himalaya CLI."""
-        account = params["account"]
+        account, err = self._resolve_email_send((request_state or {}).get("persona_obj"), params)
+        if err:
+            return err
         message_id = params["message_id"]
         body = params["body"]
         reply_all = params.get("reply_all", False)
@@ -2611,9 +2729,15 @@ class AgentCore:
             ),
         }
 
-    async def _tool_create_calendar_event(self, params: dict) -> dict:
+    async def _tool_create_calendar_event(
+        self, params: dict, request_state: dict | None = None
+    ) -> dict:
         """Create a calendar event via the CalDAV helper script."""
-        calendar = params["calendar"]
+        calendar, err = self._resolve_calendar_write(
+            (request_state or {}).get("persona_obj"), params
+        )
+        if err:
+            return err
         summary = params["summary"]
         start = params["start"]
         end = params["end"]
@@ -2987,6 +3111,10 @@ class AgentCore:
         p_skills = parent.skills if parent else []
         p_tools = parent.tools if parent else []
         p_secrets = parent.secrets if parent else []
+        # Account bindings pass None (not []) when there is no parent persona, so
+        # narrow_accounts can tell "unscoped owner" from "persona with no access".
+        p_email = parent.email_accounts if parent else None
+        p_cal = parent.calendar_accounts if parent else None
         return Persona(
             name=requested.name,
             agent_name=requested.agent_name,
@@ -3002,6 +3130,10 @@ class AgentCore:
             # scope. Dropping it would silently fall back to the owner's token and
             # re-open the very identity bleed this feature prevents.
             tool_config=requested.tool_config,
+            # Account access is a grant, narrowed to the parent's — a subagent can
+            # never reach an account (or a higher access level) its parent lacks (#110).
+            email_accounts=narrow_accounts(p_email, requested.email_accounts),
+            calendar_accounts=narrow_accounts(p_cal, requested.calendar_accounts),
         )
 
     async def _run_subagent_loop(

--- a/core/config_store.py
+++ b/core/config_store.py
@@ -192,6 +192,9 @@ class ConfigStore:
     def __init__(self, db_path: str = "data/config.db"):
         self.db_path = db_path
         self._ready = False
+        # Optional infra-vault resolver (name -> str | None), attached at boot so
+        # Himalaya materialisation can expand ${vault:NAME} email passwords (#110).
+        self.vault_resolve = None
 
     async def _ensure_schema(self) -> None:
         if self._ready:

--- a/core/email_config.py
+++ b/core/email_config.py
@@ -150,9 +150,12 @@ async def materialize_himalaya_config(config_store) -> bool:
     resolve = getattr(config_store, "vault_resolve", None)
     content = providers_to_toml(providers, resolve)
 
+    # 0600: the file holds resolved account passwords, so keep it owner-only (#110).
     HIMALAYA_CONFIG_PATH.write_text(content)
+    HIMALAYA_CONFIG_PATH.chmod(0o600)
     HIMALAYA_XDG_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     HIMALAYA_XDG_CONFIG_PATH.write_text(content)
+    HIMALAYA_XDG_CONFIG_PATH.chmod(0o600)
     log.info(
         "Materialized Himalaya config (%d accounts) to %s", len(providers), HIMALAYA_CONFIG_PATH
     )

--- a/core/email_config.py
+++ b/core/email_config.py
@@ -34,7 +34,7 @@ def _quote(value: str) -> str:
     return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
 
-def _provider_to_toml(provider: dict, *, is_default: bool = False) -> str:
+def _provider_to_toml(provider: dict, *, is_default: bool = False, resolve=None) -> str:
     """Convert a single provider dict to a Himalaya TOML account section.
 
     Expected provider keys:
@@ -46,8 +46,18 @@ def _provider_to_toml(provider: dict, *, is_default: bool = False) -> str:
         smtp_host    – SMTP server hostname
         smtp_port    – SMTP server port (default 465)
         login        – login username (defaults to email)
-        password     – app password / secret
+        password     – app password / secret; may be a ``${vault:NAME}`` reference
+
+    ``resolve`` (name -> str | None), when given, expands ``${vault:NAME}``
+    references from the infra vault so the account password never sits in the
+    stored config as plaintext (#110). The resolved secret is written only into
+    the Himalaya config file (0600, /tmp) that the CLI reads — it never returns
+    to the model's context or the logs.
     """
+    if resolve is not None:
+        from core.config import resolve_vault_vars
+
+        provider = resolve_vault_vars(provider, resolve)
     name = provider.get("name", "default").strip()
     email = provider.get("email", "").strip()
     display_name = provider.get("display_name", "").strip()
@@ -90,13 +100,16 @@ def _provider_to_toml(provider: dict, *, is_default: bool = False) -> str:
     return "\n".join(lines)
 
 
-def providers_to_toml(providers: list[dict]) -> str:
-    """Generate a complete Himalaya TOML config from a list of providers."""
+def providers_to_toml(providers: list[dict], resolve=None) -> str:
+    """Generate a complete Himalaya TOML config from a list of providers.
+
+    ``resolve`` is threaded to :func:`_provider_to_toml` to expand
+    ``${vault:NAME}`` credential references (#110)."""
     if not providers:
         return ""
     sections: list[str] = []
     for idx, provider in enumerate(providers):
-        sections.append(_provider_to_toml(provider, is_default=(idx == 0)))
+        sections.append(_provider_to_toml(provider, is_default=(idx == 0), resolve=resolve))
     return "\n\n".join(sections) + "\n"
 
 
@@ -131,7 +144,11 @@ async def materialize_himalaya_config(config_store) -> bool:
             removed = True
         return removed
 
-    content = providers_to_toml(providers)
+    # Expand ${vault:NAME} credential references, if a resolver was attached to
+    # the config store (main.py wires config_store.vault_resolve after the infra
+    # vault cache loads). Absent = literal values, preserving prior behaviour (#110).
+    resolve = getattr(config_store, "vault_resolve", None)
+    content = providers_to_toml(providers, resolve)
 
     HIMALAYA_CONFIG_PATH.write_text(content)
     HIMALAYA_XDG_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -140,3 +157,24 @@ async def materialize_himalaya_config(config_store) -> bool:
         "Materialized Himalaya config (%d accounts) to %s", len(providers), HIMALAYA_CONFIG_PATH
     )
     return True
+
+
+if __name__ == "__main__":
+    # ponytail: one runnable check — TOML build + ${vault:} password resolution (#110).
+    prov = {
+        "name": "fitness",
+        "email": "fitness@agent.example.com",
+        "imap_host": "imap.example.com",
+        "smtp_host": "smtp.example.com",
+        "password": "${vault:IMAP_PW_FITNESS}",
+    }
+    plain = _provider_to_toml(prov)
+    assert "${vault:IMAP_PW_FITNESS}" in plain  # unresolved without a resolver
+    resolved = _provider_to_toml(
+        prov, resolve=lambda n: "s3cret" if n == "IMAP_PW_FITNESS" else None
+    )
+    assert "${vault:" not in resolved and "echo -n s3cret" in resolved, resolved
+    # A vault miss leaves the reference literal rather than blanking the field.
+    miss = _provider_to_toml(prov, resolve=lambda n: None)
+    assert "${vault:IMAP_PW_FITNESS}" in miss
+    print("email_config.py self-check OK")

--- a/core/main.py
+++ b/core/main.py
@@ -14,6 +14,7 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import asynccontextmanager
 from os import environ
@@ -67,6 +68,34 @@ async def _start_agent(config_store: ConfigStore):
     if config.scheduler.jobs:
         seed_data = [j.model_dump() for j in config.scheduler.jobs]
         await agent.job_store.seed_from_config(seed_data)
+
+    # -- One-time #110 account-binding migration --
+    # Before #110 any persona could use any configured email/calendar account. Now
+    # an empty binding means no access, so on first start we grant every persona
+    # (that has none yet) full access to all existing accounts, preserving prior
+    # behaviour. Personae created afterwards start empty (safe default). Runs once.
+    if not await config_store.get("accounts.persona_binding_migrated"):
+        from core.personae import bind_existing_accounts
+
+        def _account_names(raw: str | None) -> list[str]:
+            try:
+                items = json.loads(raw) if raw else []
+            except ValueError, TypeError:
+                return []
+            return [
+                str(i.get("name", "")).strip()
+                for i in items
+                if isinstance(i, dict) and str(i.get("name", "")).strip()
+            ]
+
+        n = await bind_existing_accounts(
+            agent.personae,
+            _account_names(await config_store.get("email.providers")),
+            _account_names(await config_store.get("calendar.providers")),
+        )
+        await config_store.set("accounts.persona_binding_migrated", "true")
+        if n:
+            log.info("Bound existing email/calendar accounts to %d persona(s) (#110)", n)
 
     # -- Voice pipeline --
     voice: VoicePipeline | None = None

--- a/core/main.py
+++ b/core/main.py
@@ -205,6 +205,11 @@ async def _lifespan(application):  # noqa: ANN001
     seed_pw = environ.get("ADMIN_PASSWORD") or environ.get("ADMIN_API_KEY")
     if seed_pw:
         await _secret_store.ensure_wrapped_dek(seed_pw)
+    # Load the infra-vault cache and attach its resolver to the config store so the
+    # Himalaya materialisation below can expand ${vault:NAME} email passwords (#110).
+    # Safe with no master key: the cache is empty and infra_resolve falls back to env.
+    await _secret_store.load_infra_cache()
+    _config_store.vault_resolve = _secret_store.infra_resolve
     await materialize_himalaya_config(_config_store)
 
     setup_complete = await _config_store.is_setup_complete()

--- a/core/permissions.py
+++ b/core/permissions.py
@@ -651,7 +651,8 @@ def format_approval_message(tool_name: str, params: dict) -> str:
         subject = params.get("subject", "?")
         return f"Send email to {to}\nSubject: {subject}"
     if tool_name == "reply_email":
-        account = params.get("account", "?")
+        # account is optional now — persona-routed when omitted (#110).
+        account = params.get("account") or "the persona's default account"
         msg_id = params.get("message_id", "?")
         return f"Reply to message {msg_id} on {account}"
     if tool_name == "send_message":

--- a/core/personae.py
+++ b/core/personae.py
@@ -459,6 +459,40 @@ class PersonaStore:
             return cursor.rowcount > 0
 
 
+async def bind_existing_accounts(
+    store: PersonaStore, email_names: list[str], calendar_names: list[str]
+) -> int:
+    """One-time #110 compatibility: bind existing accounts to existing personae.
+
+    Before #110 any persona could use any configured email/calendar account (the
+    tools took an ``account`` argument with no per-persona gate). #110 makes an
+    empty binding mean *no access*, so on upgrade every persona that has **no**
+    bindings yet is granted full (``read_write``) access to all existing accounts —
+    the first email account becomes its sender identity — preserving prior
+    behaviour exactly. Personae created afterwards start empty (safe default).
+    Idempotent: a persona that already has bindings is left untouched, so a re-run
+    (or a persona configured post-migration) is a no-op. Returns the count updated.
+    """
+    updated = 0
+    for p in await store.list_personae():
+        changed = False
+        if email_names and not p.email_accounts:
+            p.email_accounts = [
+                {"account": n, "access_level": "read_write", "is_sender_identity": (i == 0)}
+                for i, n in enumerate(email_names)
+            ]
+            changed = True
+        if calendar_names and not p.calendar_accounts:
+            p.calendar_accounts = [
+                {"account": n, "access_level": "read_write"} for n in calendar_names
+            ]
+            changed = True
+        if changed:
+            await store.upsert(p)
+            updated += 1
+    return updated
+
+
 if __name__ == "__main__":
     # ponytail: one runnable check covering the parse/serialise round-trip + scopes.
     md = """---

--- a/core/personae.py
+++ b/core/personae.py
@@ -40,6 +40,8 @@ CREATE TABLE IF NOT EXISTS personae (
     bot_token TEXT DEFAULT '',
     allowed_user_ids TEXT DEFAULT '',
     tool_config TEXT DEFAULT '',
+    email_accounts TEXT DEFAULT '',
+    calendar_accounts TEXT DEFAULT '',
     created_at DATETIME DEFAULT (datetime('now')),
     updated_at DATETIME DEFAULT (datetime('now'))
 );
@@ -57,6 +59,8 @@ _MIGRATIONS = (
     "ALTER TABLE personae ADD COLUMN bot_token TEXT DEFAULT ''",  # #29
     "ALTER TABLE personae ADD COLUMN allowed_user_ids TEXT DEFAULT ''",  # #29
     "ALTER TABLE personae ADD COLUMN tool_config TEXT DEFAULT ''",  # #93
+    "ALTER TABLE personae ADD COLUMN email_accounts TEXT DEFAULT ''",  # #110
+    "ALTER TABLE personae ADD COLUMN calendar_accounts TEXT DEFAULT ''",  # #110
     # #98: personalia merged into character. Prepend any existing personalia to
     # character (idempotent — the WHERE guard empties it, so a re-run is a no-op),
     # then drop the now-unused column. On a fresh DB (no such column) both raise
@@ -86,12 +90,41 @@ class Persona:
     # Shape: {tool_key: {"enabled": bool, **tool-specific cfg}}. Empty = inherit
     # the system-wide tool config (own credentials/profile fall back to shared).
     tool_config: dict = field(default_factory=dict)
+    # Per-persona email/calendar account bindings (#110). Each email entry is
+    # {account, access_level: read|read_write, is_sender_identity: bool}; each
+    # calendar entry drops the sender flag. Empty = NO email/calendar access
+    # (safe default — a persona reaches only the accounts it is bound to).
+    email_accounts: list[dict] = field(default_factory=list)
+    calendar_accounts: list[dict] = field(default_factory=list)
 
     def allows_skill(self, name: str) -> bool:
         return not self.skills or name in self.skills
 
     def allows_tool(self, name: str) -> bool:
         return not self.tools or name in self.tools
+
+    def email_access(self, account: str) -> str | None:
+        """This persona's access level ('read'/'read_write') on ``account``, or
+        None if it is not bound to that email account (#110)."""
+        for e in self.email_accounts:
+            if e.get("account") == account:
+                return e.get("access_level")
+        return None
+
+    def calendar_access(self, account: str) -> str | None:
+        """This persona's access level on calendar ``account``, or None (#110)."""
+        for e in self.calendar_accounts:
+            if e.get("account") == account:
+                return e.get("access_level")
+        return None
+
+    def sender_identity(self) -> str | None:
+        """The email account this persona sends from (its is_sender_identity
+        binding), or None if it has no send identity (#110)."""
+        for e in self.email_accounts:
+            if e.get("is_sender_identity"):
+                return e.get("account")
+        return None
 
     def tool_setting(self, key: str) -> dict | None:
         """This persona's config for external tool ``key`` (gh/browser), or None
@@ -127,6 +160,53 @@ def _as_tool_config(value: object) -> dict:
             return {}
         return _as_tool_config(loaded)
     return {}
+
+
+_ACCESS_LEVELS = ("read", "read_write")
+
+
+def _as_account_list(value: object, *, sender: bool = False) -> list[dict]:
+    """Coerce a frontmatter / DB-column value into account-binding dicts (#110).
+
+    Accepts a parsed list (frontmatter) or a JSON string (DB column). Each entry
+    normalises to ``{account, access_level}``; for email (``sender=True``) an
+    ``is_sender_identity`` flag is kept too. A bare string is read as a
+    read-only binding. Unknown access levels default to ``read`` (safe). A sender
+    identity is forced to ``read_write`` — you cannot send from a read-only
+    account — and at most one sender identity survives (later ones demoted).
+    Anything malformed drops out so a broken value never breaks load.
+    """
+    if isinstance(value, str) and value.strip():
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError, ValueError:
+            return []
+    if not isinstance(value, (list, tuple)):
+        return []
+    out: list[dict] = []
+    seen: set[str] = set()
+    sender_taken = False
+    for item in value:
+        if isinstance(item, str):
+            item = {"account": item}
+        if not isinstance(item, dict):
+            continue
+        account = str(item.get("account", "") or "").strip()
+        if not account or account in seen:
+            continue
+        seen.add(account)
+        level = str(item.get("access_level", "") or "").strip().lower()
+        if level not in _ACCESS_LEVELS:
+            level = "read"
+        entry: dict = {"account": account, "access_level": level}
+        if sender:
+            is_sender = bool(item.get("is_sender_identity")) and not sender_taken
+            if is_sender:
+                entry["access_level"] = "read_write"  # sending needs write
+                sender_taken = True
+            entry["is_sender_identity"] = is_sender
+        out.append(entry)
+    return out
 
 
 def _as_int_list(value: object) -> list[int]:
@@ -189,6 +269,8 @@ def parse_markdown(text: str, *, name: str) -> Persona:
         bot_token=str(fm.get("bot_token", "") or ""),
         allowed_user_ids=_as_int_list(fm.get("allowed_user_ids")),
         tool_config=_as_tool_config(fm.get("tool_config")),
+        email_accounts=_as_account_list(fm.get("email_accounts"), sender=True),
+        calendar_accounts=_as_account_list(fm.get("calendar_accounts")),
     )
 
 
@@ -205,6 +287,8 @@ def to_markdown(p: Persona) -> str:
         "tools": p.tools,
         "secrets": p.secrets,
         "tool_config": p.tool_config,
+        "email_accounts": p.email_accounts,
+        "calendar_accounts": p.calendar_accounts,
         "character": p.character,
     }
     dumped = yaml.safe_dump(fm, sort_keys=False, allow_unicode=True, default_flow_style=False)
@@ -258,14 +342,16 @@ class PersonaStore:
         await db.execute(
             "INSERT INTO personae "
             "(name, agent_name, role, emoji, voice, character, skills, tools, "
-            "secrets, bot_token, allowed_user_ids, tool_config) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "secrets, bot_token, allowed_user_ids, tool_config, "
+            "email_accounts, calendar_accounts) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(name) DO UPDATE SET "
             "agent_name=excluded.agent_name, role=excluded.role, emoji=excluded.emoji, "
             "voice=excluded.voice, character=excluded.character, "
             "skills=excluded.skills, tools=excluded.tools, secrets=excluded.secrets, "
             "bot_token=excluded.bot_token, allowed_user_ids=excluded.allowed_user_ids, "
-            "tool_config=excluded.tool_config, updated_at=datetime('now')",
+            "tool_config=excluded.tool_config, email_accounts=excluded.email_accounts, "
+            "calendar_accounts=excluded.calendar_accounts, updated_at=datetime('now')",
             (
                 p.name,
                 p.agent_name,
@@ -279,6 +365,8 @@ class PersonaStore:
                 p.bot_token,
                 "\n".join(str(i) for i in p.allowed_user_ids),
                 json.dumps(p.tool_config) if p.tool_config else "",
+                json.dumps(p.email_accounts) if p.email_accounts else "",
+                json.dumps(p.calendar_accounts) if p.calendar_accounts else "",
             ),
         )
 
@@ -299,6 +387,12 @@ class PersonaStore:
                 row["allowed_user_ids"] if "allowed_user_ids" in row.keys() else ""
             ),
             tool_config=_as_tool_config(row["tool_config"] if "tool_config" in row.keys() else ""),
+            email_accounts=_as_account_list(
+                row["email_accounts"] if "email_accounts" in row.keys() else "", sender=True
+            ),
+            calendar_accounts=_as_account_list(
+                row["calendar_accounts"] if "calendar_accounts" in row.keys() else ""
+            ),
         )
 
     async def list_personae(self) -> list[Persona]:
@@ -384,6 +478,15 @@ tool_config:
   browser:
     enabled: true
     profile: forge
+email_accounts:
+  - account: fitness-agent
+    access_level: read_write
+    is_sender_identity: true
+  - account: personal
+    access_level: read
+calendar_accounts:
+  - account: fitness-agent
+    access_level: read_write
 personalia: |
   You are Forge, a strength coach.
 character: |
@@ -408,10 +511,34 @@ Extra prose in the body.
     assert p.tool_setting("browser") == {"enabled": True, "profile": "forge"}
     assert p.tool_setting("weather") is None  # no entry = inherit system config
 
-    # Empty allowlists = allow everything (default persona semantics).
+    # #110: email/calendar account bindings + access levels.
+    assert p.email_access("fitness-agent") == "read_write", p.email_accounts
+    assert p.email_access("personal") == "read"
+    assert p.email_access("work") is None  # not bound = no access
+    assert p.sender_identity() == "fitness-agent", p.sender_identity()
+    assert p.calendar_access("fitness-agent") == "read_write"
+    assert p.calendar_access("personal") is None
+
+    # A read-only account marked as sender is force-upgraded to read_write, and
+    # only the first sender identity survives.
+    coerced = _as_account_list(
+        [
+            {"account": "a", "access_level": "read", "is_sender_identity": True},
+            {"account": "b", "access_level": "read_write", "is_sender_identity": True},
+            "c",  # bare string → read-only binding
+        ],
+        sender=True,
+    )
+    assert coerced[0] == {"account": "a", "access_level": "read_write", "is_sender_identity": True}
+    assert coerced[1]["is_sender_identity"] is False  # second sender demoted
+    assert coerced[2] == {"account": "c", "access_level": "read", "is_sender_identity": False}
+
+    # Empty allowlists = allow everything (default persona semantics)…
     blank = Persona(name="default")
     assert blank.allows_skill("anything") and blank.allows_tool("anything")
     assert blank.tool_setting("gh") is None  # no per-tool config by default
+    # …but no account bindings = NO email/calendar access (safe default, #110).
+    assert blank.email_access("personal") is None and blank.sender_identity() is None
 
     # Round-trip through markdown preserves the structured fields.
     p2 = parse_markdown(to_markdown(p), name="fitness-coach")
@@ -419,4 +546,6 @@ Extra prose in the body.
     assert p2.character.strip() == p.character.strip()
     assert p2.bot_token == p.bot_token and p2.allowed_user_ids == p.allowed_user_ids
     assert p2.tool_config == p.tool_config, p2.tool_config
+    assert p2.email_accounts == p.email_accounts, p2.email_accounts
+    assert p2.calendar_accounts == p.calendar_accounts, p2.calendar_accounts
     print("personae.py self-check OK")

--- a/core/personae.py
+++ b/core/personae.py
@@ -475,21 +475,19 @@ async def bind_existing_accounts(
     """
     updated = 0
     for p in await store.list_personae():
-        changed = False
-        if email_names and not p.email_accounts:
-            p.email_accounts = [
-                {"account": n, "access_level": "read_write", "is_sender_identity": (i == 0)}
-                for i, n in enumerate(email_names)
-            ]
-            changed = True
-        if calendar_names and not p.calendar_accounts:
-            p.calendar_accounts = [
-                {"account": n, "access_level": "read_write"} for n in calendar_names
-            ]
-            changed = True
-        if changed:
-            await store.upsert(p)
-            updated += 1
+        # A persona that already carries any binding was configured deliberately —
+        # leave it alone (so a re-run, or a post-migration persona, is a no-op).
+        if p.email_accounts or p.calendar_accounts:
+            continue
+        if not email_names and not calendar_names:
+            continue
+        p.email_accounts = [
+            {"account": n, "access_level": "read_write", "is_sender_identity": (i == 0)}
+            for i, n in enumerate(email_names)
+        ]
+        p.calendar_accounts = [{"account": n, "access_level": "read_write"} for n in calendar_names]
+        await store.upsert(p)
+        updated += 1
     return updated
 
 

--- a/core/subagents.py
+++ b/core/subagents.py
@@ -100,6 +100,40 @@ def narrow_scope(parent: list[str] | None, child: list[str] | None) -> list[str]
     return [x for x in c if x in p]
 
 
+def narrow_accounts(parent: list[dict] | None, child: list[dict] | None) -> list[dict]:
+    """Intersect a child's email/calendar account bindings with the parent's (#110).
+
+    Unlike :func:`narrow_scope`, account bindings are a *grant* list, not an
+    allowlist: an empty list means *no access*, not *all*. So the semantics are:
+
+    * ``parent is None`` — no parent persona (the spawning turn ran unscoped, i.e.
+      the owner's own full access) → the child keeps its own bindings.
+    * ``parent == []`` — a persona with no account access → the child gets none.
+    * otherwise — keep only accounts the parent also has, at the *lower* of the two
+      access levels, and drop a send identity the parent can't itself write to
+      (inherit-never-widen).
+    """
+    if parent is None:
+        return [dict(e) for e in (child or [])]
+    pmap = {e["account"]: e for e in parent if e.get("account")}
+    out: list[dict] = []
+    for e in child or []:
+        pe = pmap.get(e.get("account"))
+        if not pe:
+            continue  # parent lacks this account → child cannot have it
+        # read_write only if BOTH grant it; otherwise the safer read.
+        level = (
+            "read_write"
+            if pe.get("access_level") == "read_write" and e.get("access_level") == "read_write"
+            else "read"
+        )
+        entry = {**e, "access_level": level}
+        if entry.get("is_sender_identity") and level != "read_write":
+            entry["is_sender_identity"] = False
+        out.append(entry)
+    return out
+
+
 @dataclass(slots=True)
 class SubagentRun:
     """One subagent execution and its live status."""
@@ -282,6 +316,28 @@ def _parse_summary(raw: str) -> tuple[str, str]:
     return notif, digest
 
 
+def _selfcheck() -> None:
+    # ponytail: one runnable check for the scope/account narrowing (#15, #110).
+    assert narrow_scope([], ["a"]) == ["a"]  # empty parent = no restriction
+    assert narrow_scope(["a", "b"], []) == ["a", "b"]  # empty child inherits
+    assert narrow_scope(["a", "b"], ["b", "c"]) == ["b"]  # intersection, never widen
+
+    rw = {"account": "x", "access_level": "read_write", "is_sender_identity": True}
+    ro = {"account": "x", "access_level": "read", "is_sender_identity": False}
+    # No parent persona (unscoped owner) → child keeps its own bindings.
+    assert narrow_accounts(None, [rw]) == [rw]
+    # Parent with no access → child gets nothing.
+    assert narrow_accounts([], [rw]) == []
+    # Parent read-only downgrades the child and strips its send identity.
+    got = narrow_accounts([ro], [rw])
+    assert got == [{"account": "x", "access_level": "read", "is_sender_identity": False}], got
+    # Parent lacks the account entirely → dropped.
+    assert narrow_accounts([{"account": "y", "access_level": "read_write"}], [rw]) == []
+    # Both read_write → preserved.
+    assert narrow_accounts([rw], [rw]) == [rw]
+    print("subagents.py self-check OK")
+
+
 async def summarize_batch(llm, model: str, items: list[SummaryItem]) -> tuple[str, str]:
     """LLM-distil a finished background batch into (notification, digest).
 
@@ -295,3 +351,7 @@ async def summarize_batch(llm, model: str, items: list[SummaryItem]) -> tuple[st
     if not notif:
         return fallback_summary(items)
     return notif, digest or notif
+
+
+if __name__ == "__main__":
+    _selfcheck()

--- a/docs/content/docs/personae.mdx
+++ b/docs/content/docs/personae.mdx
@@ -17,7 +17,8 @@ A persona is exactly these things:
 - a **tool scope** — which function-tools are advertised (empty = all; `load_skill` is always available);
 - a **voice** — a TTS voice override (empty = the configured default);
 - a **secret scope** — which [vault](/docs/secrets) secrets it may use, enforced as a reference-only ACL (a persona may use a secret only if it is shared or named in this scope);
-- **tool identities** — its own credentials and sessions for the external CLI tools (its own GitHub token, its own browser profile), so each persona acts as a distinct identity (see [Tool identities](#tool-identities)).
+- **tool identities** — its own credentials and sessions for the external CLI tools (its own GitHub token, its own browser profile), so each persona acts as a distinct identity (see [Tool identities](#tool-identities));
+- **email & calendar accounts** — which mail/calendar accounts it may use, at `read` or `read_write`, with an optional send identity (empty = no access; see [Email & calendar accounts](#email--calendar-accounts)).
 
 When **no** persona is active, the agent uses the configured `character` from
 the **Assistant** tab — so first-run behaviour is unchanged. The default identity *is* the
@@ -191,6 +192,68 @@ per-persona token requires a master key (configure one in the **Secrets** tab fi
 > Per-persona `gh` isolation assumes **token-based** auth. A shared `gh auth login` writes
 > credentials to `~/.config/gh` (a shared HOME), which token env vars can't override — so
 > authenticate `gh` via per-persona tokens here, not an interactive login.
+
+## Email & calendar accounts
+
+Each persona declares which email and calendar **accounts** it may use, and at what level
+([#110](https://github.com/mattmezza/mpa/issues/110)). The accounts themselves live in the
+**Email** and **Calendar** tabs (the registry); a persona simply **binds** to some of them.
+
+Two shapes of account, one model:
+
+- **Agent-owned** — the persona has its own dedicated mailbox / calendar (e.g. a cheap
+  one-mailbox-per-persona provider). It sends, receives, and schedules as itself.
+- **User-owned (delegated)** — the persona is granted access to *your* personal or work
+  account. Access is per-persona and per-account: persona A may have read-only on your
+  personal inbox, persona B read/write on your work calendar, persona C nothing at all.
+
+Each binding carries an **access level** and, for email, a **sender identity** flag:
+
+- **read** — the persona may read that account only.
+- **read/write** — it may also send email / create calendar events through it.
+- **sender identity** (email only, at most one) — the account the persona sends *from* by
+  default; automatically read/write (you cannot send from a read-only account).
+
+**A persona with no bindings has no email or calendar access** — the safe default. `send_email`,
+`reply_email`, and `create_calendar_event` route to the persona's bound account automatically:
+they default to the sender identity / a writable calendar, so the model rarely passes an
+`account` at all. A call to an unbound account, or a *send* on a read-only binding, is refused
+with a clear error. Which accounts the persona holds (names + levels, never credentials) is
+listed in its per-turn prompt, so it routes without guessing and can answer *"what email
+accounts does the fitness persona have?"* on the go.
+
+In the persona editor, the **Email & calendar accounts** card lists every configured account
+with a **None / Read / Read & write** selector and — for email — a **sender** radio. In raw
+markdown the frontmatter keys are:
+
+```yaml
+email_accounts:
+  - account: fitness-agent      # a name from the Email tab
+    access_level: read_write
+    is_sender_identity: true
+  - account: personal           # delegated, read-only access to your inbox
+    access_level: read
+calendar_accounts:
+  - account: fitness-agent
+    access_level: read_write
+```
+
+**Credentials never touch the model.** An account's password lives in config (encrypted at
+rest) or, better, in the [infra vault](/docs/secrets) referenced as `${vault:NAME}` in the
+account's password field — resolved only when the Himalaya email config is materialised, so it
+reaches the CLI but never the prompt, chat, or logs. Binding levels are enforced at the tool
+boundary, and **subagents inherit-never-widen**: a subagent can reach only accounts its parent
+persona holds, at an equal or lower level.
+
+> **Upgrade note:** before #110 any persona could use any configured account. On the first
+> start after upgrading, every existing persona that has no bindings yet is granted read/write
+> access to all existing accounts (the first email account becomes its sender identity), so
+> nothing breaks. Personae you create afterwards start with **no** access — bind accounts to
+> them explicitly.
+
+> **Test connection.** Adding an account in the Email/Calendar tabs offers provider presets
+> (Purelymail, Gmail, Fastmail; generic CalDAV) and a **Test connection** button that verifies
+> IMAP/SMTP/CalDAV login before you save — completable on a phone in under a minute.
 
 ## Bot-per-persona
 

--- a/tests/test_persona_accounts.py
+++ b/tests/test_persona_accounts.py
@@ -1,0 +1,131 @@
+"""Per-persona email/calendar account bindings + access enforcement (issue #110)."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agent import AgentCore
+from core.personae import Persona, PersonaStore, bind_existing_accounts
+from core.subagents import narrow_accounts
+
+
+# ── Persona model + access helpers ────────────────────────────────────────
+def _persona() -> Persona:
+    return Persona(
+        name="fitness",
+        email_accounts=[
+            {"account": "fitness-agent", "access_level": "read_write", "is_sender_identity": True},
+            {"account": "personal", "access_level": "read"},
+        ],
+        calendar_accounts=[{"account": "fitness-agent", "access_level": "read_write"}],
+    )
+
+
+def test_access_helpers() -> None:
+    p = _persona()
+    assert p.email_access("fitness-agent") == "read_write"
+    assert p.email_access("personal") == "read"
+    assert p.email_access("work") is None
+    assert p.sender_identity() == "fitness-agent"
+    assert p.calendar_access("fitness-agent") == "read_write"
+    assert p.calendar_access("personal") is None
+    # No bindings = no access (safe default).
+    blank = Persona(name="blank")
+    assert blank.email_access("personal") is None and blank.sender_identity() is None
+
+
+# ── Email send routing + enforcement ──────────────────────────────────────
+def test_send_defaults_to_sender_identity() -> None:
+    account, err = AgentCore._resolve_email_send(_persona(), {})
+    assert err is None and account == "fitness-agent"
+
+
+def test_send_from_read_only_account_denied() -> None:
+    account, err = AgentCore._resolve_email_send(_persona(), {"account": "personal"})
+    assert account is None and err and "read-only" in err["error"]
+
+
+def test_send_from_unbound_account_denied() -> None:
+    account, err = AgentCore._resolve_email_send(_persona(), {"account": "work"})
+    assert account is None and err and "not allowed" in err["error"]
+
+
+def test_send_from_writable_account_allowed() -> None:
+    account, err = AgentCore._resolve_email_send(_persona(), {"account": "fitness-agent"})
+    assert err is None and account == "fitness-agent"
+
+
+def test_persona_without_sender_identity_cannot_send() -> None:
+    p = Persona(name="reader", email_accounts=[{"account": "personal", "access_level": "read"}])
+    account, err = AgentCore._resolve_email_send(p, {})
+    assert account is None and err and "sender" in err["error"]
+
+
+def test_no_persona_is_legacy_requires_account() -> None:
+    # Unscoped owner agent: account required, used verbatim (backward compatible).
+    account, err = AgentCore._resolve_email_send(None, {"account": "personal"})
+    assert err is None and account == "personal"
+    account, err = AgentCore._resolve_email_send(None, {})
+    assert account is None and err and "required" in err["error"]
+
+
+# ── Calendar write routing + enforcement ──────────────────────────────────
+def test_calendar_defaults_to_writable() -> None:
+    cal, err = AgentCore._resolve_calendar_write(_persona(), {})
+    assert err is None and cal == "fitness-agent"
+
+
+def test_calendar_read_only_denied() -> None:
+    p = Persona(name="ro", calendar_accounts=[{"account": "shared", "access_level": "read"}])
+    cal, err = AgentCore._resolve_calendar_write(p, {"calendar": "shared"})
+    assert cal is None and err and "read-only" in err["error"]
+
+
+def test_calendar_unbound_denied() -> None:
+    cal, err = AgentCore._resolve_calendar_write(_persona(), {"calendar": "work"})
+    assert cal is None and err and "not allowed" in err["error"]
+
+
+# ── Subagent inherit-never-widen ──────────────────────────────────────────
+def test_narrow_accounts_downgrades_and_drops() -> None:
+    parent = [{"account": "personal", "access_level": "read"}]
+    child = [
+        {"account": "personal", "access_level": "read_write", "is_sender_identity": True},
+        {"account": "work", "access_level": "read_write"},
+    ]
+    out = narrow_accounts(parent, child)
+    # 'work' dropped (parent lacks it); 'personal' downgraded to read and its send
+    # identity stripped (parent can't write it).
+    assert out == [{"account": "personal", "access_level": "read", "is_sender_identity": False}]
+
+
+def test_account_note_lists_bindings_not_credentials() -> None:
+    note = AgentCore._account_note(_persona())
+    assert "fitness-agent (read_write, sender)" in note
+    assert "personal (read)" in note
+    assert "password" not in note.lower()
+
+
+# ── Compat migration + DB round-trip ──────────────────────────────────────
+@pytest.mark.asyncio
+async def test_binding_migration_and_store_roundtrip(tmp_path) -> None:
+    store = PersonaStore(db_path=str(tmp_path / "p.db"), seed_dir=tmp_path / "missing")
+    await store.upsert(Persona(name="coach"))
+    await store.upsert(
+        Persona(name="bound", email_accounts=[{"account": "x", "access_level": "read"}])
+    )
+
+    n = await bind_existing_accounts(store, ["work", "personal"], ["google"])
+    assert n == 1  # only the persona with no bindings is touched
+
+    coach = await store.get("coach")
+    # Full read_write on all accounts; first email = sender identity (behaviour kept).
+    assert coach.email_access("work") == "read_write"
+    assert coach.email_access("personal") == "read_write"
+    assert coach.sender_identity() == "work"
+    assert coach.calendar_access("google") == "read_write"
+
+    # Idempotent: an already-bound persona is left untouched (its read stays read).
+    bound = await store.get("bound")
+    assert bound.email_access("x") == "read" and bound.email_access("work") is None
+    assert await bind_existing_accounts(store, ["work"], []) == 0

--- a/tests/test_personae_admin.py
+++ b/tests/test_personae_admin.py
@@ -107,6 +107,55 @@ def test_persona_crud_and_activation(tmp_path) -> None:
     assert client.get("/personae/coach", headers=AUTH).status_code == 404
 
 
+def test_persona_account_bindings_roundtrip(tmp_path) -> None:
+    client, _ = _client(tmp_path)
+    r = client.post(
+        "/personae",
+        json={
+            "name": "coach",
+            "email_accounts": [
+                {"account": "coach-agent", "access_level": "read", "is_sender_identity": True},
+                {"account": "personal", "access_level": "read"},
+            ],
+            "calendar_accounts": [{"account": "google", "access_level": "read_write"}],
+        },
+        headers=AUTH,
+    )
+    assert r.status_code == 200
+    got = client.get("/personae/coach", headers=AUTH).json()
+    # Sender identity forces read_write (you cannot send from a read-only account).
+    assert got["email_accounts"][0] == {
+        "account": "coach-agent",
+        "access_level": "read_write",
+        "is_sender_identity": True,
+    }
+    assert got["email_accounts"][1]["access_level"] == "read"
+    assert got["calendar_accounts"] == [{"account": "google", "access_level": "read_write"}]
+
+
+def test_persona_editor_lists_available_accounts(tmp_path) -> None:
+    client, _ = _client(tmp_path)
+    client.post("/personae", json={"name": "coach"}, headers=AUTH)
+    # Seed the account registry the editor reads, via the real save routes.
+    client.post(
+        "/email/providers",
+        json={
+            "providers": [
+                {"name": "coach-agent", "email": "c@x.io", "imap_host": "i", "smtp_host": "s"}
+            ]
+        },
+        headers=AUTH,
+    )
+    client.post(
+        "/calendar/providers",
+        json={"providers": [{"name": "google", "url": "u", "username": "c", "password": "p"}]},
+        headers=AUTH,
+    )
+    page = client.get("/admin/personae/coach", headers=AUTH).text
+    assert "Email &amp; calendar accounts" in page  # the binding card renders
+    assert "coach-agent" in page and "google" in page  # available accounts injected
+
+
 def test_persona_raw_markdown_upsert(tmp_path) -> None:
     client, _ = _client(tmp_path)
     # A legacy `personalia:` key still parses — folded into character (#98).

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -563,7 +563,7 @@ async def test_identical_write_is_deduplicated(agent, monkeypatch) -> None:
     """
     from core.llm import LLMToolCall
 
-    async def _ok_send_email(params):
+    async def _ok_send_email(params, request_state=None):
         return {"ok": True}
 
     monkeypatch.setattr(agent, "_request_approval", _approve)

--- a/uv.lock
+++ b/uv.lock
@@ -1048,7 +1048,7 @@ wheels = [
 
 [[package]]
 name = "mpa"
-version = "0.13.0"
+version = "0.14.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Closes #110.

Gives each persona its own email/calendar identity, and lets you delegate read or read/write access to your own accounts — enforced, vault-backed, and safe-by-default.

## What's in it

**Persona facets** — `Persona` gains `email_accounts` and `calendar_accounts` bindings. Each email entry is `{account, access_level: read|read_write, is_sender_identity}`; calendar entries drop the sender flag. Stored as JSON columns (idempotent migrations), round-tripped through markdown frontmatter and the admin JSON API. **Empty bindings = no access** (the safe default).

**Routing + enforcement** — `send_email`, `reply_email`, and `create_calendar_event` resolve their account from the active persona: they default to the sender identity / a writable calendar (so the model rarely passes `account`), refuse an unbound account, and refuse a *send/write* on a `read` binding. No persona = legacy unscoped behaviour (account still required, nothing changes). The `account`/`calendar` params are now optional; a per-turn `<accounts>` preamble lists the persona's bindings + levels (names only) so routing needs no guessing and Telegram can answer "what accounts does the fitness persona have?".

**Vault-backed credentials** — an account password may be a `${vault:NAME}` reference, resolved from the infra vault only when the Himalaya config is materialised (now written `0600`). The secret reaches the CLI but never the prompt, chat, or logs.

**Subagent inherit-never-widen** — `narrow_accounts` intersects a child's bindings with the parent's: an account the parent lacks is dropped, the access level is the lower of the two, and a send identity the parent can't write is stripped. A subagent can never reach more than its parent.

**Backwards compatibility** — a one-time migration (guarded by a config flag) grants every existing persona that has no bindings full access to all existing accounts (first email account = sender identity), preserving the pre-#110 world. Personae created afterwards start empty (safe default).

**Admin UI** — the persona editor gains an "Email & calendar accounts" card (per-account None/Read/Read&write selectors + a sender radio, phone-width). The Email/Calendar tabs gain provider presets (Purelymail/Gmail/Fastmail; generic CalDAV) and a per-account **Test connection** button (`POST /email/test`, `/calendar/test`) that verifies IMAP/SMTP/CalDAV login before saving — vault passwords resolve server-side and are never echoed back.

**Docs** — new "Email & calendar accounts" section in the personae docs, updated README bullets and `config.yml.example`.

## Acceptance criteria

- ✅ A persona sends from its own mailbox with vault-resolved credentials.
- ✅ A persona can be granted `read`/`read_write` on your email/calendar; the level is enforced (a `read` binding cannot send/write).
- ✅ No bindings = no access; the default persona is bound to the existing account (via the migration) to preserve today's behaviour.
- ✅ Adding an account is completable at phone width in under a minute, with provider presets and a connection test.
- ✅ Credentials never appear in model context, chat, or logs.
- ✅ A subagent cannot access accounts its parent persona cannot.

## Deliberate scope boundaries

- **Registry reuse over a new page** — the existing Email and Calendar tabs *are* the account registry; personae bind to them. Rather than build a redundant third "Accounts" page, presets + test-connection were added to those tabs (satisfies the "add an account in under a minute" criterion).
- **Calendar credential vaulting deferred** — `${vault:}` resolution is wired for email (per the acceptance criteria); calendar creds keep their current mechanism (encrypted-at-rest config), consistent with the CalDAV deferral in the vault work (#35). Calendar's binding + access-level enforcement is fully implemented.
- **Inbound per-account polling not included** — not an acceptance criterion. Scheduled tasks already run as a given persona, so "check my mailbox" per-persona works through routing today; a dedicated poller is a follow-up.
- **Generic `run_command` escape hatch** — the structured email/calendar tools are persona-scoped; a persona could still invoke `himalaya`/`calendar_read.py` directly through `run_command`, which remains governed by the permission engine (ASK/NEVER). Per-persona sandboxing of the raw CLIs would need per-persona Himalaya configs — a larger, separate change.

## Testing

- New `tests/test_persona_accounts.py`: access helpers, send/calendar routing + denial paths, `narrow_accounts` escalation cases, the `<accounts>` note, the compat migration, and DB round-trip.
- New cases in `tests/test_personae_admin.py`: binding round-trip through the API and the editor rendering the binding card + available accounts.
- Module self-checks in `core/personae.py`, `core/email_config.py`, `core/subagents.py`.
- Full suite green: **772 passed**.
