### PR TITLE
feat(#114): split LLM settings tab into SysPrompt / Inference / Providers

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -826,23 +826,47 @@ def create_admin_app(
             return await config_store.export_to_config(vault_resolve=secret_store.infra_resolve)
         return await config_store.export_to_config()
 
-    async def _preserve_vault_refs(values: dict) -> dict:
-        """Drop blank/echoed writes to vault-managed secret keys.
+    # LLM provider credential keys that auto-migrate into the vault on save
+    # (issue #114). Base URLs are not secrets and stay as plaintext config.
+    _AUTOVAULT_KEYS = {
+        "agent.anthropic_api_key",
+        "agent.openai_api_key",
+        "agent.google_api_key",
+        "agent.grok_api_key",
+        "agent.deepseek_api_key",
+    }
 
-        Once a credential is migrated its tab shows a read-only "managed in
-        vault" field that submits empty (or echoes the ref). Without this guard
-        that save would overwrite the ``${vault:NAME}`` reference and orphan the
-        secret. A real, freshly-typed value (non-empty, not a ``${…}`` ref) is
-        always allowed through, so re-entering a key still works.
+    async def _preserve_vault_refs(values: dict) -> dict:
+        """Guard vault-managed secret keys on write.
+
+        * Auto-vault (issue #114): a freshly-typed LLM provider key is encrypted
+          into the infra vault and its config value replaced with a
+          ``${vault:NAME}`` reference, so no plaintext provider credential ever
+          lands in the config store. Falls back to plaintext only when no
+          machine key is configured.
+        * Preserve (issue #35): once a credential lives in the vault its tab
+          shows a read-only note that submits empty (or echoes the ref); dropping
+          those writes stops them orphaning the ``${vault:NAME}`` reference. A
+          real, freshly-typed value is always allowed through, so re-entering a
+          key still works.
         """
         from core.secret_store import INFRA_VAULT_KEYS
 
         out = dict(values)
-        for key in INFRA_VAULT_KEYS:
+        for key, vname in INFRA_VAULT_KEYS.items():
             if key not in out:
                 continue
             incoming = str(out[key])
             if incoming and not incoming.startswith("${"):
+                if (
+                    key in _AUTOVAULT_KEYS
+                    and secret_store is not None
+                    and secret_store.infra.available
+                ):
+                    await secret_store.set_infra_secret(
+                        vname, incoming, f"saved from LLM settings ({key})"
+                    )
+                    out[key] = f"${{vault:{vname}}}"
                 continue
             if _is_vault_ref(await config_store.get(key)):
                 del out[key]

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -115,6 +115,12 @@
     function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens, temperature, trMaxReflections) {
       const currentProvider = provider || 'anthropic';
       return {
+        // Sub-tab within the LLM tab (issue #114): sysprompt | inference | providers.
+        // Persisted so switching away and back, or a partial reload after a
+        // provider save, lands on the same sub-tab.
+        section: (() => { try { return localStorage.getItem('llm_section') || 'sysprompt'; } catch (e) { return 'sysprompt'; } })(),
+        setSection(s) { this.section = s; try { localStorage.setItem('llm_section', s); } catch (e) {} },
+        reloadLlmPartial() { if (window.htmx) { htmx.ajax('GET', '/partials/llm', {target: '#tab-content', swap: 'innerHTML'}); } },
         providerOptions: [
           {value: 'anthropic', label: 'Anthropic'},
           {value: 'openai', label: 'OpenAI'},

--- a/api/templates/partials/llm.html
+++ b/api/templates/partials/llm.html
@@ -26,7 +26,7 @@
         <p class="text-amber-600 text-xs mt-1" x-show="{{ level }} && !modelSupportsThinking({{ model }})">Heads up: “<span x-text="{{ model }}"></span>” isn't a recognized reasoning model — only set a level if you know it supports thinking, or the inference call may error.</p>
       </div>
 {%- endmacro %}
-<div class="space-y-6" x-data="llmTab(
+<div x-data="llmTab(
   {{ provider|default('anthropic', true)|tojson|forceescape }},
   {{ anthropic_api_key|default('', true)|tojson|forceescape }},
   {{ model|default('', true)|tojson|forceescape }},
@@ -75,9 +75,17 @@
   {{ temperature|default('0.5', true)|tojson|forceescape }},
   {{ tr_max_reflections|default('12', true)|tojson|forceescape }}
 )">
+  {# Sub-tabs (issue #114): split the crowded LLM settings into three views. #}
+  <div class="flex border-b border-border mb-4 overflow-x-auto">
+    <button type="button" class="tab-link" :class="section === 'sysprompt' && 'tab-link-active'" @click="setSection('sysprompt')">SysPrompt</button>
+    <button type="button" class="tab-link" :class="section === 'inference' && 'tab-link-active'" @click="setSection('inference')">Inference</button>
+    <button type="button" class="tab-link" :class="section === 'providers' && 'tab-link-active'" @click="setSection('providers')">Providers</button>
+  </div>
+
+  <div class="space-y-6" x-show="section === 'sysprompt'">
   <div class="card">
     <h2 class="text-base mb-1">System Prompt Controls</h2>
-    <p class="text-muted text-xs mb-4">Preview the full assembled system prompt, edit override blocks, compare against defaults, and optionally capture recent runtime prompts.</p>
+    <p class="text-muted text-xs mb-4">Preview the full assembled system prompt, edit override blocks, compare against defaults, and optionally capture recent runtime prompts. Debugging a live run? The <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'inspect')">Inspect</button> tab shows the exact last-sent payload per chat.</p>
 
     <form class="space-y-4" @submit.prevent>
       <div class="space-y-2">
@@ -195,7 +203,9 @@
       </template>
     </div>
   </div>
+  </div>{# /sysprompt #}
 
+  <div class="space-y-6" x-show="section === 'inference'" style="display:none">
   <div class="card">
     <h2 class="text-base mb-1">Active Inference Provider</h2>
     <p class="text-muted text-xs mb-4">Select the provider used for agent inference after testing its connection.</p>
@@ -219,7 +229,7 @@
             <option :value="item.value"></option>
           </template>
         </datalist>
-        <p class="text-muted text-xs mt-1">Type any model id, or pick from the list. Use “Fetch models” in the provider card below to load the live list from the API.</p>
+        <p class="text-muted text-xs mt-1">Type any model id, or pick from the list. Use “Fetch models” in the provider card on the <button type="button" class="text-accent hover:underline" @click="setSection('providers')">Providers</button> tab to load the live list from the API.</p>
 
         {# Native-vision indicator + one-tap vision-fallback prompt. #}
         <p class="text-muted text-xs mt-1" x-show="model && modelSupportsVision(model, provider)">
@@ -264,15 +274,6 @@
                   },
                   body: JSON.stringify({values: {
                     'agent.llm_provider': provider,
-                    'agent.anthropic_api_key': apiKey,
-                    'agent.openai_api_key': openaiKey,
-                    'agent.openai_base_url': openaiBaseUrl,
-                    'agent.google_api_key': googleKey,
-                    'agent.google_base_url': googleBaseUrl,
-                    'agent.grok_api_key': grokKey,
-                    'agent.grok_base_url': grokBaseUrl,
-                    'agent.deepseek_api_key': deepseekKey,
-                    'agent.deepseek_base_url': deepseekBaseUrl,
                     'agent.model': model,
                     'agent.thinking_level': thinkingLevel,
                     'agent.max_tokens': String(maxTokens),
@@ -691,7 +692,12 @@
       <div :class="visionResultOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="visionResult"></div>
     </template>
   </div>
+  </div>{# /inference #}
 
+  <div class="space-y-6" x-show="section === 'providers'" style="display:none">
+  <div class="mb-2 rounded border border-border bg-muted/10 px-3 py-2 text-muted text-xs">
+    🔒 Provider API keys are stored in the <strong>Secrets</strong> vault on save — only a <code>${vault:NAME}</code> reference is kept in config, never the raw key. Manage or reuse them from the <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'secrets')">Secrets</button> tab.
+  </div>
   <div class="card">
     <h2 class="text-base mb-1">Anthropic</h2>
     <p class="text-muted text-xs mb-4">Configure the Anthropic API key and test the connection.</p>
@@ -701,7 +707,7 @@
         <input type="text" class="input-sm" style="max-width:500px; display:none"
                autocomplete="username" aria-hidden="true" tabindex="-1">
         {% if anthropic_vaulted %}
-        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault — manage it there.</div>
+        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault as <code>${vault:ANTHROPIC_API_KEY}</code> for easy reuse — manage it from the <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'secrets')">Secrets</button> tab.</div>
         {% else %}
         <input type="password" class="input-sm" style="max-width:500px"
                autocomplete="new-password"
@@ -746,6 +752,7 @@
                 .then(d => {
                   result = resultOk ? 'Anthropic settings saved' : (d.detail || 'Error');
                   if (resultOk && window.showToast) { window.showToast('Anthropic settings saved'); }
+                  if (resultOk) { reloadLlmPartial(); }
                 })
                 .catch(e => { resultOk = false; result = e.message; })
               ">
@@ -761,7 +768,7 @@
       <div>
         <label class="label">OpenAI API Key</label>
         {% if openai_vaulted %}
-        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault — manage it there.</div>
+        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault as <code>${vault:OPENAI_API_KEY}</code> for easy reuse — manage it from the <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'secrets')">Secrets</button> tab.</div>
         {% else %}
         <input type="password" class="input-sm" style="max-width:500px"
                autocomplete="new-password"
@@ -812,6 +819,7 @@
                 .then(d => {
                   result = resultOk ? 'OpenAI settings saved' : (d.detail || 'Error');
                   if (resultOk && window.showToast) { window.showToast('OpenAI settings saved'); }
+                  if (resultOk) { reloadLlmPartial(); }
                 })
                 .catch(e => { resultOk = false; result = e.message; })
               ">
@@ -827,7 +835,7 @@
       <div>
         <label class="label">Google API Key</label>
         {% if google_vaulted %}
-        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault — manage it there.</div>
+        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault as <code>${vault:GOOGLE_API_KEY}</code> for easy reuse — manage it from the <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'secrets')">Secrets</button> tab.</div>
         {% else %}
         <input type="password" class="input-sm" style="max-width:500px"
                autocomplete="new-password"
@@ -878,6 +886,7 @@
                 .then(d => {
                   result = resultOk ? 'Google settings saved' : (d.detail || 'Error');
                   if (resultOk && window.showToast) { window.showToast('Google settings saved'); }
+                  if (resultOk) { reloadLlmPartial(); }
                 })
                 .catch(e => { resultOk = false; result = e.message; })
               ">
@@ -893,7 +902,7 @@
       <div>
         <label class="label">Grok API Key</label>
         {% if grok_vaulted %}
-        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault — manage it there.</div>
+        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault as <code>${vault:GROK_API_KEY}</code> for easy reuse — manage it from the <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'secrets')">Secrets</button> tab.</div>
         {% else %}
         <input type="password" class="input-sm" style="max-width:500px"
                autocomplete="new-password"
@@ -944,6 +953,7 @@
                 .then(d => {
                   result = resultOk ? 'Grok settings saved' : (d.detail || 'Error');
                   if (resultOk && window.showToast) { window.showToast('Grok settings saved'); }
+                  if (resultOk) { reloadLlmPartial(); }
                 })
                 .catch(e => { resultOk = false; result = e.message; })
               ">
@@ -959,7 +969,7 @@
       <div>
         <label class="label">DeepSeek API Key</label>
         {% if deepseek_vaulted %}
-        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault — manage it there.</div>
+        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the <strong>Secrets</strong> vault as <code>${vault:DEEPSEEK_API_KEY}</code> for easy reuse — manage it from the <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'secrets')">Secrets</button> tab.</div>
         {% else %}
         <input type="password" class="input-sm" style="max-width:500px"
                autocomplete="new-password"
@@ -1010,6 +1020,7 @@
                 .then(d => {
                   result = resultOk ? 'DeepSeek settings saved' : (d.detail || 'Error');
                   if (resultOk && window.showToast) { window.showToast('DeepSeek settings saved'); }
+                  if (resultOk) { reloadLlmPartial(); }
                 })
                 .catch(e => { resultOk = false; result = e.message; })
               ">
@@ -1017,4 +1028,5 @@
       </button>
     </div>
   </div>
+  </div>{# /providers #}
 </div>

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -39,7 +39,10 @@ Edit agent settings without touching config files:
 - **Assistant** — the default identity (agent name, character & tone), used when no persona is active
 - **Personae** — create, edit, and switch swappable agent identities (see below)
 - **Inspect** — developer view: a master/detail list of every active context showing the exact payload last sent to the LLM for each (see below)
-- **LLM** — provider, model, and API key configuration. The model field is free-text (enter any model id the provider supports); a **Fetch models** button on each provider card loads the live model list from the provider API into the field's autocomplete, and **Copy list** copies all available ids. Also configures the background models for memory, goal decomposition, task reflection, and **history compaction** (the model used to summarize old conversation turns — see the History tab for the trigger threshold)
+- **LLM** — split into three sub-tabs to keep it uncluttered:
+    - **SysPrompt** — build and preview the system prompt (tool-usage / history-handling overrides, default-block references, prompt preview, captured runtime prompts). Links to the **Inspect** tab for debugging live payloads.
+    - **Inference** — pick the provider and model for each inference and its parameters (main model, max output tokens, temperature, thinking level) plus the background models for memory, goal decomposition, task reflection, reply decision, **history compaction** (summarizes old conversation turns — see the History tab for the trigger threshold), and vision fallback. The model field is free-text (enter any model id the provider supports)
+    - **Providers** — per-provider access: API key and optional base URL, with **Test connection**, **Fetch models** (loads the live model list into each field's autocomplete), and **Copy list**. Saving a provider API key stores it in the [secrets vault](/docs/secrets) and keeps only a `${vault:NAME}` reference in config — the raw key is never written to plaintext config. If no vault machine key is configured, it falls back to plaintext
 - **Channels** — enable/disable Telegram and WhatsApp
 - **Calendar** — manage CalDAV providers
 - **Contacts** — manage contact providers
@@ -102,7 +105,7 @@ Manage scheduled tasks:
 Configure conversation history and browse stored turns:
 
 - **Mode** — `injection` (replay the last N user/assistant pairs each request) or `session` (sticky per-chat session, full context, cache-friendly). Reset a conversation any time by sending `/new` (or its alias `/clear`).
-- **Context compaction** (session mode) — when the conversation nears the model's context window, the oldest turns are summarized by a small model while recent turns are kept verbatim, and the user gets a system message saying it happened. Set the trigger threshold here as either a **percent of the context window** or an **absolute token count** (e.g. 200k), plus how many recent turns to keep. The compaction model is configured in the **LLM** tab (under *History Compaction*). Has no effect in injection mode (which is already windowed).
+- **Context compaction** (session mode) — when the conversation nears the model's context window, the oldest turns are summarized by a small model while recent turns are kept verbatim, and the user gets a system message saying it happened. Set the trigger threshold here as either a **percent of the context window** or an **absolute token count** (e.g. 200k), plus how many recent turns to keep. The compaction model is configured in the **LLM** tab (under *Inference → History Compaction*). Has no effect in injection mode (which is already windowed).
 
 ### Secrets
 

--- a/docs/content/docs/secrets.mdx
+++ b/docs/content/docs/secrets.mdx
@@ -64,6 +64,11 @@ Telegram / Search / Tools field becomes a read-only "Stored in the Secrets vault
 edit or rotate it from the Secrets tab, and saving the other tab leaves the reference
 untouched.
 
+**LLM provider keys vault automatically.** When a machine key is configured, saving an API
+key on the **LLM → Providers** tab encrypts it straight into the infra vault and stores only
+the `${vault:NAME}` reference in config — you never have to run the migrate step for those,
+and no plaintext provider key is written. Without a machine key it falls back to plaintext.
+
 ## Persona vault — `{{secret:NAME}}`
 
 Login and agent secrets are more sensitive, so the persona vault is sealed with a key

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -276,6 +276,17 @@ class TestVoicePreview:
         assert "Coding harness" in resp.text
         assert "workspace.directory" in resp.text
 
+    def test_llm_partial_has_three_subtabs(self):
+        # Issue #114: the LLM tab is split into SysPrompt / Inference / Providers
+        # sub-tabs, with a link to the Inspect tab for debugging.
+        client = _client(setup_complete=True)
+        resp = client.get("/partials/llm", headers=AUTH)
+        assert resp.status_code == 200
+        for sec in ("sysprompt", "inference", "providers"):
+            assert f"setSection('{sec}')" in resp.text
+            assert f"section === '{sec}'" in resp.text
+        assert "$dispatch('switch-tab', 'inspect')" in resp.text  # SysPrompt -> Inspect
+
     def test_llm_partial_has_vision_fallback(self):
         client = _client(setup_complete=True)
         resp = client.get("/partials/llm", headers=AUTH)

--- a/tests/test_secrets_vault.py
+++ b/tests/test_secrets_vault.py
@@ -518,13 +518,16 @@ async def test_patch_config_preserves_vault_ref(tmp_path) -> None:
     assert "agent.anthropic_api_key" not in resp.json()["updated"]  # dropped, not written
     assert await cs.get("agent.anthropic_api_key") == "${vault:ANTHROPIC_API_KEY}"
     assert await cs.get("agent.model") == "claude-x"  # non-secret still saved
-    # Re-entering a real key still works (guard only drops blank/echoed writes).
+    # Re-entering a real key now auto-vaults it (#114): the config keeps only the
+    # reference and the vault value is updated in place — plaintext never lands
+    # in config.
     client.patch(
         "/config",
         json={"values": {"agent.anthropic_api_key": "sk-new-plaintext"}},
         headers=_auth(),
     )
-    assert await cs.get("agent.anthropic_api_key") == "sk-new-plaintext"
+    assert await cs.get("agent.anthropic_api_key") == "${vault:ANTHROPIC_API_KEY}"
+    assert await s.get_infra_secret("ANTHROPIC_API_KEY") == "sk-new-plaintext"
 
 
 # ── Safe UI collapse (issue #35) ───────────────────────────────────────────
@@ -535,7 +538,10 @@ async def test_llm_tab_collapses_vaulted_key(admin_client) -> None:
     await cs.set("agent.anthropic_api_key", "${vault:ANTHROPIC_API_KEY}")
     body = client.get("/partials/llm", headers=_auth()).text
     assert "Stored in the" in body  # read-only vault note shown
-    assert "${vault:ANTHROPIC_API_KEY}" not in body  # ref never shipped to the browser
+    # The note names the vault ref for reuse (#114); the secret VALUE is never
+    # rendered and the editable key input is collapsed away.
+    assert "${vault:ANTHROPIC_API_KEY}" in body
+    assert 'x-model="apiKey"' not in body  # anthropic input replaced by the note
     assert 'x-model="openaiKey"' in body  # other providers still editable
 
 
@@ -591,3 +597,43 @@ async def test_delete_channel_preserves_vaulted_token(admin_client) -> None:
     assert resp.status_code == 200
     assert await cs.get("channels.telegram.bot_token") == "${vault:TELEGRAM_BOT_TOKEN}"
     assert await cs.get("channels.telegram.enabled") == "false"  # still disabled
+
+
+async def test_llm_provider_key_autovaults_on_save(tmp_path) -> None:
+    """A freshly-typed LLM provider key is vaulted, never stored plaintext (#114)."""
+    db = str(tmp_path / "config.db")
+    cs = ConfigStore(db_path=db)
+    await cs.set_setup_step("done")
+    await cs.set_admin_password("testpw")
+    s = SecretStore(db_path=db, infra_vault=InfraVault("test-machine-key"))
+    app, _ = create_admin_app(AgentState(), cs, secret_store=s)
+    client = TestClient(app)
+
+    resp = client.patch(
+        "/config",
+        json={"values": {"agent.anthropic_api_key": "sk-ant-secret"}},
+        headers=_auth(),
+    )
+    assert resp.status_code == 200
+    # Config keeps only the reference; the raw key lives in the vault.
+    assert await cs.get("agent.anthropic_api_key") == "${vault:ANTHROPIC_API_KEY}"
+    assert await s.get_infra_secret("ANTHROPIC_API_KEY") == "sk-ant-secret"
+    # A later blank save (the vaulted field submits empty) must not orphan the ref.
+    client.patch("/config", json={"values": {"agent.anthropic_api_key": ""}}, headers=_auth())
+    assert await cs.get("agent.anthropic_api_key") == "${vault:ANTHROPIC_API_KEY}"
+
+
+async def test_llm_provider_key_plaintext_without_machine_key(tmp_path) -> None:
+    """No machine key -> fall back to plaintext config instead of crashing (#114)."""
+    db = str(tmp_path / "config.db")
+    cs = ConfigStore(db_path=db)
+    await cs.set_setup_step("done")
+    await cs.set_admin_password("testpw")
+    s = SecretStore(db_path=db)  # no infra vault -> not available
+    app, _ = create_admin_app(AgentState(), cs, secret_store=s)
+    client = TestClient(app)
+    resp = client.patch(
+        "/config", json={"values": {"agent.openai_api_key": "sk-plain"}}, headers=_auth()
+    )
+    assert resp.status_code == 200
+    assert await cs.get("agent.openai_api_key") == "sk-plain"


### PR DESCRIPTION
Closes #114.

Splits the crowded **LLM** settings tab into three sub-tabs — **SysPrompt**, **Inference**, **Providers** — instead of one long scroll of 13 cards.

## Approach
Sub-tabs *inside* the existing LLM tab (not three new top-level tabs), so the already-crowded 20-tab top nav stays clean and the whole thing keeps **one shared Alpine component** — all the cross-card state (provider list, model fetch, vision fallback, thinking levels) and every save button stay intact. The active sub-tab is persisted in `localStorage`.

## What's where
- **SysPrompt** — system-prompt build/preview cards. Adds a link to the **Inspect** tab for debugging live payloads (per the issue).
- **Inference** — active inference provider + params, memory models, goal decomposition, task reflection, reply decision, history compaction, vision fallback.
- **Providers** — Anthropic / OpenAI / Google / Grok / DeepSeek access (key + base URL, test, fetch models).

## Credentials live in the vault
Saving a provider API key now **auto-migrates it into the infra vault**: the raw key is encrypted into the vault and config keeps only a `${vault:NAME}` reference — no plaintext provider key is ever written to config. Falls back to plaintext only when no machine key is configured. The guard lives in the shared `_preserve_vault_refs` on the `/config` PATCH path, so it covers every provider save at once. The vault note now names the ref (e.g. `${vault:OPENAI_API_KEY}`) and points to the Secrets tab for reuse. The Inference "Save" no longer writes provider keys — the Providers tab owns them.

## Tests
- `test_llm_provider_key_autovaults_on_save` — fresh key → `${vault:…}` in config + raw value in vault; a later blank save keeps the ref.
- `test_llm_provider_key_plaintext_without_machine_key` — no machine key → plaintext fallback, no crash.
- `test_llm_partial_has_three_subtabs` — the three sub-tabs + Inspect link render.
- Updated `test_patch_config_preserves_vault_ref` and `test_llm_tab_collapses_vaulted_key` for the new auto-vault / ref-display behavior.
- Full suite green (813 passed); ruff clean.

Docs updated: `admin-ui.mdx` (sub-tab breakdown) and `secrets.mdx` (auto-vault on save).
