### PR TITLE
feat(#124): Jobs table — agent filter, hardened to survive re-renders

### DIFF
--- a/api/templates/partials/jobs.html
+++ b/api/templates/partials/jobs.html
@@ -8,7 +8,7 @@
     </button>
     <span class="text-muted text-xs">{{ jobs|length }} job{{ 's' if jobs|length != 1 else '' }}</span>
     {% if job_agents %}
-    <select class="input-sm" style="max-width:200px" x-model="agentFilter"
+    <select id="jobs-agent-filter" class="input-sm" style="max-width:200px" x-model="agentFilter"
             title="Filter jobs by the agent they run as">
       <option value="">All agents</option>
       {% for p in job_agents %}
@@ -211,7 +211,14 @@
 function jobsTab() {
   return {
     editing: false,
-    agentFilter: '',
+    // Persist filter so it survives HTMX re-renders (Refresh, Show completed, add/edit/delete).
+    agentFilter: sessionStorage.getItem('jobsAgentFilter') || '',
+    init() {
+      // Drop a stale filter whose agent no longer has any listed job.
+      const opts = [...this.$el.querySelectorAll('#jobs-agent-filter option')].map(o => o.value);
+      if (this.agentFilter && !opts.includes(this.agentFilter)) this.agentFilter = '';
+      this.$watch('agentFilter', v => sessionStorage.setItem('jobsAgentFilter', v));
+    },
     form: {
       id: '',
       schedule: 'cron',


### PR DESCRIPTION
Closes #124

## Context

The Jobs screen **already had** the requested agent filter — a dropdown
that narrows the table to a single agent (shipped in #101, renamed
persona→agent in #115). It sits right next to the **Show completed**
toggle and is documented in `docs/scheduler.mdx`.

So the acceptance criteria were mostly already met — with one crack: the
dropdown's selection lived only in Alpine component state. Every HTMX
re-render of the Jobs partial — toggling **Show completed**, hitting
**Refresh**, or adding/editing/deleting a job — rebuilds that component
and reset the filter back to **All agents**. That directly undercut AC
_"works alongside the existing completed-jobs filter"_: pick an agent,
flip Show completed, and your filter was gone.

## Change

Persist the selection in `sessionStorage` and restore it when the
component re-initialises. If the remembered agent no longer has any
listed job (e.g. its jobs are all completed and hidden), the filter is
cleared on init so the table can't get stuck showing nothing behind a
blank dropdown.

Client-side only — no new routes, no new dependency, one template file.

## Acceptance criteria

- [x] Jobs table has a dropdown to show only jobs for a selected agent.
- [x] Works alongside the completed-jobs filter — now *survives*
      toggling it, instead of being wiped.
- [x] No regressions — `tests/test_admin_api.py` (11) green; partial
      renders unchanged server-side.

## Try it

Jobs tab → pick an agent → toggle **Show completed** / **Refresh** /
add a job. The agent filter now stays put.