### PR TITLE
Add OpenRouter as a full LLM provider (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ MPA follows a **Python orchestrator + CLI tools** design. Python glues everythin
 
 | Concern | Tool |
 |---------|------|
-| LLM | Anthropic Claude, OpenAI, Grok (xAI), DeepSeek |
+| LLM | Anthropic Claude, OpenAI, Grok (xAI), Google, DeepSeek, OpenRouter |
 | Email | Himalaya CLI (Rust) |
 | Contacts | Built-in contacts CLI |
 | Calendar | python-caldav |
@@ -179,7 +179,7 @@ The binary is installed from a pinned upstream tag (`WACLI_VERSION` in the `Dock
 ## Tech stack
 
 - **Python 3.14** with **uv** for package management
-- **Anthropic Claude**, **OpenAI**, **Grok (xAI)**, or **DeepSeek** as the LLM backend
+- **Anthropic Claude**, **OpenAI**, **Grok (xAI)**, **Google**, **DeepSeek**, or **OpenRouter** as the LLM backend
 - **SQLite** via aiosqlite for all persistence
 - **FastAPI** + **Jinja2** + **HTMX** + **Alpine.js** + **Tailwind CSS v4** for the admin UI
 - **python-telegram-bot** for the Telegram channel

--- a/api/admin.py
+++ b/api/admin.py
@@ -181,6 +181,8 @@ async def _wizard_step_context(step: str, config_store: ConfigStore) -> dict[str
             ("agent.grok_base_url", "grok_base_url"),
             ("agent.deepseek_api_key", "deepseek_api_key"),
             ("agent.deepseek_base_url", "deepseek_base_url"),
+            ("agent.openrouter_api_key", "openrouter_api_key"),
+            ("agent.openrouter_base_url", "openrouter_base_url"),
             ("agent.model", "model"),
         ):
             val = await config_store.get(key)
@@ -836,6 +838,7 @@ def create_admin_app(
         "agent.google_api_key",
         "agent.grok_api_key",
         "agent.deepseek_api_key",
+        "agent.openrouter_api_key",
     }
 
     async def _preserve_vault_refs(values: dict) -> dict:
@@ -892,6 +895,8 @@ def create_admin_app(
         "agent.grok_base_url",
         "agent.deepseek_api_key",
         "agent.deepseek_base_url",
+        "agent.openrouter_api_key",
+        "agent.openrouter_base_url",
         "agent.model",
     }
     _SEARCH_PREFIX = "search."
@@ -1307,6 +1312,8 @@ def create_admin_app(
         grok_base_url = await config_store.get("agent.grok_base_url") or ""
         deepseek_api_key = await config_store.get("agent.deepseek_api_key") or ""
         deepseek_base_url = await config_store.get("agent.deepseek_base_url") or ""
+        openrouter_api_key = await config_store.get("agent.openrouter_api_key") or ""
+        openrouter_base_url = await config_store.get("agent.openrouter_base_url") or ""
         # Vault-managed keys (issue #35): show a read-only "in vault" note instead
         # of the input, and don't ship the ref to the browser.
         anthropic_vaulted = _is_vault_ref(anthropic_api_key)
@@ -1314,6 +1321,7 @@ def create_admin_app(
         google_vaulted = _is_vault_ref(google_api_key)
         grok_vaulted = _is_vault_ref(grok_api_key)
         deepseek_vaulted = _is_vault_ref(deepseek_api_key)
+        openrouter_vaulted = _is_vault_ref(openrouter_api_key)
         model = await config_store.get("agent.model") or "claude-4-6-sonnet"
         max_tokens = await config_store.get("agent.max_tokens") or "8192"
         thinking_level = await config_store.get("agent.thinking_level") or ""
@@ -1380,6 +1388,9 @@ def create_admin_app(
             deepseek_api_key="" if deepseek_vaulted else deepseek_api_key,
             deepseek_vaulted=deepseek_vaulted,
             deepseek_base_url=deepseek_base_url,
+            openrouter_api_key="" if openrouter_vaulted else openrouter_api_key,
+            openrouter_vaulted=openrouter_vaulted,
+            openrouter_base_url=openrouter_base_url,
             model=model,
             max_tokens=max_tokens,
             temperature=temperature,
@@ -3693,6 +3704,12 @@ def create_admin_app(
                 payload.get("base_url"),
                 model="deepseek-chat",
             )
+        if service == "openrouter":
+            return await _test_openai(
+                payload.get("api_key", ""),
+                payload.get("base_url") or "https://openrouter.ai/api/v1",
+                model="openai/gpt-4o-mini",
+            )
         if service == "telegram":
             return await _test_telegram(payload.get("bot_token", ""))
         if service == "tavily":
@@ -3714,6 +3731,8 @@ def create_admin_app(
             return await _list_models_openai(api_key, base_url, strip_prefix="models/")
         if service in ("grok", "deepseek"):
             return await _list_models_openai(api_key, base_url)
+        if service == "openrouter":
+            return await _list_models_openai(api_key, base_url or "https://openrouter.ai/api/v1")
         return {"ok": False, "error": f"Unknown service: {service}"}
 
     @app.post("/setup/thinking-levels")

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -112,7 +112,7 @@
     }
     window.previewVoice = previewVoice;
 
-    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens, temperature, trMaxReflections) {
+    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, openrouterKey, openrouterBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens, temperature, trMaxReflections) {
       const currentProvider = provider || 'anthropic';
       return {
         // Sub-tab within the LLM tab (issue #114): sysprompt | inference | providers.
@@ -143,7 +143,8 @@
           {value: 'openai', label: 'OpenAI'},
           {value: 'google', label: 'Google Gemini'},
           {value: 'grok', label: 'Grok (xAI)'},
-          {value: 'deepseek', label: 'DeepSeek'}
+          {value: 'deepseek', label: 'DeepSeek'},
+          {value: 'openrouter', label: 'OpenRouter'}
         ],
         provider: currentProvider,
         apiKey: apiKey || '',
@@ -156,9 +157,9 @@
         gdThinkingLevel: gdThinkingLevel || '',
         trThinkingLevel: trThinkingLevel || '',
         compactionThinkingLevel: compactionThinkingLevel || '',
-        fetchedLevels: {anthropic: [], openai: [], google: [], grok: [], deepseek: []},
-        fetchingLevels: {anthropic: false, openai: false, google: false, grok: false, deepseek: false},
-        fetchLevelsResult: {anthropic: '', openai: '', google: '', grok: '', deepseek: ''},
+        fetchedLevels: {anthropic: [], openai: [], google: [], grok: [], deepseek: [], openrouter: []},
+        fetchingLevels: {anthropic: false, openai: false, google: false, grok: false, deepseek: false, openrouter: false},
+        fetchLevelsResult: {anthropic: '', openai: '', google: '', grok: '', deepseek: '', openrouter: ''},
         openaiKey: openaiKey || '',
         openaiBaseUrl: openaiBaseUrl || '',
         googleKey: googleKey || '',
@@ -167,6 +168,8 @@
         grokBaseUrl: grokBaseUrl || '',
         deepseekKey: deepseekKey || '',
         deepseekBaseUrl: deepseekBaseUrl || '',
+        openrouterKey: openrouterKey || '',
+        openrouterBaseUrl: openrouterBaseUrl || '',
         extractionProvider: extractionProvider || 'anthropic',
         extractionModel: extractionModel || 'claude-haiku-4-5',
         consolidationProvider: consolidationProvider || 'anthropic',
@@ -227,21 +230,24 @@
           openai: currentProvider === 'openai',
           google: currentProvider === 'google',
           grok: currentProvider === 'grok',
-          deepseek: currentProvider === 'deepseek'
+          deepseek: currentProvider === 'deepseek',
+          openrouter: currentProvider === 'openrouter'
         },
         testing: {
           anthropic: false,
           openai: false,
           google: false,
           grok: false,
-          deepseek: false
+          deepseek: false,
+          openrouter: false
         },
         testResults: {
           anthropic: '',
           openai: '',
           google: '',
           grok: '',
-          deepseek: ''
+          deepseek: '',
+          openrouter: ''
         },
         models: {
           anthropic: [
@@ -268,11 +274,17 @@
           deepseek: [
             {value: 'deepseek-chat', label: 'deepseek-chat'},
             {value: 'deepseek-reasoner', label: 'deepseek-reasoner'}
+          ],
+          openrouter: [
+            {value: 'anthropic/claude-sonnet-4.5', label: 'anthropic/claude-sonnet-4.5'},
+            {value: 'openai/gpt-5', label: 'openai/gpt-5'},
+            {value: 'google/gemini-2.5-flash', label: 'google/gemini-2.5-flash'},
+            {value: 'deepseek/deepseek-chat', label: 'deepseek/deepseek-chat'}
           ]
         },
-        fetchedModels: {anthropic: [], openai: [], google: [], grok: [], deepseek: []},
-        fetchingModels: {anthropic: false, openai: false, google: false, grok: false, deepseek: false},
-        fetchModelsResult: {anthropic: '', openai: '', google: '', grok: '', deepseek: ''},
+        fetchedModels: {anthropic: [], openai: [], google: [], grok: [], deepseek: [], openrouter: []},
+        fetchingModels: {anthropic: false, openai: false, google: false, grok: false, deepseek: false, openrouter: false},
+        fetchModelsResult: {anthropic: '', openai: '', google: '', grok: '', deepseek: '', openrouter: ''},
         modelOptions(prov) {
           const fetched = this.fetchedModels[prov];
           if (fetched && fetched.length) {
@@ -368,7 +380,8 @@
             openai: 'https://platform.openai.com/docs/guides/reasoning',
             google: 'https://ai.google.dev/gemini-api/docs/thinking',
             grok: 'https://docs.x.ai/docs/guides/reasoning',
-            deepseek: 'https://api-docs.deepseek.com/guides/reasoning_model'
+            deepseek: 'https://api-docs.deepseek.com/guides/reasoning_model',
+            openrouter: 'https://openrouter.ai/docs/use-cases/reasoning-tokens'
           })[prov] || '';
         },
         // True when a background kind points at the exact same provider+model as
@@ -492,6 +505,7 @@
           if (service === 'google') return this.googleKey;
           if (service === 'grok') return this.grokKey;
           if (service === 'deepseek') return this.deepseekKey;
+          if (service === 'openrouter') return this.openrouterKey;
           return this.apiKey;
         },
         baseUrlFor(service) {
@@ -499,6 +513,7 @@
           if (service === 'google') return this.googleBaseUrl;
           if (service === 'grok') return this.grokBaseUrl;
           if (service === 'deepseek') return this.deepseekBaseUrl;
+          if (service === 'openrouter') return this.openrouterBaseUrl;
           return '';
         },
         resolvedBaseUrl(service) {
@@ -506,6 +521,7 @@
           if (service === 'google') return base || 'https://generativelanguage.googleapis.com/v1beta/openai';
           if (service === 'grok') return base || 'https://api.x.ai/v1';
           if (service === 'deepseek') return base || 'https://api.deepseek.com';
+          if (service === 'openrouter') return base || 'https://openrouter.ai/api/v1';
           return base;
         },
         canSelect(service) {

--- a/api/templates/partials/llm.html
+++ b/api/templates/partials/llm.html
@@ -38,6 +38,8 @@
   {{ grok_base_url|default('', true)|tojson|forceescape }},
   {{ deepseek_api_key|default('', true)|tojson|forceescape }},
   {{ deepseek_base_url|default('', true)|tojson|forceescape }},
+  {{ openrouter_api_key|default('', true)|tojson|forceescape }},
+  {{ openrouter_base_url|default('', true)|tojson|forceescape }},
   {{ extraction_provider|default('deepseek', true)|tojson|forceescape }},
   {{ extraction_model|default('deepseek-v4-flash', true)|tojson|forceescape }},
   {{ consolidation_provider|default('deepseek', true)|tojson|forceescape }},
@@ -1026,6 +1028,74 @@
                 .catch(e => { resultOk = false; result = e.message; })
               ">
         Save DeepSeek
+      </button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2 class="text-base mb-1">OpenRouter</h2>
+    <p class="text-muted text-xs mb-2">A provider-agnostic gateway: one API key reaches models from many labs (Anthropic, OpenAI, Google, Meta, DeepSeek, …). Model ids are namespaced <code>provider/model</code> (e.g. <code>anthropic/claude-sonnet-4.5</code>) — use <strong>Fetch models</strong> for the live catalog.</p>
+    <p class="text-muted text-xs mb-4">OpenRouter can auto-route around provider outages and fall back between hosts, and publishes transparent per-token pricing per model. Docs: <a href="https://openrouter.ai/docs" target="_blank" rel="noopener">openrouter.ai/docs</a> · Models &amp; pricing: <a href="https://openrouter.ai/models" target="_blank" rel="noopener">openrouter.ai/models</a> · Routing &amp; fallbacks: <a href="https://openrouter.ai/docs/features/provider-routing" target="_blank" rel="noopener">provider routing</a>.</p>
+    <form class="space-y-3" @submit.prevent>
+      <div>
+        <label class="label">OpenRouter API Key</label>
+        {% if openrouter_vaulted %}
+        <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the vault as <code>${vault:OPENROUTER_API_KEY}</code> for easy reuse — manage it from the <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'secrets')">Vaults</button> tab.</div>
+        {% else %}
+        <input type="password" class="input-sm" style="max-width:500px"
+               autocomplete="new-password"
+               x-model="openrouterKey" placeholder="sk-or-...">
+        <p class="text-muted text-xs mt-1">Create a key in <a href="https://openrouter.ai/settings/keys" target="_blank" rel="noopener">openrouter.ai/settings/keys</a></p>
+        {% endif %}
+      </div>
+      <div>
+        <label class="label">OpenRouter Base URL (optional)</label>
+        <input type="text" class="input-sm" style="max-width:500px"
+               x-model="openrouterBaseUrl" placeholder="https://openrouter.ai/api/v1">
+        <div class="flex items-center gap-2 mt-2">
+          <button class="btn btn-sm" type="button" :disabled="testing.openrouter || !openrouterKey"
+                  @click="testProvider('openrouter')">
+            <span x-show="!testing.openrouter">Test connection</span>
+            <span x-show="testing.openrouter">Testing...</span>
+          </button>
+          <button class="btn btn-sm" type="button" :disabled="fetchingModels.openrouter || !openrouterKey"
+                  @click="fetchModels('openrouter')">
+            <span x-show="!fetchingModels.openrouter">Fetch models</span>
+            <span x-show="fetchingModels.openrouter">Fetching...</span>
+          </button>
+          <button class="btn btn-sm" type="button" @click="copyModels('openrouter')">Copy list</button>
+        </div>
+        <template x-if="testResults.openrouter">
+          <div :class="tests.openrouter ? 'alert-success' : 'alert-error'" class="mt-2" x-text="testResults.openrouter"></div>
+        </template>
+        <template x-if="fetchModelsResult.openrouter">
+          <div class="text-muted text-xs mt-1" x-text="fetchModelsResult.openrouter"></div>
+        </template>
+      </div>
+    </form>
+    <div class="flex items-center gap-2 mt-4">
+      <button class="btn btn-sm"
+              @click="
+                fetch('/config', {
+                  method: 'PATCH',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+                  },
+                  body: JSON.stringify({values: {
+                    'agent.openrouter_api_key': openrouterKey,
+                    'agent.openrouter_base_url': openrouterBaseUrl
+                  }})
+                })
+                .then(r => { resultOk = r.ok; return r.json(); })
+                .then(d => {
+                  result = resultOk ? 'OpenRouter settings saved' : (d.detail || 'Error');
+                  if (resultOk && window.showToast) { window.showToast('OpenRouter settings saved'); }
+                  if (resultOk) { reloadLlmPartial(); }
+                })
+                .catch(e => { resultOk = false; result = e.message; })
+              ">
+        Save OpenRouter
       </button>
     </div>
   </div>

--- a/api/templates/wizard/llm.html
+++ b/api/templates/wizard/llm.html
@@ -1,8 +1,8 @@
 <div class="card" x-data="{
   provider: {{ step_ctx.provider|default('anthropic')|tojson|forceescape }},
   model: {{ step_ctx.model|default('', true)|tojson|forceescape }},
-  tests: { anthropic: false, openai: false, google: false, grok: false, deepseek: false },
-  testResults: { anthropic: '', openai: '', google: '', grok: '', deepseek: '' },
+  tests: { anthropic: false, openai: false, google: false, grok: false, deepseek: false, openrouter: false },
+  testResults: { anthropic: '', openai: '', google: '', grok: '', deepseek: '', openrouter: '' },
   testing: false,
   models: {
     anthropic: [
@@ -29,11 +29,17 @@
     deepseek: [
       {value: 'deepseek-chat', label: 'deepseek-chat'},
       {value: 'deepseek-reasoner', label: 'deepseek-reasoner'}
+    ],
+    openrouter: [
+      {value: 'anthropic/claude-sonnet-4.5', label: 'anthropic/claude-sonnet-4.5'},
+      {value: 'openai/gpt-5', label: 'openai/gpt-5'},
+      {value: 'google/gemini-2.5-flash', label: 'google/gemini-2.5-flash'},
+      {value: 'deepseek/deepseek-chat', label: 'deepseek/deepseek-chat'}
     ]
   },
-  fetchedModels: {anthropic: [], openai: [], google: [], grok: [], deepseek: []},
-  fetchingModels: {anthropic: false, openai: false, google: false, grok: false, deepseek: false},
-  fetchModelsResult: {anthropic: '', openai: '', google: '', grok: '', deepseek: ''},
+  fetchedModels: {anthropic: [], openai: [], google: [], grok: [], deepseek: [], openrouter: []},
+  fetchingModels: {anthropic: false, openai: false, google: false, grok: false, deepseek: false, openrouter: false},
+  fetchModelsResult: {anthropic: '', openai: '', google: '', grok: '', deepseek: '', openrouter: ''},
   visionFallback: true,
   init() {
     const savedModel = this.model;
@@ -101,6 +107,7 @@
       <option value="google" {{ 'selected' if step_ctx.provider|default('') == 'google' }}>Google Gemini</option>
       <option value="grok" {{ 'selected' if step_ctx.provider|default('') == 'grok' }}>Grok (xAI)</option>
       <option value="deepseek" {{ 'selected' if step_ctx.provider|default('') == 'deepseek' }}>DeepSeek</option>
+      <option value="openrouter" {{ 'selected' if step_ctx.provider|default('') == 'openrouter' }}>OpenRouter</option>
     </select>
 
   <label class="label mt-3" for="w-model">Model</label>
@@ -375,6 +382,58 @@
     </template>
   </div>
 
+  <div class="card" style="padding: 0; box-shadow: none; border: 0; margin-top: 16px;">
+    <h3 class="text-sm mb-2">OpenRouter</h3>
+    <p class="text-muted text-xs mb-2">One API key for models from many labs (Anthropic, OpenAI, Google, Meta, DeepSeek, …) through a single OpenAI-compatible endpoint. Model ids are namespaced <code>provider/model</code> — use “Fetch models” for the live catalog. OpenRouter routes around outages, supports fallbacks, and publishes transparent per-token pricing.</p>
+    <label class="label" for="w-openrouter-key">OpenRouter API Key</label>
+    <input type="password" class="input" id="w-openrouter-key" placeholder="sk-or-..."
+           value="{{ step_ctx.openrouter_api_key|default('') }}">
+    <p class="hint">Create a key in <a href="https://openrouter.ai/settings/keys" target="_blank" rel="noopener">openrouter.ai/settings/keys</a> · <a href="https://openrouter.ai/docs" target="_blank" rel="noopener">docs</a> · <a href="https://openrouter.ai/models" target="_blank" rel="noopener">models &amp; pricing</a></p>
+    <label class="label mt-2" for="w-openrouter-base-url">OpenRouter Base URL (optional)</label>
+    <input type="text" class="input" id="w-openrouter-base-url" placeholder="https://openrouter.ai/api/v1"
+           value="{{ step_ctx.openrouter_base_url|default('') }}">
+
+    <div class="mt-3">
+      <button class="btn" :disabled="testing"
+              @click="
+                testing = true;
+                const provider = 'openrouter';
+                const apiKey = document.getElementById('w-openrouter-key').value;
+                const baseUrl = document.getElementById('w-openrouter-base-url').value || 'https://openrouter.ai/api/v1';
+                fetch('/setup/test-connection', {
+                  method: 'POST',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({service: provider, api_key: apiKey, base_url: baseUrl})
+                })
+                .then(r => r.json())
+                .then(d => {
+                  tests[provider] = !!d.ok;
+                  testResults[provider] = d.ok ? 'Connection successful' + (d.response ? ': ' + d.response : '') : d.error;
+                })
+                .catch(e => {
+                  tests[provider] = false;
+                  testResults[provider] = e.message;
+                })
+                .finally(() => { testing = false; })
+              ">
+        <span x-show="testing" class="spinner mr-1"></span>
+        Test connection
+      </button>
+      <button class="btn ml-2" type="button" :disabled="fetchingModels.openrouter"
+              @click="fetchModels('openrouter', document.getElementById('w-openrouter-key').value, document.getElementById('w-openrouter-base-url').value || 'https://openrouter.ai/api/v1')">
+        <span x-show="!fetchingModels.openrouter">Fetch models</span>
+        <span x-show="fetchingModels.openrouter">Fetching...</span>
+      </button>
+      <button class="btn ml-2" type="button" @click="copyModels('openrouter')">Copy list</button>
+    </div>
+    <template x-if="testResults.openrouter">
+      <div :class="tests.openrouter ? 'alert-success' : 'alert-error'" class="mt-2" x-text="testResults.openrouter"></div>
+    </template>
+    <template x-if="fetchModelsResult.openrouter">
+      <div class="hint mt-1" x-text="fetchModelsResult.openrouter"></div>
+    </template>
+  </div>
+
   <div class="flex justify-between mt-4">
     <button class="btn"
             hx-post="/setup/step" hx-target="#wizard-step" hx-swap="innerHTML"
@@ -393,9 +452,12 @@
               const grokBaseUrl = document.getElementById('w-grok-base-url')?.value || '';
               const deepseekKey = document.getElementById('w-deepseek-key')?.value || '';
               const deepseekBaseUrl = document.getElementById('w-deepseek-base-url')?.value || '';
+              const openrouterKey = document.getElementById('w-openrouter-key')?.value || '';
+              const openrouterBaseUrl = document.getElementById('w-openrouter-base-url')?.value || '';
               const googleBaseUrlValue = googleBaseUrl || 'https://generativelanguage.googleapis.com/v1beta/openai';
               const grokBaseUrlValue = grokBaseUrl || 'https://api.x.ai/v1';
               const deepseekBaseUrlValue = deepseekBaseUrl || 'https://api.deepseek.com';
+              const openrouterBaseUrlValue = openrouterBaseUrl || 'https://openrouter.ai/api/v1';
               const modelValue = document.getElementById('w-model').value;
               const vals = {
                 step: 'identity',
@@ -409,6 +471,8 @@
                 'values[agent.grok_base_url]': grokBaseUrlValue,
                 'values[agent.deepseek_api_key]': deepseekKey,
                 'values[agent.deepseek_base_url]': deepseekBaseUrlValue,
+                'values[agent.openrouter_api_key]': openrouterKey,
+                'values[agent.openrouter_base_url]': openrouterBaseUrlValue,
                 'values[agent.model]': modelValue
               };
               // One-tap inline: enable the vision fallback when the picked model

--- a/config.yml.example
+++ b/config.yml.example
@@ -11,6 +11,8 @@ agent:
   grok_base_url: "${GROK_BASE_URL}"
   deepseek_api_key: "${DEEPSEEK_API_KEY}"
   deepseek_base_url: "${DEEPSEEK_BASE_URL}"
+  openrouter_api_key: "${OPENROUTER_API_KEY}"   # one key, many models via an OpenAI-compatible gateway
+  openrouter_base_url: "${OPENROUTER_BASE_URL}" # optional; defaults to https://openrouter.ai/api/v1
   model: "deepseek-v4-flash"
   max_tokens: 8192                  # max tokens the model may emit per response; raise for capable models (Claude up to 128000)
   timezone: "Europe/Zurich"

--- a/core/config.py
+++ b/core/config.py
@@ -72,6 +72,10 @@ class AgentConfig(BaseModel):
     grok_base_url: str = ""
     deepseek_api_key: str = ""
     deepseek_base_url: str = ""
+    # OpenRouter (#128): a provider-agnostic gateway to many models through one
+    # OpenAI-compatible API. Base URL defaults via _DEFAULT_BASE_URLS in core.llm.
+    openrouter_api_key: str = ""
+    openrouter_base_url: str = ""
     model: str = "deepseek-v4-flash"
     thinking_level: str = ""  # "" (off) | "low" | "medium" | "high" — only for reasoning models
     # Hard ceiling on tokens the model may emit per response. The agentic loop

--- a/core/config_store.py
+++ b/core/config_store.py
@@ -50,6 +50,7 @@ SECRET_KEYS = frozenset(
         "agent.google_api_key",
         "agent.grok_api_key",
         "agent.deepseek_api_key",
+        "agent.openrouter_api_key",
         "channels.telegram.bot_token",
         "admin.api_key",
         "admin.password_hash",

--- a/core/imagegen.py
+++ b/core/imagegen.py
@@ -53,8 +53,13 @@ def llm_fallback_key(cfg: Config, provider: str) -> str:
     agent = cfg.agent
     if provider == "openai":
         return agent.openai_api_key or ""
-    if provider == "openrouter" and "openrouter" in (agent.openai_base_url or "").lower():
-        return agent.openai_api_key or ""
+    if provider == "openrouter":
+        # Prefer the dedicated OpenRouter LLM key (#128); fall back to the legacy
+        # "OpenAI-compatible base URL points at openrouter" arrangement.
+        if getattr(agent, "openrouter_api_key", ""):
+            return agent.openrouter_api_key
+        if "openrouter" in (agent.openai_base_url or "").lower():
+            return agent.openai_api_key or ""
     return ""
 
 

--- a/core/llm.py
+++ b/core/llm.py
@@ -66,6 +66,7 @@ _DEFAULT_BASE_URLS = {
     "google": "https://generativelanguage.googleapis.com/v1beta/openai",
     "grok": "https://api.x.ai/v1",
     "deepseek": "https://api.deepseek.com",
+    "openrouter": "https://openrouter.ai/api/v1",  # #128: OpenAI-compatible gateway
 }
 
 _ANTHROPIC_MODEL_ALIASES = {
@@ -315,6 +316,14 @@ class LLMClient:
                 provider,
                 getattr(config, "deepseek_api_key", ""),
                 getattr(config, "deepseek_base_url", ""),
+                thinking_level=thinking,
+            )
+        if provider == "openrouter":
+            # OpenAI-compatible; empty base_url falls back to _DEFAULT_BASE_URLS.
+            return cls(
+                provider,
+                getattr(config, "openrouter_api_key", ""),
+                getattr(config, "openrouter_base_url", ""),
                 thinking_level=thinking,
             )
         return cls("anthropic", getattr(config, "anthropic_api_key", ""), thinking_level=thinking)

--- a/core/secret_store.py
+++ b/core/secret_store.py
@@ -89,6 +89,7 @@ INFRA_VAULT_KEYS: dict[str, str] = {
     "agent.google_api_key": "GOOGLE_API_KEY",
     "agent.grok_api_key": "GROK_API_KEY",
     "agent.deepseek_api_key": "DEEPSEEK_API_KEY",
+    "agent.openrouter_api_key": "OPENROUTER_API_KEY",
     "channels.telegram.bot_token": "TELEGRAM_BOT_TOKEN",
     "search.api_key": "TAVILY_API_KEY",
     "tools.gh.token": "GH_TOKEN",

--- a/docs/content/docs/architecture.mdx
+++ b/docs/content/docs/architecture.mdx
@@ -88,6 +88,7 @@ Abstraction layer supporting multiple LLM backends:
 - **Grok** — xAI models (via OpenAI-compatible API)
 - **Google** — Gemini models
 - **DeepSeek** — DeepSeek models (via OpenAI-compatible API)
+- **OpenRouter** — provider-agnostic gateway to many models across labs (via OpenAI-compatible API)
 
 ### Tool Executor (`core/executor.py`)
 
@@ -182,7 +183,7 @@ mpa/
 | Component | Technology |
 |-----------|-----------|
 | Language | Python 3.14 with uv |
-| LLM | Anthropic Claude, OpenAI, Grok, Google, DeepSeek |
+| LLM | Anthropic Claude, OpenAI, Grok, Google, DeepSeek, OpenRouter |
 | Messaging | python-telegram-bot, wacli (Go) |
 | Email | Himalaya CLI (Rust) |
 | Calendar | python-caldav |

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -31,6 +31,7 @@ Key variables:
 | `GROK_API_KEY` | xAI Grok API key (optional) |
 | `GOOGLE_API_KEY` | Google Gemini API key (optional) |
 | `DEEPSEEK_API_KEY` | DeepSeek API key (optional) |
+| `OPENROUTER_API_KEY` | OpenRouter API key (optional) — one key, many models via an OpenAI-compatible gateway |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token from BotFather |
 | `TELEGRAM_ALLOWED_USER_IDS` | Comma-separated Telegram user IDs |
 | `ADMIN_API_KEY` | API key for the admin UI |
@@ -58,6 +59,7 @@ agent:
   google_api_key: "${GOOGLE_API_KEY}"
   grok_api_key: "${GROK_API_KEY}"
   deepseek_api_key: "${DEEPSEEK_API_KEY}"
+  openrouter_api_key: "${OPENROUTER_API_KEY}"
   model: "claude-sonnet-4-5-20250514"
   timezone: "Europe/Zurich"
   skills_dir: "skills/"

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -8,7 +8,7 @@ description: Get MPA up and running in minutes with Docker or from source.
 ## Prerequisites
 
 - **Docker** and **Docker Compose** (recommended), or Python 3.14+ with [uv](https://docs.astral.sh/uv/)
-- An [Anthropic API key](https://console.anthropic.com/) (or OpenAI, Grok, Google, DeepSeek)
+- An [Anthropic API key](https://console.anthropic.com/) (or OpenAI, Grok, Google, DeepSeek, or [OpenRouter](https://openrouter.ai/) for many models via one key)
 - A [Telegram bot token](https://core.telegram.org/bots#botfather)
 
 ## Quick start with Docker

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -41,7 +41,7 @@ MPA follows a **Python orchestrator + CLI tools** design. Python glues everythin
 
 | Concern | Tool |
 |---------|------|
-| LLM | Anthropic Claude, OpenAI, Grok (xAI), Google, DeepSeek |
+| LLM | Anthropic Claude, OpenAI, Grok (xAI), Google, DeepSeek, OpenRouter |
 | Email | Himalaya CLI (Rust) |
 | Contacts | Built-in contacts CLI |
 | Calendar | python-caldav |

--- a/docs/content/docs/secrets.mdx
+++ b/docs/content/docs/secrets.mdx
@@ -53,7 +53,7 @@ in `.env`, are skipped. The credentials covered:
 
 | Config key | Vault name |
 | --- | --- |
-| `agent.anthropic_api_key` / `openai` / `google` / `grok` / `deepseek_api_key` | `ANTHROPIC_API_KEY`, … |
+| `agent.anthropic_api_key` / `openai` / `google` / `grok` / `deepseek` / `openrouter_api_key` | `ANTHROPIC_API_KEY`, … |
 | `channels.telegram.bot_token` | `TELEGRAM_BOT_TOKEN` |
 | `search.api_key` | `TAVILY_API_KEY` |
 | `tools.gh.token` | `GH_TOKEN` |

--- a/tests/test_admin_ui.py
+++ b/tests/test_admin_ui.py
@@ -307,6 +307,16 @@ class TestVoicePreview:
         assert "reply_decision.enabled" in resp.text
         assert "reply_decision.max_replies_per_window" in resp.text
 
+    def test_llm_partial_has_openrouter(self):
+        # OpenRouter provider card (#128): renders (exercises the positional
+        # llmTab() call), saves the dedicated key, and carries the info text.
+        client = _client(setup_complete=True)
+        resp = client.get("/partials/llm", headers=AUTH)
+        assert resp.status_code == 200
+        assert "OpenRouter" in resp.text
+        assert "agent.openrouter_api_key" in resp.text  # save button wiring
+        assert "openrouter.ai/docs" in resp.text  # info text / docs link
+
     def test_telegram_wizard_has_group_chat(self):
         client = _client(setup_complete=True)
         resp = client.get("/channels/wizard?channel=telegram", headers=AUTH)
@@ -944,6 +954,20 @@ class TestWizardPrePopulation:
         assert resp.status_code == 200
         assert "sk-ant-test123" in resp.text
         assert "claude-haiku-4-5" in resp.text
+
+    def test_llm_step_offers_openrouter(self):
+        """The wizard LLM step lists OpenRouter and pre-fills its saved key (#128)."""
+        client = _client_with_config(
+            {
+                "agent.llm_provider": "openrouter",
+                "agent.openrouter_api_key": "sk-or-test123",
+            },
+            step="identity",
+        )
+        resp = client.post("/setup/step", json={"step": "llm", "values": {}})
+        assert resp.status_code == 200
+        assert 'value="openrouter"' in resp.text  # provider dropdown option
+        assert "sk-or-test123" in resp.text  # pre-filled saved key
 
     def test_identity_step_shows_saved_values(self):
         """Navigating back to identity step should show saved name, owner, tz."""

--- a/tests/test_imagegen.py
+++ b/tests/test_imagegen.py
@@ -91,6 +91,15 @@ def test_openrouter_reuse_requires_openrouter_base_url():
     assert imagegen.resolve_api_key(cfg) == "sk-or"
 
 
+def test_openrouter_reuses_dedicated_llm_key():
+    """The dedicated OpenRouter LLM key (#128) is reused without the legacy
+    openai_base_url trick, and wins over it."""
+    cfg = Config()
+    cfg.tools.imagegen.provider = "openrouter"
+    cfg.agent.openrouter_api_key = "sk-or-dedicated"
+    assert imagegen.resolve_api_key(cfg) == "sk-or-dedicated"
+
+
 def test_fal_never_reuses_llm_key():
     cfg = Config()
     cfg.tools.imagegen.provider = "fal"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -21,6 +21,25 @@ def test_from_agent_config_carries_thinking_level() -> None:
     assert LLMClient.from_agent_config(cfg).thinking_level == "low"
 
 
+def test_from_agent_config_openrouter_defaults_base_url() -> None:
+    """OpenRouter (#128) routes through the OpenAI-compatible client with the
+    gateway base URL when none is configured."""
+    cfg = AgentConfig(llm_provider="openrouter", openrouter_api_key="k")
+    client = LLMClient.from_agent_config(cfg)
+    assert client.provider == "openrouter"
+    assert "openrouter.ai/api/v1" in str(client._client.base_url)
+
+
+def test_from_agent_config_openrouter_base_url_override() -> None:
+    cfg = AgentConfig(
+        llm_provider="openrouter",
+        openrouter_api_key="k",
+        openrouter_base_url="https://example.test/v1",
+    )
+    client = LLMClient.from_agent_config(cfg)
+    assert "example.test" in str(client._client.base_url)
+
+
 @pytest.mark.asyncio
 async def test_anthropic_generate_sends_effort_when_set() -> None:
     client = LLMClient("anthropic", "x", thinking_level="medium")


### PR DESCRIPTION
Closes #128.

Promotes OpenRouter from an image-generation-only helper to a first-class LLM provider usable across chat and every background-inference kind (memory extraction/consolidation, goal decomposition, task reflection, reply decision, compaction, vision fallback).

## What it does

OpenRouter is OpenAI-compatible, so it routes through the existing `AsyncOpenAI` path — no new SDK. The work is wiring it into every place the codebase enumerates a provider.

**Backend**
- `AgentConfig` gains `openrouter_api_key` / `openrouter_base_url`.
- `LLMClient.from_agent_config` routes `openrouter`; default base URL `https://openrouter.ai/api/v1` (via `_DEFAULT_BASE_URLS`), overridable in config.
- Background inference already resolves `{provider}_api_key` / `{provider}_base_url` generically, so selecting OpenRouter for any background task works with no extra code.

**Credentials (in the vault)**
- `agent.openrouter_api_key` added to `INFRA_VAULT_KEYS` (→ `OPENROUTER_API_KEY`), `_AUTOVAULT_KEYS` (encrypts on save, config keeps only a `${vault:…}` ref), and `SECRET_KEYS` (redacted in read-only exports). No plaintext key is shipped to the browser once vaulted.

**Model list**
- `/setup/list-models` and `/setup/test-connection` handle `openrouter` via the OpenAI-compatible client, so **Fetch models** returns OpenRouter's live catalog and **Test connection** validates the key.

**UI + info text**
- OpenRouter added to the provider selector, model datalists, and all per-provider state in the setup wizard and the admin **Providers** sub-tab.
- Each OpenRouter card carries the requested guidance: what OpenRouter is, namespaced `provider/model` ids, model-routing / fallback / transparent-pricing notes, and doc links (docs, models & pricing, provider routing).

**Image generation coherence**
- "Reuse LLM key" now resolves the dedicated `openrouter_api_key` directly, preferring it over the legacy `openai_base_url == openrouter` arrangement (which still works).

**Docs**
- README, architecture / configuration / secrets / index / getting-started, and `config.yml.example` list OpenRouter.

## Tests
- `from_agent_config` base-URL defaulting + explicit override.
- Image-gen reuse of the dedicated OpenRouter key.
- Render smoke tests: `/partials/llm` and the wizard LLM step emit the OpenRouter card, save wiring, info-text link, and provider option (exercises the positional `llmTab()` call end-to-end).
- Full suite green: 834 passed.
