### PR TITLE
fix: serialize concurrent turns of one chat with a per-chat lock

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -3624,24 +3624,31 @@ class AgentCore:
     ) -> None:
         """Record a background batch's notification + digest as an assistant turn —
         merged into the trailing assistant turn so replayed history stays strictly
-        alternating for providers that require it (#15)."""
+        alternating for providers that require it (#15).
+
+        Runs in the background subagent task, so it holds the same per-chat lock as
+        ``process()``: this fold is another read-modify-write on the chat's history,
+        and a concurrent foreground turn on the same chat would otherwise interleave
+        with it. Background delivery never runs under a held lock for this key (the
+        spawning turn returned long ago), so acquiring it here can't deadlock."""
         if not chat_id or channel == "system":
             return
         try:
-            if self.history_mode == "session":
-                merged = await self.history.append_to_last_session_message(
-                    channel, user_id, f"\n\n{framed}", chat_id
-                )
-                if not merged:
-                    await self.history.append_session_message(
-                        channel, user_id, {"role": "assistant", "content": framed}, chat_id
+            async with self._chat_lock(channel, user_id, chat_id):
+                if self.history_mode == "session":
+                    merged = await self.history.append_to_last_session_message(
+                        channel, user_id, f"\n\n{framed}", chat_id
                     )
-            else:
-                merged = await self.history.append_to_last_turn(
-                    channel, user_id, "assistant", f"\n\n{framed}", chat_id
-                )
-                if not merged:
-                    await self.history.add_turn(channel, user_id, "assistant", framed, chat_id)
+                    if not merged:
+                        await self.history.append_session_message(
+                            channel, user_id, {"role": "assistant", "content": framed}, chat_id
+                        )
+                else:
+                    merged = await self.history.append_to_last_turn(
+                        channel, user_id, "assistant", f"\n\n{framed}", chat_id
+                    )
+                    if not merged:
+                        await self.history.add_turn(channel, user_id, "assistant", framed, chat_id)
         except Exception:
             log.exception("Failed to record subagent context (chat=%s)", chat_id)
 
@@ -3665,10 +3672,10 @@ class AgentCore:
         starts a fresh user turn — ``_coalesce_user_messages`` merges the run back
         into one before the next LLM call, so alternation always holds.
 
-        ponytail: the fold is a non-locked read-modify-write, so two silent
-        records racing in one busy group can drop a line of ambient context (never
-        a reply). Add a per-(channel,user,chat) asyncio.Lock around process() if a
-        room ever shows missing turns.
+        This fold is a read-modify-write; two silent records racing in one busy
+        group would drop a line of ambient context. It runs inside ``process()``,
+        which now holds a per-(channel,user,chat) lock, so records of one chat are
+        serialized and the race is closed.
         """
         if channel == "system":
             return

--- a/core/agent.py
+++ b/core/agent.py
@@ -11,7 +11,7 @@ import re
 import shlex
 import time
 import uuid
-from collections import OrderedDict, deque
+from collections import OrderedDict, defaultdict, deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
@@ -1042,6 +1042,18 @@ class AgentCore:
         # ponytail: unbounded keys if you have thousands of distinct chats;
         # prune oldest keys if that ever shows up in memory.
         self._reply_times: dict[tuple[str, str], list[float]] = {}
+        # Per-chat turn lock: serialize concurrent turns of the SAME
+        # (channel, user_id, chat_id) so their read-modify-writes on the shared
+        # history/session caches can't interleave. In a crowded group room two
+        # inbound messages arrive as separate tasks and race the silent-fold RMW
+        # (_record_inbound) and the session cache — dropping a line of context.
+        # Different chats/agents get different keys, so cross-chat concurrency is
+        # untouched. In-memory, resets on restart.
+        # ponytail: one lock per distinct chat key, never evicted — a lock is
+        # tiny; prune stale keys only if a real deployment ever shows growth.
+        self._chat_locks: defaultdict[tuple[str, str, str], asyncio.Lock] = defaultdict(
+            asyncio.Lock
+        )
 
         # Web search (Tavily)
         if config.search.enabled and config.search.api_key:
@@ -1054,6 +1066,43 @@ class AgentCore:
             log.info("Web search disabled (no API key or not enabled)")
 
     async def process(
+        self,
+        message: str,
+        channel: str,
+        user_id: str,
+        attachments: list[Attachment] | None = None,
+        chat_id: str = "",
+        agent_name: str | None = None,
+        respond: bool = True,
+        addressed: bool = True,
+        message_id: int | None = None,
+    ) -> AgentResponse:
+        """Serialize concurrent turns of one chat, then run the turn.
+
+        A single ``(channel, user_id, chat_id)`` is one conversation, and its
+        turns share in-memory history/session caches. When two inbound messages
+        of the same chat arrive as separate tasks (a crowded group room), their
+        read-modify-writes can interleave — the silent-fold RMW in
+        ``_record_inbound`` drops a line of ambient context, and the session
+        cache can lose an append. The per-chat lock makes turns of one chat run
+        one at a time; different chats and agents get different keys, so
+        cross-chat concurrency is unchanged. The turn logic lives in
+        ``_process_impl``.
+        """
+        async with self._chat_locks[(channel, user_id, chat_id)]:
+            return await self._process_impl(
+                message,
+                channel,
+                user_id,
+                attachments=attachments,
+                chat_id=chat_id,
+                agent_name=agent_name,
+                respond=respond,
+                addressed=addressed,
+                message_id=message_id,
+            )
+
+    async def _process_impl(
         self,
         message: str,
         channel: str,

--- a/core/agent.py
+++ b/core/agent.py
@@ -11,7 +11,7 @@ import re
 import shlex
 import time
 import uuid
-from collections import OrderedDict, defaultdict, deque
+from collections import OrderedDict, deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
@@ -1042,18 +1042,6 @@ class AgentCore:
         # ponytail: unbounded keys if you have thousands of distinct chats;
         # prune oldest keys if that ever shows up in memory.
         self._reply_times: dict[tuple[str, str], list[float]] = {}
-        # Per-chat turn lock: serialize concurrent turns of the SAME
-        # (channel, user_id, chat_id) so their read-modify-writes on the shared
-        # history/session caches can't interleave. In a crowded group room two
-        # inbound messages arrive as separate tasks and race the silent-fold RMW
-        # (_record_inbound) and the session cache — dropping a line of context.
-        # Different chats/agents get different keys, so cross-chat concurrency is
-        # untouched. In-memory, resets on restart.
-        # ponytail: one lock per distinct chat key, never evicted — a lock is
-        # tiny; prune stale keys only if a real deployment ever shows growth.
-        self._chat_locks: defaultdict[tuple[str, str, str], asyncio.Lock] = defaultdict(
-            asyncio.Lock
-        )
 
         # Web search (Tavily)
         if config.search.enabled and config.search.api_key:
@@ -1089,7 +1077,7 @@ class AgentCore:
         cross-chat concurrency is unchanged. The turn logic lives in
         ``_process_impl``.
         """
-        async with self._chat_locks[(channel, user_id, chat_id)]:
+        async with self._chat_lock(channel, user_id, chat_id):
             return await self._process_impl(
                 message,
                 channel,
@@ -1101,6 +1089,25 @@ class AgentCore:
                 addressed=addressed,
                 message_id=message_id,
             )
+
+    def _chat_lock(self, channel: str, user_id: str, chat_id: str) -> asyncio.Lock:
+        """The turn lock for one chat key, created on first use.
+
+        Built lazily rather than in ``__init__`` so ``process()`` also works on an
+        instance created via ``object.__new__`` (the bare-agent test pattern) and
+        on any future alternate constructor — the lock map has a single owner here.
+        In-memory, resets on restart. ponytail: one lock per distinct chat key,
+        never evicted — a lock is tiny; prune stale keys only if a real deployment
+        ever shows growth.
+        """
+        locks = getattr(self, "_chat_locks", None)
+        if locks is None:
+            locks = self._chat_locks = {}
+        key = (channel, user_id, chat_id)
+        lock = locks.get(key)
+        if lock is None:
+            lock = locks[key] = asyncio.Lock()
+        return lock
 
     async def _process_impl(
         self,

--- a/tests/test_chat_lock.py
+++ b/tests/test_chat_lock.py
@@ -1,0 +1,63 @@
+"""Per-chat turn lock: concurrent turns of the SAME (channel, user_id, chat_id)
+serialize, while different chats still run concurrently.
+
+This guards the group-room race — two inbound messages of one chat racing the
+shared history/session caches (silent-fold RMW in ``_record_inbound``, session
+append) — without throttling unrelated chats.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core.config import Config
+from core.models import AgentResponse
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from core.agent import AgentCore
+
+    return AgentCore(Config())
+
+
+def _install_overlap_tracker(agent, monkeypatch):
+    """Swap ``_process_impl`` for a slow coroutine that records peak overlap.
+
+    It holds the turn across an ``await`` so a racing task overlaps whenever the
+    lock does NOT serialize them — making the peak concurrent count the signal.
+    """
+    state = {"active": 0, "peak": 0}
+
+    async def fake_impl(message, channel, user_id, **kw):
+        state["active"] += 1
+        state["peak"] = max(state["peak"], state["active"])
+        await asyncio.sleep(0.05)
+        state["active"] -= 1
+        return AgentResponse(text="")
+
+    monkeypatch.setattr(agent, "_process_impl", fake_impl)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_same_chat_turns_serialize(agent, monkeypatch) -> None:
+    state = _install_overlap_tracker(agent, monkeypatch)
+    await asyncio.gather(
+        agent.process("a", "telegram", "u", chat_id="-100"),
+        agent.process("b", "telegram", "u", chat_id="-100"),
+    )
+    assert state["peak"] == 1  # same key → never ran at the same time
+
+
+@pytest.mark.asyncio
+async def test_different_chats_run_concurrently(agent, monkeypatch) -> None:
+    state = _install_overlap_tracker(agent, monkeypatch)
+    await asyncio.gather(
+        agent.process("a", "telegram", "u", chat_id="-100"),
+        agent.process("b", "telegram", "u", chat_id="-200"),
+    )
+    assert state["peak"] == 2  # different keys → overlapped freely


### PR DESCRIPTION
## Problem

Every inbound message is handled as its own asyncio task (`concurrent_updates(8)` per bot; each Telegram update → `asyncio.create_task`). Two messages of the **same** `(channel, user_id, chat_id)` therefore process concurrently and race the shared in-memory history/session caches:

- the silent-fold read-modify-write in `_record_inbound` (group rooms, #30) can **drop a line of ambient context**, and
- a session-cache append can be lost.

Most visible in crowded group rooms, where un-addressed messages arrive back-to-back and each folds into the trailing turn. The race was already flagged as a deferred `ponytail:` note in `_record_inbound`.

## Fix

Serialize turns of one chat with a per-chat `asyncio.Lock`:

- `process()` now wraps the whole turn in `async with self._chat_lock(channel, user_id, chat_id)`. Same chat → one lock → turns run one at a time. Different chat/agent → different key → concurrency untouched, so throughput is unchanged.
- The lock map is built lazily in `_chat_lock()` (not `__init__`), so `process()` also works on instances created via `object.__new__` (the bare-agent test pattern) with no per-test wiring.
- Root-caused beyond `process()`: `_record_subagent_context` folds a finished background batch into the origin chat's history with the **same** RMW pattern, but runs in the subagent task — outside `process()`, hence outside the lock. It now takes the same per-chat key. Background delivery never runs under a held lock for that key (the spawning turn returned long ago), so it can't deadlock.
- Refreshed the now-stale deferral note in `_record_inbound`.

No new dependency; `process()` internals moved verbatim into `_process_impl`.

## Behaviour note

Scheduler agent-tasks all use the key `(system, scheduler, scheduler)`, so concurrent cron jobs now serialize. This is correct — they already shared that history key — but if scheduled-job parallelism ever matters, give jobs distinct keys.

## Tests

- New `tests/test_chat_lock.py`: same chat → peak concurrency 1 (serialized); different chats → peak 2 (overlap freely).
- Full suite: 831 passed. `ruff check` clean.
