### PR TITLE
feat(#135): restructure agent editor into tabs

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -200,12 +200,10 @@ async def _wizard_step_context(step: str, config_store: ConfigStore) -> dict[str
                 ctx[var] = val
     elif step == "agent":
         store = await _agent_store_from_config(config_store)
-        # Plain dicts so the wizard template (Jinja) can read emoji/role/name.
+        # Plain dicts so the wizard template (Jinja) can read role/name.
         # The current default is offered as the "Default" radio, not a starter card.
         ctx["agents"] = [  # type: ignore[assignment]
-            {"name": p.name, "role": p.role, "emoji": p.emoji}
-            for p in await store.list_agents()
-            if not p.is_default
+            {"name": p.name, "role": p.role} for p in await store.list_agents() if not p.is_default
         ]
     elif step == "email":
         raw = await config_store.get("email.providers")
@@ -563,7 +561,6 @@ class AgentUpsertIn(BaseModel):
     name: str
     agent_name: str = ""
     role: str = ""
-    emoji: str = ""
     voice: str = ""
     character: str = ""
     skills: list[str] = []
@@ -958,10 +955,12 @@ def create_admin_app(
         A globally-disabled feature (e.g. artifacts) is dropped so its tool is
         hidden from the agent scope UI.
         """
-        from voice.pipeline import KOKORO_LANGUAGES, KOKORO_VOICES
-
         store = await _skills_store_from_config(config_store)
-        all_skills = [s["name"] for s in await store.list_skills()]
+        # Skills carry a summary; tools get a short static blurb (#135) so the
+        # editor can show what each does next to its checkbox.
+        all_skills = [
+            {"name": s["name"], "summary": s.get("summary", "")} for s in await store.list_skills()
+        ]
         sub_enabled = await config_store.get("subagents.enabled")
         sub_on = sub_enabled is None or sub_enabled == "true"
         ig_on = (await config_store.get("tools.imagegen.enabled")) == "true"
@@ -970,13 +969,17 @@ def create_admin_app(
         )
         return {
             "all_skills": all_skills,
-            "all_tools": gateable_tools_for(
-                subagents_enabled=sub_on,
-                imagegen_enabled=ig_on,
-                workspace_enabled=ws_on,
-            ),
-            "kokoro_voices": KOKORO_VOICES,
-            "kokoro_languages": KOKORO_LANGUAGES,
+            "all_tools": [
+                {"name": t, "desc": TOOL_DESCRIPTIONS.get(t, "")}
+                for t in gateable_tools_for(
+                    subagents_enabled=sub_on,
+                    imagegen_enabled=ig_on,
+                    workspace_enabled=ws_on,
+                )
+            ],
+            # Global Voice (STT/TTS) settings — the editor's Identity tab now hosts
+            # this panel (#135); it moved off the Agents list tab.
+            **await _voice_context(),
             # External CLI tools that support a per-agent identity (#93). Only the
             # system-wide enabled ones are offered, so the registry stays the
             # source of truth for what exists.
@@ -1136,14 +1139,11 @@ def create_admin_app(
         }
 
     async def _agents_context() -> dict:
-        """Context for the Agents tab: all agents (the default flagged one pinned
-        first) + the global voice card (#115 flw)."""
+        """Context for the Agents tab: all agents, the default flagged one pinned
+        first. The global voice card moved to the agent editor's Identity tab (#135)."""
         store = await _agent_store_from_config(config_store)
         agents = sorted(await store.list_agents(), key=lambda a: (not a.is_default, a.name))
-        return {
-            "agents": agents,
-            **await _voice_context(),
-        }
+        return {"agents": agents}
 
     @app.get("/partials/identity", dependencies=[Depends(auth)])
     async def partial_identity() -> HTMLResponse:
@@ -2886,7 +2886,6 @@ def create_admin_app(
                 name=name,
                 agent_name=body.agent_name.strip(),
                 role=body.role.strip(),
-                emoji=body.emoji.strip(),
                 voice=body.voice.strip(),
                 character=body.character,
                 skills=[s.strip() for s in body.skills if s.strip()],
@@ -4054,6 +4053,29 @@ _WORKSPACE_TOOLS = (
     "grep",
     "run_command_in_dir",
 )
+
+# One-line blurbs for the per-agent Tool scope UI (#135), so each checkbox says
+# what it does. Keyed by the gateable tool name; unlisted tools show no blurb.
+TOOL_DESCRIPTIONS = {
+    "run_command": "Run shell commands on the host (guarded; risky ones ask first).",
+    "send_email": "Compose and send email from a bound account.",
+    "reply_email": "Reply within an existing email thread.",
+    "send_message": "Send a chat message to a Telegram/WhatsApp conversation.",
+    "set_reaction": "React to a message with an emoji.",
+    "create_calendar_event": "Create events on a bound calendar.",
+    "search_contacts": "Look up people in a bound address book.",
+    "create_contact": "Add a contact to a bound address book.",
+    "web_search": "Search the web (needs the Web search tool enabled).",
+    "manage_jobs": "Schedule, list and cancel the agent's own jobs.",
+    "spawn_subagent": "Delegate a scoped subtask to a child agent.",
+    "generate_image": "Generate images and send them as photos.",
+    "read_file": "Read a file inside the workspace.",
+    "write_file": "Create or overwrite a file inside the workspace.",
+    "edit_file": "Edit a file inside the workspace.",
+    "list_dir": "List a directory inside the workspace.",
+    "grep": "Search file contents inside the workspace.",
+    "run_command_in_dir": "Run a command inside a workspace subdirectory.",
+}
 
 
 def gateable_tools_for(

--- a/api/templates/agent_editor.html
+++ b/api/templates/agent_editor.html
@@ -15,22 +15,26 @@
     </div>
   </div>
 
-  {# ── Guided mode ── #}
-  <div x-show="mode === 'guided'" class="flex gap-4 flex-wrap items-start">
-    <div class="flex-[2] min-w-[280px] space-y-3">
+  {# ── Guided mode: one tab per concern (#135) ── #}
+  <div x-show="mode === 'guided'">
+    <div class="flex border-b border-border mb-4 overflow-x-auto">
+      <button type="button" class="tab-link" :class="tab === 'identity' && 'tab-link-active'" @click="tab = 'identity'">Identity</button>
+      <button type="button" class="tab-link" :class="tab === 'telegram' && 'tab-link-active'" @click="tab = 'telegram'">Telegram</button>
+      <button type="button" class="tab-link" :class="tab === 'accounts' && 'tab-link-active'" @click="tab = 'accounts'">Accounts</button>
+      <button type="button" class="tab-link" :class="tab === 'skills' && 'tab-link-active'" @click="tab = 'skills'">Skills</button>
+      <button type="button" class="tab-link" :class="tab === 'tools' && 'tab-link-active'" @click="tab = 'tools'">Tools</button>
+      <button type="button" class="tab-link" :class="tab === 'secrets' && 'tab-link-active'" @click="tab = 'secrets'">Secrets</button>
+    </div>
+
+    {# ── Identity ── #}
+    <div x-show="tab === 'identity'" class="space-y-3">
       <div class="card space-y-3">
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          <div class="sm:col-span-2">
-            <label class="label">Name (slug)</label>
-            <input class="input-sm" x-model="name" placeholder="fitness-coach">
-            {% if not is_new %}
-            <p class="hint" x-show="name.trim() !== originalName">Renaming moves this agent's chat bindings, private memories and scheduled jobs to the new slug. An agent with its own bot needs an agent restart afterwards.</p>
-            {% endif %}
-          </div>
-          <div>
-            <label class="label">Emoji</label>
-            <input class="input-sm" x-model="emoji" placeholder="🏋️">
-          </div>
+        <div>
+          <label class="label">Name (slug)</label>
+          <input class="input-sm" x-model="name" placeholder="fitness-coach">
+          {% if not is_new %}
+          <p class="hint" x-show="name.trim() !== originalName">Renaming moves this agent's chat bindings, private memories and scheduled jobs to the new slug. An agent with its own bot needs an agent restart afterwards.</p>
+          {% endif %}
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
@@ -42,37 +46,55 @@
             <input class="input-sm" x-model="agent_name" placeholder="Forge">
           </div>
         </div>
-        <div>
-          <label class="label">Voice <span class="text-muted">(TTS — blank = default)</span></label>
-          <input class="input-sm" x-model="voice" list="voice-options" placeholder="en-US-AvaNeural">
-          <datalist id="voice-options">
-            <option value="en-US-AvaNeural"></option>
-            <option value="en-US-AndrewNeural"></option>
-            <option value="en-US-GuyNeural"></option>
-            <option value="en-GB-SoniaNeural"></option>
-            <option value="en-GB-RyanNeural"></option>
-            <option value="en-AU-NatashaNeural"></option>
-            {% for v in kokoro_voices %}
-            <option value="{{ v }}"></option>
-            {% endfor %}
-          </datalist>
-          <div class="flex items-center gap-2 mt-2 flex-wrap">
-            <input type="text" class="input-sm" style="max-width:240px" x-model="previewText"
-                   placeholder="Preview text… (blank = sample)">
-            <select x-show="/^[a-z][fm]_/.test(voice)" class="input-sm" style="max-width:170px"
-                    x-model="previewLang" title="Pronunciation language">
-              <option value="">Auto (match voice)</option>
-              {% for code, label in kokoro_languages %}
-              <option value="{{ code }}">{{ label }}</option>
-              {% endfor %}
-            </select>
-            <button type="button" class="btn btn-sm"
-                    @click="previewVoice(voice, previewText, /^[a-z][fm]_/.test(voice) ? previewLang : '', $event.currentTarget)">▶ Preview</button>
-          </div>
-          <p class="text-muted text-xs mt-1">Edge TTS names (<code>en-US-AvaNeural</code>) or Kokoro names (<code>af_bella</code>) — match the active backend. Preview plays the selected voice; for Kokoro you can override the language.</p>
-        </div>
       </div>
 
+      <div class="card">
+        <label class="label">Character &amp; tone <span class="text-muted">— who the agent is + tone & behaviour</span></label>
+        <textarea class="textarea" x-model="character" style="min-height:260px; font-size:0.8rem; line-height:1.5"
+                  placeholder="You are a strength &amp; conditioning coach…&#10;&#10;## Tone&#10;- Direct and motivating…"></textarea>
+      </div>
+
+      {# Per-agent voice override #}
+      <div class="card">
+        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">This agent's voice</h3>
+        <label class="label">Voice <span class="text-muted">(TTS — blank = the global default below)</span></label>
+        <input class="input-sm" x-model="voice" list="voice-options" placeholder="en-US-AvaNeural">
+        <datalist id="voice-options">
+          <option value="en-US-AvaNeural"></option>
+          <option value="en-US-AndrewNeural"></option>
+          <option value="en-US-GuyNeural"></option>
+          <option value="en-GB-SoniaNeural"></option>
+          <option value="en-GB-RyanNeural"></option>
+          <option value="en-AU-NatashaNeural"></option>
+          {% for v in kokoro_voices %}
+          <option value="{{ v }}"></option>
+          {% endfor %}
+        </datalist>
+        <div class="flex items-center gap-2 mt-2 flex-wrap">
+          <input type="text" class="input-sm" style="max-width:240px" x-model="previewText"
+                 placeholder="Preview text… (blank = sample)">
+          <select x-show="/^[a-z][fm]_/.test(voice)" class="input-sm" style="max-width:170px"
+                  x-model="previewLang" title="Pronunciation language">
+            <option value="">Auto (match voice)</option>
+            {% for code, label in kokoro_languages %}
+            <option value="{{ code }}">{{ label }}</option>
+            {% endfor %}
+          </select>
+          <button type="button" class="btn btn-sm"
+                  @click="previewVoice(voice, previewText, /^[a-z][fm]_/.test(voice) ? previewLang : '', $event.currentTarget)">▶ Preview</button>
+        </div>
+        <p class="text-muted text-xs mt-1">Edge TTS names (<code>en-US-AvaNeural</code>) or Kokoro names (<code>af_bella</code>) — match the active backend. Preview plays the selected voice; for Kokoro you can override the language.</p>
+      </div>
+
+      {# Global speech engine (STT/TTS) — shared by every agent (#135). #}
+      <div>
+        <p class="text-muted text-xs mb-2">Engine settings below are <strong>global</strong> — the STT model and TTS backend are shared by every agent. The <em>Voice</em> field above overrides only this agent's speaking voice.</p>
+        {% include "partials/identity.html" %}
+      </div>
+    </div>
+
+    {# ── Telegram ── #}
+    <div x-show="tab === 'telegram'" class="space-y-3">
       <div class="card space-y-3">
         <h3 class="text-xs text-muted uppercase tracking-wider">Telegram bot</h3>
         <p class="text-xs text-muted">Each agent talks to Telegram through its own bot. Paste a token to bring this agent online; leave it blank and the agent has no bot of its own. The <strong>default</strong> agent's bot is the one people reach when no other bot or per-chat binding matches. Restart the agent after changing a token.</p>
@@ -136,50 +158,10 @@
           </div>
         </template>
       </div>
-
-      <div class="card">
-        <label class="label">Character &amp; tone <span class="text-muted">— who the agent is + tone & behaviour</span></label>
-        <textarea class="textarea" x-model="character" style="min-height:260px; font-size:0.8rem; line-height:1.5"
-                  placeholder="You are a strength &amp; conditioning coach…&#10;&#10;## Tone&#10;- Direct and motivating…"></textarea>
-      </div>
     </div>
 
-    {# Scopes #}
-    <div class="flex-1 min-w-[240px] space-y-3">
-      <div class="card">
-        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Skills allowlist</h3>
-        <p class="text-xs text-muted mb-2">None ticked = all skills allowed.</p>
-        <div class="space-y-1 max-h-56 overflow-y-auto">
-          {% for s in all_skills %}
-          <label class="flex items-center gap-2 text-xs">
-            <input type="checkbox" value="{{ s }}" x-model="skills"> {{ s }}
-          </label>
-          {% else %}
-          <p class="text-xs text-muted">No skills defined yet.</p>
-          {% endfor %}
-        </div>
-      </div>
-
-      <div class="card">
-        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Tool scope</h3>
-        <p class="text-xs text-muted mb-2">None ticked = all tools. <code>load_skill</code> is always available.</p>
-        <div class="space-y-1">
-          {% for t in all_tools %}
-          <label class="flex items-center gap-2 text-xs">
-            <input type="checkbox" value="{{ t }}" x-model="tools"> {{ t }}
-          </label>
-          {% endfor %}
-        </div>
-      </div>
-
-      <div class="card">
-        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Secret scope</h3>
-        <p class="text-xs text-muted mb-2">Vault namespaces (one per line). Stored now; enforced once the secrets vault lands.</p>
-        <textarea class="textarea" x-model="secretsText" style="min-height:64px; font-size:0.75rem"
-                  placeholder="agent:fitness-coach:*"></textarea>
-      </div>
-
-      {# ── Email, calendar & contacts accounts (#110) ── #}
+    {# ── Accounts: email, calendar & contacts bindings (#110) ── #}
+    <div x-show="tab === 'accounts'" class="space-y-3">
       <div class="card">
         <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Email, calendar &amp; contacts accounts</h3>
         <p class="text-xs text-muted mb-3">
@@ -252,6 +234,46 @@
         <template x-if="!availableContacts.length">
           <p class="text-xs text-muted mt-3">No contacts accounts configured yet — add one in the Contacts tab.</p>
         </template>
+      </div>
+    </div>
+
+    {# ── Skills ── #}
+    <div x-show="tab === 'skills'">
+      <div class="card">
+        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Skills allowlist</h3>
+        <p class="text-xs text-muted mb-3">Tick the skills this agent may load. None ticked = all skills allowed.</p>
+        <div class="space-y-2 max-h-[32rem] overflow-y-auto">
+          {% for s in all_skills %}
+          <label class="flex items-start gap-2 text-xs">
+            <input type="checkbox" value="{{ s.name }}" x-model="skills" class="mt-0.5">
+            <span>
+              <span class="font-semibold break-all">{{ s.name }}</span>
+              {% if s.summary %}<span class="text-muted block">{{ s.summary }}</span>{% endif %}
+            </span>
+          </label>
+          {% else %}
+          <p class="text-xs text-muted">No skills defined yet.</p>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+
+    {# ── Tools: scope + per-agent tool identities (#93) ── #}
+    <div x-show="tab === 'tools'" class="space-y-3">
+      <div class="card">
+        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Tool scope</h3>
+        <p class="text-xs text-muted mb-3">Tick the tools this agent may call. None ticked = all tools. <code>load_skill</code> is always available.</p>
+        <div class="space-y-2">
+          {% for t in all_tools %}
+          <label class="flex items-start gap-2 text-xs">
+            <input type="checkbox" value="{{ t.name }}" x-model="tools" class="mt-0.5">
+            <span>
+              <span class="font-semibold">{{ t.name }}</span>
+              {% if t.desc %}<span class="text-muted block">{{ t.desc }}</span>{% endif %}
+            </span>
+          </label>
+          {% endfor %}
+        </div>
       </div>
 
       {# ── Tool identities (#93) ── #}
@@ -377,13 +399,23 @@
         {% endfor %}
       </div>
     </div>
+
+    {# ── Secrets ── #}
+    <div x-show="tab === 'secrets'">
+      <div class="card">
+        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Secret scope</h3>
+        <p class="text-xs text-muted mb-2">Vault namespaces (one per line). Stored now; enforced once the secrets vault lands.</p>
+        <textarea class="textarea" x-model="secretsText" style="min-height:64px; font-size:0.75rem"
+                  placeholder="agent:fitness-coach:*"></textarea>
+      </div>
+    </div>
   </div>
 
   {# ── Raw mode ── #}
   <div x-show="mode === 'raw'" class="card">
     <label class="label">Markdown (YAML frontmatter)</label>
     <textarea class="textarea" x-model="raw" style="min-height:460px; font-size:0.8rem; line-height:1.5; tab-size:2"></textarea>
-    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, emoji, voice, bot_token, allowed_user_ids, group_chat, skills, tools, secrets, email_accounts, calendar_accounts, contacts_accounts, chat_settings, character).</p>
+    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, voice, bot_token, allowed_user_ids, group_chat, skills, tools, secrets, email_accounts, calendar_accounts, contacts_accounts, chat_settings, character).</p>
   </div>
 
   <div class="flex items-center gap-2 mt-3">
@@ -396,12 +428,12 @@
   function agentEditor() {
     return {
       mode: 'guided',
+      tab: 'identity',
       isNew: {{ is_new|tojson }},
       originalName: {{ agent.name|tojson }},
       name: {{ agent.name|tojson }},
       agent_name: {{ agent.agent_name|tojson }},
       role: {{ agent.role|tojson }},
-      emoji: {{ agent.emoji|tojson }},
       voice: {{ agent.voice|tojson }},
       previewText: '',
       previewLang: '',
@@ -599,7 +631,6 @@
           '---\n' +
           'agent_name: ' + (this.agent_name || '') + '\n' +
           'role: ' + (this.role || '') + '\n' +
-          'emoji: ' + (this.emoji || '') + '\n' +
           'voice: ' + (this.voice || '') + '\n' +
           'bot_token: ' + JSON.stringify(this.bot_token || '') + '\n' +
           'allowed_user_ids: ' + list(userIds) + '\n' +
@@ -630,7 +661,7 @@
           ? { name: name, raw: this.raw, gh_token: ghToken }
           : {
               name: name, agent_name: this.agent_name, role: this.role,
-              emoji: this.emoji, voice: this.voice,
+              voice: this.voice,
               character: this.character,
               skills: this.skills, tools: this.tools,
               secrets: this.secretsText.split('\n').map(s => s.trim()).filter(Boolean),

--- a/api/templates/partials/agents.html
+++ b/api/templates/partials/agents.html
@@ -21,7 +21,7 @@
                  || {{ p.name|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
                  || {{ (p.role or '')|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())">
       <div class="flex items-start gap-2">
-        <span class="text-2xl leading-none">{{ p.emoji or '🧩' }}</span>
+        <span class="text-2xl leading-none">🧩</span>
         <div class="min-w-0 flex-1">
           <div class="text-sm font-semibold truncate">{{ p.role or p.name }}</div>
           <div class="text-muted text-xs break-all">{{ p.name }}</div>
@@ -69,12 +69,5 @@
     {% if not agents %}
     <div class="text-muted text-xs py-2 col-span-full">No agents yet — create one to get started.</div>
     {% endif %}
-  </div>
-
-  {# Global voice settings (STT/TTS — applies to every agent) #}
-  <div class="mt-8 border-t border-border pt-6">
-    <h2 class="text-base mb-1">Voice</h2>
-    <p class="text-muted text-xs mb-3">Global speech-to-text / text-to-speech settings, shared by every agent.</p>
-    {% include "partials/identity.html" %}
   </div>
 </div>

--- a/core/agent.py
+++ b/core/agent.py
@@ -3398,7 +3398,6 @@ class AgentCore:
             name=requested.name,
             agent_name=requested.agent_name,
             role=requested.role,
-            emoji=requested.emoji,
             voice=requested.voice,
             character=requested.character,
             skills=narrow_scope(p_skills, requested.skills),

--- a/core/agents.py
+++ b/core/agents.py
@@ -34,7 +34,6 @@ CREATE TABLE IF NOT EXISTS agents (
     name TEXT PRIMARY KEY,
     agent_name TEXT DEFAULT '',
     role TEXT DEFAULT '',
-    emoji TEXT DEFAULT '',
     voice TEXT DEFAULT '',
     character TEXT DEFAULT '',
     skills TEXT DEFAULT '',
@@ -106,7 +105,6 @@ class Agent:
     name: str  # slug / identifier (PK)
     agent_name: str = ""  # display name it goes by when active; empty = global agent.name
     role: str = ""
-    emoji: str = ""
     voice: str = ""  # TTS voice override; empty = configured default
     character: str = ""  # identity + tone (a legacy `personalia` field folded in here — #98)
     skills: list[str] = field(default_factory=list)  # allowlist; [] = all
@@ -393,7 +391,6 @@ def parse_markdown(text: str, *, name: str) -> Agent:
         name=name,
         agent_name=str(fm.get("agent_name", "") or ""),
         role=str(fm.get("role", "") or ""),
-        emoji=str(fm.get("emoji", "") or ""),
         voice=str(fm.get("voice", "") or ""),
         character=character,
         skills=_as_list(fm.get("skills")),
@@ -415,7 +412,6 @@ def to_markdown(a: Agent) -> str:
     fm = {
         "agent_name": a.agent_name,
         "role": a.role,
-        "emoji": a.emoji,
         "voice": a.voice,
         "bot_token": a.bot_token,
         "allowed_user_ids": a.allowed_user_ids,
@@ -605,12 +601,12 @@ class AgentStore:
     async def _upsert(db: aiosqlite.Connection, a: Agent) -> None:
         await db.execute(
             "INSERT INTO agents "
-            "(name, agent_name, role, emoji, voice, character, skills, tools, "
+            "(name, agent_name, role, voice, character, skills, tools, "
             "secrets, bot_token, allowed_user_ids, tool_config, "
             "email_accounts, calendar_accounts, contacts_accounts, chat_settings, group_chat) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(name) DO UPDATE SET "
-            "agent_name=excluded.agent_name, role=excluded.role, emoji=excluded.emoji, "
+            "agent_name=excluded.agent_name, role=excluded.role, "
             "voice=excluded.voice, character=excluded.character, "
             "skills=excluded.skills, tools=excluded.tools, secrets=excluded.secrets, "
             "bot_token=excluded.bot_token, allowed_user_ids=excluded.allowed_user_ids, "
@@ -623,7 +619,6 @@ class AgentStore:
                 a.name,
                 a.agent_name,
                 a.role,
-                a.emoji,
                 a.voice,
                 a.character,
                 "\n".join(a.skills),
@@ -646,7 +641,6 @@ class AgentStore:
             name=row["name"],
             agent_name=row["agent_name"] or "",
             role=row["role"] or "",
-            emoji=row["emoji"] or "",
             voice=row["voice"] or "",
             character=row["character"] or "",
             skills=_as_list(row["skills"]),
@@ -781,7 +775,6 @@ if __name__ == "__main__":
     md = """---
 agent_name: Forge
 role: Fitness coach
-emoji: "🏋️"
 skills: [scheduling, memory]
 tools:
   - run_command
@@ -822,7 +815,6 @@ Extra prose in the body.
     a = parse_markdown(md, name="fitness-coach")
     assert a.agent_name == "Forge", a.agent_name
     assert a.role == "Fitness coach", a.role
-    assert a.emoji == "🏋️"
     assert a.skills == ["scheduling", "memory"], a.skills
     assert a.tools == ["run_command", "send_message"], a.tools
     assert a.bot_token == "123:ABC", a.bot_token

--- a/docs/content/docs/agents.mdx
+++ b/docs/content/docs/agents.mdx
@@ -52,7 +52,6 @@ both who the agent is and its tone).
 ---
 agent_name: Forge
 role: Fitness coach
-emoji: "🏋️"
 voice: en-US-GuyNeural
 skills: [scheduling, memory, weather]
 tools: [send_message, create_calendar_event, manage_jobs, web_search]
@@ -288,7 +287,7 @@ reach only accounts its parent identity holds, at an equal or lower level.
 ## Bot-per-agent
 
 Each agent carries its own Telegram **bot token**, so it's a separate contact in your
-address book — its own name, emoji, and voice — addressable independently of every other
+address book — its own name and voice — addressable independently of every other
 agent ([#29](https://github.com/mattmezza/mpa/issues/29)). The bot is part of the agent's
 identity, configured on the agent, not on any channel.
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -45,7 +45,6 @@ def test_markdown_roundtrip() -> None:
     p = Agent(
         name="t",
         role="R",
-        emoji="🤖",
         voice="en-GB-SoniaNeural",
         character="How.",
         skills=["memory"],

--- a/tests/test_agents_admin.py
+++ b/tests/test_agents_admin.py
@@ -84,7 +84,6 @@ def test_agent_crud_and_activation(tmp_path) -> None:
         json={
             "name": "coach",
             "role": "Fitness coach",
-            "emoji": "🏋️",
             "voice": "en-US-GuyNeural",
             "character": "You are Forge. Direct.",
             "skills": ["memory"],


### PR DESCRIPTION
Closes #135.

## What

Restructures the crowded Agent edit page into tabs, consistent with the rest of the admin UI.

### Tabs
- **Identity** — slug, role, agent name, character/tone, this agent's voice, and the global speech engine panel.
- **Telegram** — bot token, allowed user IDs, group multi-agent rooms, per-chat trigger/DM settings.
- **Accounts** — email / calendar / contacts account bindings.
- **Skills** — skill allowlist, now with a summary per skill.
- **Tools** — tool scope (each with a one-line description) + per-agent tool identities.
- **Secrets** — vault namespace scope.

### Also
- **Emoji removed** — the `emoji` property is gone from the Agent model, DB schema, markdown frontmatter, the upsert API, the wizard, and the UI. Agent cards now use a neutral 🧩. (Legacy DB columns are left in place and simply unused — no destructive migration.)
- **Voice panel moved** — the global speech (STT/TTS) card left the Agents list tab and now lives in the editor's Identity tab. Docs updated.

## Notes for review
- The **speech engine settings** (STT model, TTS backend, TTS-enabled, default voice) are inherently global — one engine, one model — so that panel still writes global config; it's just displayed in the Identity tab now, above a note that says so. The per-agent **Voice** field overrides only that agent's speaking voice. If you'd rather these be fully per-agent, that's a larger backend change and a separate issue.
- `/partials/identity` still serves the same voice card standalone (unchanged), so nothing that fetched it breaks.

## Tests
- Full suite: **856 passed**.
- Updated the agent + admin tests that referenced the dropped `emoji` field; the tabbed editor still renders every panel the existing editor tests assert on (Tool identities, GitHub identity, Token source, etc.).
