### PR TITLE
feat: Voice tab + agent-card relabel (emoji out, name/role·slug)

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1147,7 +1147,7 @@ def create_admin_app(
 
     @app.get("/partials/identity", dependencies=[Depends(auth)])
     async def partial_identity() -> HTMLResponse:
-        """Global Voice settings fragment (also embedded in the Agents tab)."""
+        """Global Voice settings fragment — the Voice tab (#135 follow-up)."""
         return _render_partial("partials/identity.html", **await _voice_context())
 
     @app.get("/partials/you", dependencies=[Depends(auth)])

--- a/api/templates/agent_editor.html
+++ b/api/templates/agent_editor.html
@@ -54,21 +54,26 @@
                   placeholder="You are a strength &amp; conditioning coach…&#10;&#10;## Tone&#10;- Direct and motivating…"></textarea>
       </div>
 
-      {# Per-agent voice override #}
+      {# Per-agent voice override — only the voices valid for the active global
+         TTS backend are offered (the backend itself lives in the Voice tab). #}
       <div class="card">
         <h3 class="text-xs text-muted uppercase tracking-wider mb-2">This agent's voice</h3>
-        <label class="label">Voice <span class="text-muted">(TTS — blank = the global default below)</span></label>
-        <input class="input-sm" x-model="voice" list="voice-options" placeholder="en-US-AvaNeural">
+        <label class="label">Voice <span class="text-muted">(TTS — blank = the global default in the Voice tab)</span></label>
+        <input class="input-sm" x-model="voice" list="voice-options"
+               placeholder="{% if backend == 'kokoro' %}af_bella{% else %}en-US-AvaNeural{% endif %}">
         <datalist id="voice-options">
+          {% if backend == 'kokoro' %}
+          {% for v in kokoro_voices %}
+          <option value="{{ v }}"></option>
+          {% endfor %}
+          {% else %}
           <option value="en-US-AvaNeural"></option>
           <option value="en-US-AndrewNeural"></option>
           <option value="en-US-GuyNeural"></option>
           <option value="en-GB-SoniaNeural"></option>
           <option value="en-GB-RyanNeural"></option>
           <option value="en-AU-NatashaNeural"></option>
-          {% for v in kokoro_voices %}
-          <option value="{{ v }}"></option>
-          {% endfor %}
+          {% endif %}
         </datalist>
         <div class="flex items-center gap-2 mt-2 flex-wrap">
           <input type="text" class="input-sm" style="max-width:240px" x-model="previewText"
@@ -83,13 +88,10 @@
           <button type="button" class="btn btn-sm"
                   @click="previewVoice(voice, previewText, /^[a-z][fm]_/.test(voice) ? previewLang : '', $event.currentTarget)">▶ Preview</button>
         </div>
-        <p class="text-muted text-xs mt-1">Edge TTS names (<code>en-US-AvaNeural</code>) or Kokoro names (<code>af_bella</code>) — match the active backend. Preview plays the selected voice; for Kokoro you can override the language.</p>
-      </div>
-
-      {# Global speech engine (STT/TTS) — shared by every agent (#135). #}
-      <div>
-        <p class="text-muted text-xs mb-2">Engine settings below are <strong>global</strong> — the STT model and TTS backend are shared by every agent. The <em>Voice</em> field above overrides only this agent's speaking voice.</p>
-        {% include "partials/identity.html" %}
+        <p class="text-muted text-xs mt-1">
+          {% if backend == 'kokoro' %}Kokoro voice names (<code>af_bella</code>) — the active backend. You can override the pronunciation language.{% else %}Edge TTS voice names (<code>en-US-AvaNeural</code>) — the active backend.{% endif %}
+          Preview plays the selected voice. Change the engine in the <strong>Voice</strong> tab.
+        </p>
       </div>
     </div>
 

--- a/api/templates/dashboard.html
+++ b/api/templates/dashboard.html
@@ -78,6 +78,10 @@
             @click="select('llm')">
       LLM
     </button>
+    <button class="tab-link" :class="tab === 'voice' && 'tab-link-active'"
+            @click="select('voice')">
+      Voice
+    </button>
     <button class="tab-link" :class="tab === 'memory' && 'tab-link-active'"
             @click="select('memory')">
       Memory
@@ -527,6 +531,7 @@
       you: '/partials/you',
       agents: '/partials/agents',
       llm: '/partials/llm',
+      voice: '/partials/identity',
       memory: '/partials/memory',
       tools: '/partials/tools',
       workspace: '/partials/workspace',

--- a/api/templates/partials/agents.html
+++ b/api/templates/partials/agents.html
@@ -19,12 +19,12 @@
     <div class="card flex flex-col gap-2 {% if p.is_default %}border-accent{% endif %}{% if not p.enabled %} opacity-60{% endif %}"
          x-show="!filter
                  || {{ p.name|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                 || {{ (p.agent_name or '')|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
                  || {{ (p.role or '')|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())">
       <div class="flex items-start gap-2">
-        <span class="text-2xl leading-none">🧩</span>
         <div class="min-w-0 flex-1">
-          <div class="text-sm font-semibold truncate">{{ p.role or p.name }}</div>
-          <div class="text-muted text-xs break-all">{{ p.name }}</div>
+          <div class="text-sm font-semibold truncate">{{ p.agent_name or p.name }}</div>
+          <div class="text-muted text-xs break-all">{{ p.role }}{% if p.role and p.agent_name %} · {% endif %}{% if p.agent_name %}{{ p.name }}{% endif %}</div>
         </div>
         {% if p.is_default %}
         <span class="badge-ok whitespace-nowrap">✓ Default</span>

--- a/api/templates/partials/identity.html
+++ b/api/templates/partials/identity.html
@@ -1,6 +1,6 @@
-{# Global Voice (STT/TTS) settings — shared by every agent. Embedded in the Agents
-   tab and served standalone at /partials/identity. Per-agent identity/character/
-   accounts now live on the agent row + editor (#115 follow-up). #}
+{# Global Voice (STT/TTS) settings — shared by every agent. Its own top-level
+   Voice tab, served at /partials/identity. The per-agent voice override lives on
+   the agent editor's Identity tab; identity/character/accounts on the agent row. #}
 <div class="card" x-data="{
   ttsEnabled: {{ tts_enabled|default('true', true)|tojson|forceescape }},
   sttModel: {{ stt_model|default('base', true)|tojson|forceescape }},


### PR DESCRIPTION
Follow-up UI polish on the Agents tab + agent editor.

## Changes

### Agents tab — card
- Drop the emoji glyph from the card.
- Title/subtitle swapped: the **agent name** is now the big title; **role · slug** is the subtitle (e.g. `Forge` / `Fitness coach · fitness-coach`).
- Fallbacks: no agent name → slug is the title; no role → subtitle is just the slug (no duplication). Filter now matches agent name too.

### Voice tab
- New top-level **Voice** tab (right after **LLM**) hosting the global STT/TTS engine settings.
- That panel is removed from the agent editor. It now lives only in the Voice tab (served by the existing `/partials/identity` fragment — no new route).

### Agent editor — per-agent voice
- Kept the per-agent voice override, but the suggestion list now shows **only voices valid for the active global TTS backend** (Kokoro voices when the backend is Kokoro, Edge names otherwise). Placeholder + hint follow the backend, and point to the Voice tab to change the engine.

## Tests
- Full suite: **856 passed**.
- Verified the card label logic across all agent-name/role combinations via a StrictUndefined render; confirmed the editor no longer embeds the engine panel and the Voice tab is wired.
