### PR TITLE
Rebrand MPA to humux

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ WHATSAPP_ALLOWED_NUMBERS=
 ADMIN_API_KEY=
 
 # Secrets vault (issue #19) — machine key for the *infra* vault.
-# Optional. If unset, MPA looks for a keyfile at data/master.key (auto-generated
+# Optional. If unset, humux looks for a keyfile at data/master.key (auto-generated
 # from the setup wizard), and ${vault:NAME} config references fall back to env.
 # Any string works (a passphrase is hashed to a key); a generated Fernet key is
 # used as-is. The agent/login vault is keyed by your admin password instead.
@@ -22,10 +22,10 @@ ADMIN_API_KEY=
 #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # In Docker:  docker compose run --rm mpa python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 # Set it once and keep it — rotating it makes existing infra-vault secrets unreadable.
-#MPA_MASTER_KEY=
+#HUMUX_MASTER_KEY=
 # Base URL used in secure "provide a secret" links sent to you (defaults to
 # http://localhost:<admin port>). Set to your reachable admin URL.
-#MPA_BASE_URL=
+#HUMUX_BASE_URL=
 
 # Web search (Tavily) — get a free API key at https://app.tavily.com
 TAVILY_API_KEY=

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
         working-directory: docs
         env:
-          NEXT_PUBLIC_BASE_PATH: /mpa
+          NEXT_PUBLIC_BASE_PATH: /humux
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ RUN if [ "$INSTALL_BROWSER" = "true" ]; then \
     fi
 
 # Create non-root user
-RUN groupadd --gid 10001 mpa && \
-    useradd --uid 10001 --gid 10001 --create-home --shell /bin/bash mpa
+RUN groupadd --gid 10001 humux && \
+    useradd --uid 10001 --gid 10001 --create-home --shell /bin/bash humux
 
 # Copy application code
 COPY core/ core/
@@ -104,12 +104,12 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # Data directory
 RUN mkdir -p /app/data \
-    && chown -R mpa:mpa /home/mpa /app
+    && chown -R humux:humux /home/humux /app
 
-USER mpa
+USER humux
 
-# Identify the linked WhatsApp device as "MPA" (native since wacli 0.2.0).
-ENV WACLI_DEVICE_LABEL=MPA
+# Identify the linked WhatsApp device as "humux" (native since wacli 0.2.0).
+ENV WACLI_DEVICE_LABEL=humux
 
 EXPOSE 8000
 CMD ["uv", "run", "python", "-m", "core.main"]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ KOKORO_BASE_URL := https://github.com/thewh1teagle/kokoro-onnx/releases/download
 # Show available targets
 help:
 	@echo ""
-	@echo "MPA — My Personal Agent"
+	@echo "humux — Human Multiplexer"
 	@echo ""
 	@echo "  Setup & Dependencies:"
 	@echo "    make setup        First-time setup (install, hooks, copy example configs)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MPA — My Personal Agent
+# humux — Human Multiplexer
 
-A self-hosted personal AI agent that runs in a single Docker container. MPA acts as a unified interface across messaging channels (Telegram, WhatsApp), email, calendars, and contacts — capable of autonomous action, scheduled tasks, voice interaction, and persistent memory.
+A self-hosted personal AI agent that runs in a single Docker container. humux acts as a unified interface across messaging channels (Telegram, WhatsApp), email, calendars, and contacts — capable of autonomous action, scheduled tasks, voice interaction, and persistent memory.
 
 ## Features
 
@@ -28,7 +28,7 @@ A self-hosted personal AI agent that runs in a single Docker container. MPA acts
 
 ## Architecture
 
-MPA follows a **Python orchestrator + CLI tools** design. Python glues everything together, while battle-tested CLI tools handle protocol complexity:
+humux follows a **Python orchestrator + CLI tools** design. Python glues everything together, while battle-tested CLI tools handle protocol complexity:
 
 | Concern | Tool |
 |---------|------|
@@ -53,8 +53,8 @@ Instead of hardcoded integrations, the agent learns to use CLI tools via markdow
 ### 1. Clone and configure
 
 ```bash
-git clone https://github.com/mattmezza/mpa.git
-cd mpa
+git clone https://github.com/mattmezza/humux.git
+cd humux
 cp .env.example .env
 cp config.yml.example config.yml
 cp character.md.example character.md
@@ -68,7 +68,7 @@ Edit `.env` with your API keys and secrets. Edit `config.yml` to customize the a
 docker compose up -d
 ```
 
-The admin UI will be available at `http://localhost:8000`. On first boot, MPA starts in **setup mode** — a wizard walks you through the initial configuration.
+The admin UI will be available at `http://localhost:8000`. On first boot, humux starts in **setup mode** — a wizard walks you through the initial configuration.
 
 ### 3. Run without Docker
 
@@ -82,7 +82,7 @@ make run         # starts the agent
 
 ## Configuration
 
-MPA uses a dual-layer config system:
+humux uses a dual-layer config system:
 
 - **`config.yml`** + **`.env`** — File-based seed config loaded on first boot. Supports `${ENV_VAR}` interpolation.
 - **SQLite config store** (`data/config.db`) — Becomes the source of truth after setup. Managed through the admin UI.

--- a/api/admin.py
+++ b/api/admin.py
@@ -3720,7 +3720,7 @@ def create_admin_app(
 
         ctx = await _secrets_ctx()
         if not secret_store.infra.available:
-            ctx["error"] = "No machine key configured (set MPA_MASTER_KEY or generate one)."
+            ctx["error"] = "No machine key configured (set HUMUX_MASTER_KEY or generate one)."
             return _render_partial("partials/secrets.html", **ctx)
         migrated = await migrate_config_to_infra_vault(config_store, secret_store)
         ctx = await _secrets_ctx()
@@ -3796,7 +3796,7 @@ def create_admin_app(
 
         if not secret_store.infra.available:
             ctx = await _secrets_ctx()
-            ctx["error"] = "No machine key configured (set MPA_MASTER_KEY or generate one)."
+            ctx["error"] = "No machine key configured (set HUMUX_MASTER_KEY or generate one)."
             return _render_partial("partials/secrets.html", **ctx)
         if not valid_name(name):
             ctx = await _secrets_ctx()

--- a/api/templates/partials/tools.html
+++ b/api/templates/partials/tools.html
@@ -363,8 +363,8 @@
     <div x-show="enabled === 'true' || enabled === true">
       <label class="label">Device label <span class="text-muted">(optional)</span></label>
       <input type="text" class="input-sm" style="max-width:300px" x-model="deviceLabel"
-             placeholder="MPA">
-      <p class="text-muted text-xs mt-1">Shown in WhatsApp's linked-devices list. Blank = MPA.</p>
+             placeholder="humux">
+      <p class="text-muted text-xs mt-1">Shown in WhatsApp's linked-devices list. Blank = humux.</p>
     </div>
 
     <div class="flex flex-wrap items-center gap-2 mt-4">

--- a/api/templates/wizard/secrets.html
+++ b/api/templates/wizard/secrets.html
@@ -22,7 +22,7 @@
     {% else %}
     <p class="text-muted text-xs mb-2">
       No machine key yet. Generate one (saved to <code>data/master.key</code>), or set
-      <code>MPA_MASTER_KEY</code> in your environment.
+      <code>HUMUX_MASTER_KEY</code> in your environment.
     </p>
     <button class="btn btn-sm"
             hx-post="/setup/step/secrets" hx-target="#wizard-step" hx-swap="innerHTML"

--- a/config.yml.example
+++ b/config.yml.example
@@ -164,7 +164,7 @@ memory:
 # tools; they're served at /artifacts/<slug>/. This only toggles that public,
 # no-auth route — the files live in the workspace below, so serving needs the
 # workspace harness enabled too. The slug is public/guessable: no secrets in an
-# artifact. Set MPA_BASE_URL so the shared links are reachable from your devices.
+# artifact. Set HUMUX_BASE_URL so the shared links are reachable from your devices.
 artifacts:
   enabled: true
 

--- a/core/agent.py
+++ b/core/agent.py
@@ -2797,7 +2797,7 @@ class AgentCore:
     def _base_url(self) -> str:
         import os
 
-        return os.getenv("MPA_BASE_URL", f"http://localhost:{self.config.admin.port}")
+        return os.getenv("HUMUX_BASE_URL", f"http://localhost:{self.config.admin.port}")
 
     # -- Coding harness (issue #76) ------------------------------------------
 

--- a/core/compaction.py
+++ b/core/compaction.py
@@ -4,7 +4,7 @@ When a sticky session grows close to the model's context window, the oldest
 turns are summarised by a (cheap) LLM into a single synthetic exchange, while
 the most recent turns are kept verbatim. This keeps long conversations going
 without blowing the context window, and — unlike provider-specific server-side
-compaction — works across every provider MPA supports.
+compaction — works across every provider humux supports.
 
 The trigger is the *real* token usage reported by the provider after the turn
 (see ``LLMResponse.usage``), so no local tokenizer is needed.

--- a/core/config.py
+++ b/core/config.py
@@ -411,7 +411,7 @@ class WhatsAppToolConfig(BaseModel):
     # WACLI_STORE override (which linked account). Blank = wacli default (~/.wacli).
     # ponytail: one global store; per-agent accounts ride #93's tool_env override.
     store: str = ""
-    device_label: str = ""  # WACLI_DEVICE_LABEL; blank = wacli default ("MPA")
+    device_label: str = ""  # WACLI_DEVICE_LABEL; blank = wacli default ("humux")
 
 
 class ToolsConfig(BaseModel):

--- a/core/email_config.py
+++ b/core/email_config.py
@@ -14,8 +14,8 @@ from pathlib import Path
 
 log = logging.getLogger(__name__)
 
-HIMALAYA_CONFIG_PATH = Path("/tmp/mpa-himalaya-config.toml")
-HIMALAYA_XDG_DIR = Path("/tmp/mpa-himalaya-xdg")
+HIMALAYA_CONFIG_PATH = Path("/tmp/humux-himalaya-config.toml")
+HIMALAYA_XDG_DIR = Path("/tmp/humux-himalaya-xdg")
 HIMALAYA_XDG_CONFIG_PATH = HIMALAYA_XDG_DIR / "himalaya" / "config.toml"
 
 # Config key used to store the structured provider list.

--- a/core/executor.py
+++ b/core/executor.py
@@ -179,9 +179,9 @@ class ToolExecutor:
             env = os.environ.copy()
             if "himalaya" in command:
                 env.update(himalaya_env())
-            # wacli: identify the linked device as MPA (matches the Docker ENV).
+            # wacli: identify the linked device as humux (matches the Docker ENV).
             if wants_wacli_label:
-                env.setdefault("WACLI_DEVICE_LABEL", "MPA")
+                env.setdefault("WACLI_DEVICE_LABEL", "humux")
             # An agent-scoped override is authoritative over the registry's managed
             # keys: strip any it didn't set so an agent can't inherit a tool
             # credential (e.g. GH_TOKEN from .env) its policy dropped (#93).

--- a/core/llm.py
+++ b/core/llm.py
@@ -25,7 +25,7 @@ reasoning_log.setLevel(logging.WARNING)
 # admin Inspect tab reads it back. ponytail: process-global dict, fine for one
 # agent process; move onto the agent instance if multi-tenant ever lands.
 # Context key = (channel, user_id, chat_id) — same triple as ConversationHistory.
-_capture_ctx: contextvars.ContextVar = contextvars.ContextVar("mpa_llm_capture_ctx", default=None)
+_capture_ctx: contextvars.ContextVar = contextvars.ContextVar("humux_llm_capture_ctx", default=None)
 _LAST_SENT: OrderedDict[tuple[str, str, str], dict[str, Any]] = OrderedDict()
 _CAPTURE_CAP = 100  # ponytail: LRU cap; bump if you watch >100 live chats
 

--- a/core/log_streams.py
+++ b/core/log_streams.py
@@ -24,8 +24,8 @@ DEFAULT_STREAM = "default"
 # Empty = "never set by a turn" (distinct from a turn that ran as the default
 # identity, which sets it to "default" explicitly). The distinction matters for
 # subagent_stream's fallback below.
-_stream: contextvars.ContextVar[str] = contextvars.ContextVar("mpa_log_stream", default="")
-_subagent: contextvars.ContextVar[str] = contextvars.ContextVar("mpa_log_subagent", default="")
+_stream: contextvars.ContextVar[str] = contextvars.ContextVar("humux_log_stream", default="")
+_subagent: contextvars.ContextVar[str] = contextvars.ContextVar("humux_log_subagent", default="")
 
 
 def current_stream() -> str:

--- a/core/main.py
+++ b/core/main.py
@@ -309,7 +309,7 @@ _agent_state = AgentState()
 async def _lifespan(application):  # noqa: ANN001
     """FastAPI lifespan: seed config, start agent, yield, then tear down."""
     # -- startup --
-    # Load .env so MPA_MASTER_KEY / ADMIN_PASSWORD etc. are in the environment even
+    # Load .env so HUMUX_MASTER_KEY / ADMIN_PASSWORD etc. are in the environment even
     # for existing installs where the config store is already seeded (Docker injects
     # env_file directly; this covers `make run` / bare-process deployments).
     from dotenv import load_dotenv

--- a/core/repl.py
+++ b/core/repl.py
@@ -317,7 +317,7 @@ async def main() -> None:
 
     from dotenv import load_dotenv
 
-    load_dotenv()  # MPA_MASTER_KEY / ADMIN_PASSWORD from .env, as main.py does at boot
+    load_dotenv()  # HUMUX_MASTER_KEY / ADMIN_PASSWORD from .env, as main.py does at boot
 
     spinner = Spinner()
     _setup_logging(spinner)

--- a/core/tools.py
+++ b/core/tools.py
@@ -572,19 +572,19 @@ if __name__ == "__main__":
         _ga.installation_token = _real_it
 
     # Per-agent repo allowlist (#111): only --repo targets outside the list are blocked.
-    scoped = Agent(name="coder", tool_config={"gh": {"enabled": True, "repos": ["me/mpa"]}})
-    assert github_repo_violation(scoped, "gh issue list --repo me/mpa") is None
+    scoped = Agent(name="coder", tool_config={"gh": {"enabled": True, "repos": ["me/humux"]}})
+    assert github_repo_violation(scoped, "gh issue list --repo me/humux") is None
     assert github_repo_violation(scoped, "gh pr view 1 -R me/other") == "me/other"
     assert github_repo_violation(scoped, "gh api user") is None  # no --repo → can't tell → allow
     assert github_repo_violation(plain, "gh pr view 1 --repo any/thing") is None  # no allowlist
     # Quote/glue-tolerant + gh-scoped (no false-block on grep -R).
     assert github_repo_violation(scoped, 'gh pr view 1 --repo "me/evil"') == "me/evil"
     assert github_repo_violation(scoped, "gh pr view 1 -Rme/evil") == "me/evil"
-    assert github_repo_violation(scoped, "gh pr view 1 --repo=me/mpa") is None
+    assert github_repo_violation(scoped, "gh pr view 1 --repo=me/humux") is None
     assert github_repo_violation(scoped, "grep -R foo/bar .") is None  # not a gh command
     # Present-but-empty allowlist = block every --repo (disjoint-narrow result).
     blocked = Agent(name="sub", tool_config={"gh": {"enabled": True, "repos": []}})
-    assert github_repo_violation(blocked, "gh pr view 1 --repo me/mpa") == "me/mpa"
+    assert github_repo_violation(blocked, "gh pr view 1 --repo me/humux") == "me/humux"
     assert github_repo_violation(blocked, "gh api user") is None  # no --repo target
 
     # Prompts: hopper sees gh + browser, with identity notes; lingua's gh is hidden.

--- a/core/vault.py
+++ b/core/vault.py
@@ -46,7 +46,7 @@ def _coerce_fernet_key(value: str | bytes) -> bytes:
 
     A real 32-byte url-safe base64 Fernet key is used as-is; anything else
     (e.g. a human passphrase) is hashed to 32 bytes and base64-encoded. This
-    lets the user set ``MPA_MASTER_KEY`` to either a generated key or a memorable
+    lets the user set ``HUMUX_MASTER_KEY`` to either a generated key or a memorable
     passphrase.
     """
     raw = value.encode() if isinstance(value, str) else value
@@ -67,14 +67,14 @@ def derive_kek(password: str, salt: bytes) -> bytes:
 def load_machine_key() -> str | None:
     """Locate the infra-vault machine key.
 
-    Order: ``MPA_MASTER_KEY`` env → ``MPA_MASTER_KEY_FILE`` path → the default
+    Order: ``HUMUX_MASTER_KEY`` env → ``HUMUX_MASTER_KEY_FILE`` path → the default
     keyfile on the data volume. Returns ``None`` when no key is configured (the
     infra vault is then unavailable and ``${vault:...}`` falls back to env).
     """
-    env = os.getenv("MPA_MASTER_KEY")
+    env = os.getenv("HUMUX_MASTER_KEY")
     if env:
         return env
-    keyfile = os.getenv("MPA_MASTER_KEY_FILE") or DEFAULT_KEYFILE
+    keyfile = os.getenv("HUMUX_MASTER_KEY_FILE") or DEFAULT_KEYFILE
     path = Path(keyfile)
     if path.exists():
         text = path.read_text().strip()

--- a/core/wacli.py
+++ b/core/wacli.py
@@ -27,7 +27,7 @@ def default_wacli_store() -> str:
 
 
 def default_device_label() -> str:
-    return os.getenv("WACLI_DEVICE_LABEL", "MPA")
+    return os.getenv("WACLI_DEVICE_LABEL", "humux")
 
 
 # Lock-wait window for write commands: wait for the store lock instead of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   agent:
     build: .
-    container_name: mpa
+    container_name: humux
     restart: unless-stopped
     ports:
       - "8000:8000"
@@ -24,7 +24,7 @@ services:
   # Exposes a CDP endpoint; point tools.browser.cdp_url at ws://browser:3000.
   # browser:
   #   image: browserless/chrome:latest
-  #   container_name: mpa-browser
+  #   container_name: humux-browser
   #   restart: unless-stopped
   #   profiles: ["browser"]
   #   environment:

--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -35,8 +35,8 @@
   --fd-popover-foreground: 210 16% 22%;
   --fd-secondary: 210 20% 94%;
   --fd-secondary-foreground: 210 16% 22%;
-  --mpa-code-bg: 210 25% 96%;
-  --mpa-code-border: 210 15% 82%;
+  --humux-code-bg: 210 25% 96%;
+  --humux-code-border: 210 15% 82%;
 }
 
 .dark {
@@ -72,8 +72,8 @@
   --fd-popover-foreground: 210 14% 82%;
   --fd-secondary: 0 0% 18%;
   --fd-secondary-foreground: 210 14% 82%;
-  --mpa-code-bg: 0 0% 9%;
-  --mpa-code-border: 0 0% 24%;
+  --humux-code-bg: 0 0% 9%;
+  --humux-code-border: 0 0% 24%;
 }
 
 body {
@@ -112,10 +112,10 @@ body {
   border-color: hsl(var(--fd-border) / 0.18) !important;
 }
 
-/* Code blocks styling to match MPA terminal aesthetic */
+/* Code blocks styling to match humux terminal aesthetic */
 pre {
   border: none !important;
-  background: hsl(var(--mpa-code-bg)) !important;
+  background: hsl(var(--humux-code-bg)) !important;
 }
 
 pre code {

--- a/docs/app/layout.config.tsx
+++ b/docs/app/layout.config.tsx
@@ -4,7 +4,7 @@ export const baseOptions: BaseLayoutProps = {
   nav: {
     title: (
       <span style={{ fontFamily: "'SF Mono', 'Cascadia Code', 'Fira Code', 'JetBrains Mono', ui-monospace, monospace", fontWeight: 700, letterSpacing: "0.05em" }}>
-        <span style={{ color: "#66cc99" }}>MPA</span>
+        <span style={{ color: "#66cc99" }}>humux</span>
       </span>
     ),
     url: "/docs",
@@ -12,8 +12,8 @@ export const baseOptions: BaseLayoutProps = {
   links: [
     {
       text: "GitHub",
-      url: "https://github.com/mattmezza/mpa",
+      url: "https://github.com/mattmezza/humux",
     },
   ],
-  githubUrl: "https://github.com/mattmezza/mpa",
+  githubUrl: "https://github.com/mattmezza/humux",
 };

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -5,11 +5,11 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: {
-    template: "%s — MPA Docs",
-    default: "MPA — My Personal Agent",
+    template: "%s — humux Docs",
+    default: "humux — Human Multiplexer",
   },
   description:
-    "Documentation for MPA, a self-hosted personal AI agent with messaging, email, calendar, memory, and voice capabilities.",
+    "Documentation for humux, a self-hosted personal AI agent with messaging, email, calendar, memory, and voice capabilities.",
 };
 
 export default function Layout({ children }: { children: ReactNode }) {

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -5,7 +5,7 @@ description: Web dashboard for configuration, monitoring, and agent management.
 
 # Admin UI
 
-MPA includes a web-based admin interface built with FastAPI, HTMX, Alpine.js, and Tailwind CSS. It provides a dark, terminal-aesthetic dashboard for managing every aspect of your agent.
+humux includes a web-based admin interface built with FastAPI, HTMX, Alpine.js, and Tailwind CSS. It provides a dark, terminal-aesthetic dashboard for managing every aspect of your agent.
 
 ## Access
 

--- a/docs/content/docs/agents.mdx
+++ b/docs/content/docs/agents.mdx
@@ -204,7 +204,7 @@ per-agent token requires a master key (configure one in the **Vaults** tab first
 ## Email, calendar & contacts accounts
 
 Each agent declares which email, calendar, and contacts **accounts** it may use, and at what
-level ([#110](https://github.com/mattmezza/mpa/issues/110)). The accounts themselves live in the
+level ([#110](https://github.com/mattmezza/humux/issues/110)). The accounts themselves live in the
 **Email**, **Calendar**, and **Contacts** tabs (the registry); an agent simply **binds** to
 some of them.
 
@@ -288,7 +288,7 @@ reach only accounts its parent identity holds, at an equal or lower level.
 
 Each agent carries its own Telegram **bot token**, so it's a separate contact in your
 address book — its own name and voice — addressable independently of every other
-agent ([#29](https://github.com/mattmezza/mpa/issues/29)). The bot is part of the agent's
+agent ([#29](https://github.com/mattmezza/humux/issues/29)). The bot is part of the agent's
 identity, configured on the agent, not on any channel.
 
 - **Configure** — open the agent in the admin UI and fill in the **Telegram bot** section:
@@ -318,7 +318,7 @@ step that needs no further code.
 
 `allowed_user_ids` is a single **bot-wide** allowlist. To gate who can reach an agent **per
 chat** — trigger it in one group but not another, let some users DM it and block others — use
-per-chat settings ([#129](https://github.com/mattmezza/mpa/issues/129)).
+per-chat settings ([#129](https://github.com/mattmezza/humux/issues/129)).
 
 Open the agent in the admin UI: the **Telegram chat settings** section lists every Telegram
 chat the agent takes part in (its own bot's chats, chats bound to it, and — when it is the
@@ -355,7 +355,7 @@ unaffected: they were never going to reply.
 Agent resolution is deliberately funnelled through one seam,
 `AgentCore._resolve_agent(channel, user_id, chat_id)`, so future work is additive:
 
-- **Group multi-agent** ([#30](https://github.com/mattmezza/mpa/issues/30)) — several
+- **Group multi-agent** ([#30](https://github.com/mattmezza/humux/issues/30)) — several
   agent-bots in one group chat, taking turns. Builds directly on bot-per-agent.
 
 The **secret scope** facet is now enforced by the [secrets vault](/docs/secrets) — an agent

--- a/docs/content/docs/architecture.mdx
+++ b/docs/content/docs/architecture.mdx
@@ -1,11 +1,11 @@
 ---
 title: Architecture
-description: Deep dive into MPA's Python orchestrator + CLI tools design.
+description: Deep dive into humux's Python orchestrator + CLI tools design.
 ---
 
 # Architecture
 
-MPA is built around a simple but powerful principle: **Python orchestrator + CLI tools**. Python handles async orchestration, the LLM conversation loop, and the web UI. Battle-tested CLI tools handle protocol complexity (IMAP, CalDAV, CardDAV).
+humux is built around a simple but powerful principle: **Python orchestrator + CLI tools**. Python handles async orchestration, the LLM conversation loop, and the web UI. Battle-tested CLI tools handle protocol complexity (IMAP, CalDAV, CardDAV).
 
 ## High-level overview
 
@@ -67,7 +67,7 @@ The agent becomes a **thin orchestrator**: it reads skill files, passes them to 
 
 ### Agent Core (`core/agent.py`)
 
-The brain of MPA. Implements the LLM tool-use loop:
+The brain of humux. Implements the LLM tool-use loop:
 
 1. Load conversation history
 2. Build the static system prompt (character, active tools). In session mode this is snapshotted once per conversation (rebuilt after `/new`) and reused every turn, so the cacheable prefix stays stable; on Anthropic it is sent with a `cache_control` breakpoint so the tools + system prefix is not reprocessed each turn
@@ -144,7 +144,7 @@ Agent Core (agent.py)
 ## Project structure
 
 ```
-mpa/
+humux/
 ├── core/                 Core agent modules
 │   ├── agent.py            LLM tool-use loop
 │   ├── llm.py              LLM provider abstraction

--- a/docs/content/docs/artifacts.mdx
+++ b/docs/content/docs/artifacts.mdx
@@ -33,7 +33,7 @@ http://your-host:8000/artifacts/q3-report/
 ```
 
 `<slug>` is agent-chosen — letters, digits, `-` and `_`. Set
-[`MPA_BASE_URL`](/docs/configuration) to your reachable admin URL so the links work from
+[`HUMUX_BASE_URL`](/docs/configuration) to your reachable admin URL so the links work from
 your phone, not just `localhost`.
 
 Because artifacts are just workspace files, the **same** `write_file` / `edit_file` /

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -5,7 +5,7 @@ description: Telegram, configured per-agent (WhatsApp is a tool, see below).
 
 # Channels
 
-MPA talks over Telegram, and **each agent runs its own Telegram bot**. There is no
+humux talks over Telegram, and **each agent runs its own Telegram bot**. There is no
 separate "channel" to set up: a bot belongs to an agent, and you configure it on the
 **agent edit screen** (admin UI → **Agents** → edit an agent → the **Telegram bot**
 section). The **default** agent's bot is the bare `telegram` channel; every other
@@ -121,14 +121,14 @@ Subject: Meeting tomorrow
 
 ## WhatsApp (tool)
 
-WhatsApp is a **tool**, not a channel (issue #97). MPA does not run an inbound WhatsApp
+WhatsApp is a **tool**, not a channel (issue #97). humux does not run an inbound WhatsApp
 bot; instead the agent reads and sends WhatsApp on demand by running
 [wacli](https://github.com/openclaw/wacli) — a local WhatsApp CLI written in Go — through
 the `run_command` tool. No cloud APIs or business verification needed. Reads run without
 asking; sending a message asks for confirmation first. See the **wacli-whatsapp** skill for
 the full command reference.
 
-The binary is not vendored: the Docker image installs a pinned upstream tag (`WACLI_VERSION` in the `Dockerfile`, currently `v0.11.0`) with `go install`. For local dev, `make dev-wa` installs the same tag into `~/go/bin`. Point MPA at a custom binary with the `WACLI_BIN` env var. The linked device shows up as **MPA** via `WACLI_DEVICE_LABEL` (override it per the **Device label** field in the Tools tab).
+The binary is not vendored: the Docker image installs a pinned upstream tag (`WACLI_VERSION` in the `Dockerfile`, currently `v0.11.0`) with `go install`. For local dev, `make dev-wa` installs the same tag into `~/go/bin`. Point humux at a custom binary with the `WACLI_BIN` env var. The linked device shows up as **humux** via `WACLI_DEVICE_LABEL` (override it per the **Device label** field in the Tools tab).
 
 ### Setup
 

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -1,11 +1,11 @@
 ---
 title: Configuration
-description: Complete reference for MPA's dual-layer configuration system.
+description: Complete reference for humux's dual-layer configuration system.
 ---
 
 # Configuration
 
-MPA uses a dual-layer configuration system:
+humux uses a dual-layer configuration system:
 
 1. **File-based** (`config.yml` + `.env`) — seed config loaded on first boot, supports `${ENV_VAR}` interpolation
 2. **SQLite config store** (`data/config.db`) — becomes the source of truth after setup, managed through the admin UI
@@ -38,8 +38,8 @@ Key variables:
 | `TAVILY_API_KEY` | Tavily web search API key |
 | `GOOGLE_EMAIL` | Google account for calendar |
 | `GOOGLE_APP_PASSWORD` | Google app-specific password |
-| `MPA_MASTER_KEY` | Infra [secrets vault](/docs/secrets) machine key (optional; a `data/master.key` keyfile is used if unset) |
-| `MPA_BASE_URL` | Base URL for secure "provide a secret" links and [web artifact](/docs/artifacts) links (defaults to `http://localhost:<admin port>`) |
+| `HUMUX_MASTER_KEY` | Infra [secrets vault](/docs/secrets) machine key (optional; a `data/master.key` keyfile is used if unset) |
+| `HUMUX_BASE_URL` | Base URL for secure "provide a secret" links and [web artifact](/docs/artifacts) links (defaults to `http://localhost:<admin port>`) |
 
 ## Agent config (`config.yml`)
 
@@ -185,7 +185,7 @@ Memory system settings. `extraction_model` is the cheap/fast model used for post
 
 #### `artifacts`
 
-[Web artifacts](/docs/artifacts) — pages, multi-file sites, or documents the agent publishes by writing files under `{workspace}/artifacts/<slug>/` with the `workspace` file tools, served at `/artifacts/<slug>/`. The only key is `enabled`, which toggles that public, no-auth route; the files live in the `workspace` (below), so serving also requires the workspace harness to be on. The slug is public and guessable — don't publish secrets. Set `MPA_BASE_URL` so the shared links are reachable from your devices. Managed from the admin **Tools** tab; `enabled: false` 404s all links.
+[Web artifacts](/docs/artifacts) — pages, multi-file sites, or documents the agent publishes by writing files under `{workspace}/artifacts/<slug>/` with the `workspace` file tools, served at `/artifacts/<slug>/`. The only key is `enabled`, which toggles that public, no-auth route; the files live in the `workspace` (below), so serving also requires the workspace harness to be on. The slug is public and guessable — don't publish secrets. Set `HUMUX_BASE_URL` so the shared links are reachable from your devices. Managed from the admin **Tools** tab; `enabled: false` 404s all links.
 
 #### `workspace`
 

--- a/docs/content/docs/deployment.mdx
+++ b/docs/content/docs/deployment.mdx
@@ -1,11 +1,11 @@
 ---
 title: Deployment
-description: Deploy MPA with Docker on any VPS.
+description: Deploy humux with Docker on any VPS.
 ---
 
 # Deployment
 
-MPA is designed to run as a single Docker container on any VPS. It runs comfortably on a small server.
+humux is designed to run as a single Docker container on any VPS. It runs comfortably on a small server.
 
 ## Resource requirements
 
@@ -25,8 +25,8 @@ MPA is designed to run as a single Docker container on any VPS. It runs comforta
 ### 1. Clone and configure
 
 ```bash
-git clone https://github.com/mattmezza/mpa.git
-cd mpa
+git clone https://github.com/mattmezza/humux.git
+cd humux
 cp .env.example .env
 cp config.yml.example config.yml
 cp character.md.example character.md
@@ -50,10 +50,10 @@ docker compose logs -f
 
 ## Docker image
 
-MPA publishes Docker images to GitHub Container Registry on every release:
+humux publishes Docker images to GitHub Container Registry on every release:
 
 ```bash
-docker pull ghcr.io/mattmezza/mpa:latest
+docker pull ghcr.io/mattmezza/humux:latest
 ```
 
 ### Available tags
@@ -117,7 +117,7 @@ Or pin a specific version:
 # docker-compose.yml
 services:
   agent:
-    image: ghcr.io/mattmezza/mpa:0.1.0
+    image: ghcr.io/mattmezza/humux:0.1.0
 ```
 
 ## Releasing

--- a/docs/content/docs/development.mdx
+++ b/docs/content/docs/development.mdx
@@ -1,6 +1,6 @@
 ---
 title: Development
-description: Set up a local development environment for MPA.
+description: Set up a local development environment for humux.
 ---
 
 # Development
@@ -14,8 +14,8 @@ description: Set up a local development environment for MPA.
 ## Setup
 
 ```bash
-git clone https://github.com/mattmezza/mpa.git
-cd mpa
+git clone https://github.com/mattmezza/humux.git
+cd humux
 make setup       # creates venv, installs deps, copies example configs
 ```
 
@@ -23,7 +23,7 @@ Edit `.env` and `config.yml` with your secrets.
 
 ## Running in dev mode
 
-MPA requires multiple services. Run each in its own terminal:
+humux requires multiple services. Run each in its own terminal:
 
 ### 1. Agent with auto-reload
 

--- a/docs/content/docs/extending.mdx
+++ b/docs/content/docs/extending.mdx
@@ -1,11 +1,11 @@
 ---
-title: Extending MPA
-description: Add new capabilities to MPA by writing markdown skill files.
+title: Extending humux
+description: Add new capabilities to humux by writing markdown skill files.
 ---
 
-# Extending MPA
+# Extending humux
 
-One of MPA's core principles is that adding new capabilities should not require writing Python code. The system is designed to be extended through markdown skill files and configuration changes.
+One of humux's core principles is that adding new capabilities should not require writing Python code. The system is designed to be extended through markdown skill files and configuration changes.
 
 ## Adding a new tool in 4 steps
 
@@ -117,7 +117,7 @@ silently override a PAT you later select:
 - **GitHub App** — the recommended path for an agent. Register an app at
   [github.com/settings/apps/new](https://github.com/settings/apps/new), grant it the
   fine-grained permissions you want, install it on the repos it may touch, then paste the
-  **App ID**, **Installation ID**, and **private key** (PEM). MPA signs a short JWT with the
+  **App ID**, **Installation ID**, and **private key** (PEM). humux signs a short JWT with the
   key, exchanges it for an installation access token (valid ~1h, auto-refreshed in memory,
   never persisted), and injects it as `GH_TOKEN`. Actions then show as the app's bot
   identity (`<app>[bot]`) with the app's own rate-limit pool. The private key lives in the

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Get MPA up and running in minutes with Docker or from source.
+description: Get humux up and running in minutes with Docker or from source.
 ---
 
 # Getting Started
@@ -16,8 +16,8 @@ description: Get MPA up and running in minutes with Docker or from source.
 ### 1. Clone and configure
 
 ```bash
-git clone https://github.com/mattmezza/mpa.git
-cd mpa
+git clone https://github.com/mattmezza/humux.git
+cd humux
 cp .env.example .env
 cp config.yml.example config.yml
 cp character.md.example character.md
@@ -31,7 +31,7 @@ Edit `.env` with your API keys and secrets. Edit `config.yml` to customize the a
 docker compose up -d
 ```
 
-The admin UI will be available at `http://localhost:8000`. On first boot, MPA starts in **setup mode** — a wizard walks you through the initial configuration.
+The admin UI will be available at `http://localhost:8000`. On first boot, humux starts in **setup mode** — a wizard walks you through the initial configuration.
 
 ### 3. Talk to your agent
 
@@ -85,7 +85,7 @@ After setup, all configuration is managed through the admin UI or `config.yml`.
 
 ## Next steps
 
-- [Architecture](/docs/architecture) — understand how MPA works under the hood
+- [Architecture](/docs/architecture) — understand how humux works under the hood
 - [Configuration](/docs/configuration) — detailed config reference
 - [Skills](/docs/skills) — learn how the skills system works
 - [Channels](/docs/channels) — set up per-agent Telegram bots (WhatsApp is a tool)

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,15 +1,15 @@
 ---
 title: Introduction
-description: MPA is a self-hosted personal AI agent that runs in a single Docker container.
+description: humux is a self-hosted personal AI agent that runs in a single Docker container.
 ---
 
-# MPA — My Personal Agent
+# humux — Human Multiplexer
 
-MPA is a self-hosted personal AI agent that runs in a single Docker container. It acts as a unified interface across messaging channels, email, calendars, and contacts — capable of autonomous action, scheduled tasks, voice interaction, and persistent memory.
+humux is a self-hosted personal AI agent that runs in a single Docker container. It acts as a unified interface across messaging channels, email, calendars, and contacts — capable of autonomous action, scheduled tasks, voice interaction, and persistent memory.
 
-## Why MPA?
+## Why humux?
 
-Most AI assistants are cloud-hosted black boxes with limited integrations. MPA takes a different approach:
+Most AI assistants are cloud-hosted black boxes with limited integrations. humux takes a different approach:
 
 - **Self-hosted** — runs on your own server, your data stays with you
 - **Single container** — one `docker compose up` and you're running
@@ -37,7 +37,7 @@ Most AI assistants are cloud-hosted black boxes with limited integrations. MPA t
 
 ## How it works
 
-MPA follows a **Python orchestrator + CLI tools** design. Python glues everything together, while battle-tested CLI tools handle protocol complexity:
+humux follows a **Python orchestrator + CLI tools** design. Python glues everything together, while battle-tested CLI tools handle protocol complexity:
 
 | Concern | Tool |
 |---------|------|

--- a/docs/content/docs/memory.mdx
+++ b/docs/content/docs/memory.mdx
@@ -1,11 +1,11 @@
 ---
 title: Memory
-description: MPA's persistent memory — two tiers, semantic retrieval, forgetting, and a self-healing hygiene pass.
+description: humux's persistent memory — two tiers, semantic retrieval, forgetting, and a self-healing hygiene pass.
 ---
 
 # Memory
 
-MPA has a persistent memory system that lets the agent remember facts about you and your world. Memories are stored in SQLite at `data/memory.db`. The agent reads and writes them via the `sqlite3` CLI (guided by `skills/memory.md`), following the same "skills over code" philosophy as the rest of the system — but the heavy lifting (extraction, dedup, ranking, forgetting) runs in `core/memory.py`.
+humux has a persistent memory system that lets the agent remember facts about you and your world. Memories are stored in SQLite at `data/memory.db`. The agent reads and writes them via the `sqlite3` CLI (guided by `skills/memory.md`), following the same "skills over code" philosophy as the rest of the system — but the heavy lifting (extraction, dedup, ranking, forgetting) runs in `core/memory.py`.
 
 The system is layered in four tiers:
 

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -1,11 +1,11 @@
 ---
 title: Permissions
-description: MPA's glob-pattern permission system with interactive approval flow.
+description: humux's glob-pattern permission system with interactive approval flow.
 ---
 
 # Permissions
 
-MPA has an explicit permission system — nothing happens without your approval (or a pre-approved rule). The permission engine uses glob patterns to match actions and commands, with three permission levels.
+humux has an explicit permission system — nothing happens without your approval (or a pre-approved rule). The permission engine uses glob patterns to match actions and commands, with three permission levels.
 
 ## Permission levels
 
@@ -17,7 +17,7 @@ MPA has an explicit permission system — nothing happens without your approval 
 
 ## Default rules
 
-MPA ships with sensible defaults:
+humux ships with sensible defaults:
 
 ### Always allowed (read operations)
 

--- a/docs/content/docs/scheduler.mdx
+++ b/docs/content/docs/scheduler.mdx
@@ -5,7 +5,7 @@ description: Cron-based task scheduling for proactive agent actions.
 
 # Scheduler
 
-MPA includes a built-in scheduler powered by [APScheduler](https://apscheduler.readthedocs.io/) for running recurring and one-shot tasks. This enables proactive behaviors like morning briefings, email monitoring, and memory consolidation.
+humux includes a built-in scheduler powered by [APScheduler](https://apscheduler.readthedocs.io/) for running recurring and one-shot tasks. This enables proactive behaviors like morning briefings, email monitoring, and memory consolidation.
 
 ## Job types
 

--- a/docs/content/docs/secrets.mdx
+++ b/docs/content/docs/secrets.mdx
@@ -5,7 +5,7 @@ description: Encrypted, two-tier secrets store — infra keys and per-agent logi
 
 # Secrets vault
 
-MPA stores secrets encrypted at rest and lets agents use them **by reference** — a
+humux stores secrets encrypted at rest and lets agents use them **by reference** — a
 secret's value is never placed in the model's context, history, logs, or messages. There
 are **two vaults** with **two different keys**, because the two kinds of secret have
 different unseal requirements.
@@ -13,7 +13,7 @@ different unseal requirements.
 | | **Infra vault** | **Agent / login vault** |
 |---|---|---|
 | Holds | provider keys, bot token, Tavily, CalDAV/email/contacts creds, `gh` token | website logins, payment keys, agent session tokens |
-| Key | **machine key** (env `MPA_MASTER_KEY` or a keyfile) | derived from your **admin password** (envelope) |
+| Key | **machine key** (env `HUMUX_MASTER_KEY` or a keyfile) | derived from your **admin password** (envelope) |
 | Unseals | at boot, headless | when you log into the admin UI |
 | Used as | `${vault:NAME}` in config (with `.env` fallback) | `{{secret:NAME}}` inside `run_command` |
 | Access control | none (app code reads it) | per-agent **secret scope** (ACL) |
@@ -25,7 +25,7 @@ Encryption uses [Fernet](https://cryptography.io/en/latest/fernet/) (AES-128-CBC
 Infrastructure secrets are read at boot, before anyone logs in, so they are sealed with a
 **machine key** that is available headlessly:
 
-- `MPA_MASTER_KEY` environment variable (a generated key or any passphrase), or
+- `HUMUX_MASTER_KEY` environment variable (a generated key or any passphrase), or
 - a keyfile (default `data/master.key`, auto-generated from the setup wizard).
 
 Any config value can then reference a vault entry: `anthropic_api_key: "${vault:ANTHROPIC_API_KEY}"`.
@@ -40,7 +40,7 @@ You don't have to start from scratch or re-run setup. Both the wizard's **Secret
 and the **Secrets** tab (post-setup) can move the credentials already in your config into
 the infra vault in one click — the move is **non-destructive** and **idempotent**:
 
-1. Make sure a machine key exists (`MPA_MASTER_KEY` set, or click **Generate & save key**
+1. Make sure a machine key exists (`HUMUX_MASTER_KEY` set, or click **Generate & save key**
    on the Vaults tab / wizard — it writes `data/master.key`).
 2. Click **Migrate N credential(s) into the vault** on the Vaults tab (**Infra** sub-tab), or
    **Move … into the vault** in the wizard.
@@ -138,7 +138,7 @@ are never entered or shown over chat** — sensitive entry is deep-linked to the
 ### Import from Bitwarden
 
 Export your Bitwarden vault as JSON (`bw export --format json`, or the web vault → Export),
-then upload it on the Vaults tab (**Import** sub-tab). Login items become secrets you can scope. MPA never sees
+then upload it on the Vaults tab (**Import** sub-tab). Login items become secrets you can scope. humux never sees
 your Bitwarden master password.
 
 ## Duration
@@ -151,9 +151,9 @@ your Bitwarden master password.
 
 | Variable | Purpose |
 |----------|---------|
-| `MPA_MASTER_KEY` | Infra-vault machine key. Optional; a keyfile (`data/master.key`) is used if unset. |
-| `MPA_MASTER_KEY_FILE` | Override the keyfile path. |
-| `MPA_BASE_URL` | Base URL used in secure "provide a secret" links (defaults to `http://localhost:<admin port>`). |
+| `HUMUX_MASTER_KEY` | Infra-vault machine key. Optional; a keyfile (`data/master.key`) is used if unset. |
+| `HUMUX_MASTER_KEY_FILE` | Override the keyfile path. |
+| `HUMUX_BASE_URL` | Base URL used in secure "provide a secret" links (defaults to `http://localhost:<admin port>`). |
 
 > **Tip:** if you seeded the admin password via `ADMIN_PASSWORD` / `ADMIN_API_KEY` in
 > `.env`, remove it after setup. Once the agent vault is keyed by your admin password, a

--- a/docs/content/docs/skills.mdx
+++ b/docs/content/docs/skills.mdx
@@ -1,11 +1,11 @@
 ---
 title: Skills
-description: The markdown-based capability system at the heart of MPA.
+description: The markdown-based capability system at the heart of humux.
 ---
 
 # Skills
 
-Skills are the central design idea of MPA. Instead of hardcoding how each integration works, the agent loads **skill documents** — markdown files that teach the LLM how to use CLI tools.
+Skills are the central design idea of humux. Instead of hardcoding how each integration works, the agent loads **skill documents** — markdown files that teach the LLM how to use CLI tools.
 
 ## How it works
 
@@ -20,7 +20,7 @@ This means adding a new capability is as simple as writing a markdown file. No P
 
 ## Built-in skills
 
-MPA ships with these skills:
+humux ships with these skills:
 
 | Skill | File | Purpose |
 |-------|------|---------|

--- a/docs/content/docs/voice.mdx
+++ b/docs/content/docs/voice.mdx
@@ -5,7 +5,7 @@ description: Speech-to-text and text-to-speech pipeline for voice interactions.
 
 # Voice
 
-MPA includes a voice pipeline for receiving and sending voice messages through messaging channels. It uses local, offline-capable models — no cloud speech APIs needed.
+humux includes a voice pipeline for receiving and sending voice messages through messaging channels. It uses local, offline-capable models — no cloud speech APIs needed.
 
 ## Components
 
@@ -102,7 +102,7 @@ the Kokoro extra (onnxruntime ~200 MB) and model (~325 MB) just ride along ready
 to use. For a leaner edge-tts-only image, opt out at build time:
 
 ```bash
-docker build --build-arg INSTALL_KOKORO=false -t mpa .
+docker build --build-arg INSTALL_KOKORO=false -t humux .
 ```
 
 For a local (non-Docker) run, fetch the extra and the model with one command:
@@ -122,7 +122,7 @@ curl -fL https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-fil
 curl -fL https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin -o models/kokoro/voices-v1.0.bin
 ```
 
-If the model can't be loaded (missing file, OOM), MPA logs a warning and **falls
+If the model can't be loaded (missing file, OOM), humux logs a warning and **falls
 back to edge-tts** — both at startup and per-reply — so voice replies are never
 lost.
 

--- a/docs/content/docs/workspace.mdx
+++ b/docs/content/docs/workspace.mdx
@@ -41,7 +41,7 @@ root or a descendant of it. So neither `../../etc/passwd` nor a symlink pointing
 the workspace can escape — both are blocked (`NEVER`).
 
 `run_command_in_dir` confines only the **working directory** it runs in — *not* the
-command itself. The command runs through the shell with the full privileges of the MPA
+command itself. The command runs through the shell with the full privileges of the humux
 process, so it can still read paths outside the workspace (e.g. `cat /etc/passwd`). Its
 real boundary is the permission gate (the `run_command` rules above), not the workspace.
 Enable it only if you're comfortable with that.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mpa-docs",
+  "name": "humux-docs",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mpa-docs",
+      "name": "humux-docs",
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mpa-docs",
+  "name": "humux-docs",
   "version": "1.0.0",
   "private": true,
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mpa"
+name = "humux"
 version = "0.15.0"
 description = "Personal AI agent — unified interface across messaging, email, and calendars"
 requires-python = ">=3.14"

--- a/skills/artifact-hosting.md
+++ b/skills/artifact-hosting.md
@@ -25,7 +25,7 @@ write_file(path="artifacts/q3-report/index.html", content="<!doctype html><html>
 The page is then live at `<base>/artifacts/q3-report/`. The exact `<base>` for
 this deployment is given to you each turn as `[Web artifact base URL: …]` in the
 context preamble — use that verbatim to build the link you give the user (it
-already reflects `MPA_BASE_URL` when configured). If that line is absent,
+already reflects `HUMUX_BASE_URL` when configured). If that line is absent,
 artifacts aren't servable here (the workspace harness is off).
 
 - `<slug>` must be letters, digits, `-` and `_` only (e.g. `q3-report`,

--- a/skills/skill-creator.md
+++ b/skills/skill-creator.md
@@ -20,7 +20,7 @@ stored in SQLite and seeded from markdown files at startup.
 3. Create or update the skill in the DB.
 4. Optionally update the seed file for new deployments.
 
-## Skill format (MPA)
+## Skill format (humux)
 
 - Skills are plain markdown files stored in the DB.
 - The first non-empty line becomes the summary shown in the UI.

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -217,8 +217,8 @@ def test_gh_env_auth_app_uses_app(monkeypatch) -> None:
 
 
 def test_repo_gate_blocks_only_disallowed_repo_flags() -> None:
-    coder = Agent(name="coder", tool_config={"gh": {"enabled": True, "repos": ["me/mpa"]}})
-    assert github_repo_violation(coder, "gh pr list --repo me/mpa") is None
+    coder = Agent(name="coder", tool_config={"gh": {"enabled": True, "repos": ["me/humux"]}})
+    assert github_repo_violation(coder, "gh pr list --repo me/humux") is None
     assert github_repo_violation(coder, "gh pr view 1 --repo me/secret") == "me/secret"
     assert github_repo_violation(coder, "gh api user") is None  # no --repo → cannot tell → allow
     open_p = Agent(name="open", tool_config={"gh": {"enabled": True}})
@@ -226,7 +226,7 @@ def test_repo_gate_blocks_only_disallowed_repo_flags() -> None:
 
 
 def test_repo_gate_is_quote_glue_tolerant_and_gh_scoped() -> None:
-    coder = Agent(name="coder", tool_config={"gh": {"enabled": True, "repos": ["me/mpa"]}})
+    coder = Agent(name="coder", tool_config={"gh": {"enabled": True, "repos": ["me/humux"]}})
     # Quoting / `=` / glued `-R` must not bypass the gate.
     assert github_repo_violation(coder, 'gh pr view 1 --repo "me/evil"') == "me/evil"
     assert github_repo_violation(coder, "gh pr view 1 --repo='me/evil'") == "me/evil"
@@ -239,10 +239,10 @@ def test_repo_gate_is_quote_glue_tolerant_and_gh_scoped() -> None:
 def test_repo_gate_empty_allowlist_blocks_everything() -> None:
     # A present-but-empty allowlist (disjoint-narrow result) = allow nothing.
     sub = Agent(name="sub", tool_config={"gh": {"enabled": True, "repos": []}})
-    assert github_repo_violation(sub, "gh pr view 1 --repo me/mpa") == "me/mpa"
+    assert github_repo_violation(sub, "gh pr view 1 --repo me/humux") == "me/humux"
     # Absent repos key = unrestricted (distinct from empty list).
     plain = Agent(name="plain", tool_config={"gh": {"enabled": True}})
-    assert github_repo_violation(plain, "gh pr view 1 --repo me/mpa") is None
+    assert github_repo_violation(plain, "gh pr view 1 --repo me/humux") is None
 
 
 def test_narrow_gh_repos_never_widens() -> None:

--- a/tools/browser.py
+++ b/tools/browser.py
@@ -555,7 +555,7 @@ def _load_agent_config():
 
     Resolves ``${vault:NAME}`` references so a migrated LLM key (issue #35)
     reaches the explore loop's own LLM calls. This subprocess inherits the
-    machine key (``MPA_MASTER_KEY`` / ``data/master.key``) and ``.env``, so the
+    machine key (``HUMUX_MASTER_KEY`` / ``data/master.key``) and ``.env``, so the
     infra vault unseals headlessly with a plain env fallback.
     """
     import asyncio

--- a/tools/calendar_write.py
+++ b/tools/calendar_write.py
@@ -67,7 +67,7 @@ def build_vcalendar(
     lines = [
         "BEGIN:VCALENDAR",
         "VERSION:2.0",
-        "PRODID:-//MPA Agent//CalDAV Writer//EN",
+        "PRODID:-//humux//CalDAV Writer//EN",
         "BEGIN:VEVENT",
         f"UID:{uid}",
         f"DTSTAMP:{now}",

--- a/tools/skills.py
+++ b/tools/skills.py
@@ -118,7 +118,7 @@ def _write_seed_file(seed_dir: str, name: str, content: str) -> Path:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Manage MPA skills.")
+    parser = argparse.ArgumentParser(description="Manage humux skills.")
     parser.add_argument("--db", default=_default_db_path(), help="Path to skills DB")
     parser.add_argument(
         "--seed-dir",


### PR DESCRIPTION
Full rebranding from MPA → humux across code, docs, config, and CI

## Changes

- Rename product from "MPA — My Personal Agent" to "humux — Human Multiplexer"
- Update all env vars: `MPA_MASTER_KEY` → `HUMUX_MASTER_KEY`, `MPA_BASE_URL` → `HUMUX_BASE_URL`
- Rename Docker user/group `mpa` → `humux`
- Update Docker containers: `mpa` → `humux`, `mpa-browser` → `humux-browser`
- Update GitHub URLs from `mattmezza/mpa` → `mattmezza/humux`
- Update CSS variables: `--mpa-*` → `--humux-*`
- Update WACLI device label default: `MPA` → `humux`
- Update all documentation (docs/, README, skills, etc.)
- Update test data repo references: `me/mpa` → `me/humux`
- Update CI configs
- Update package names and config files

52 files modified, 139 insertions(+), 139 deletions(-)