### PR TITLE
fix: control-command robustness (#154) + YOLO over coding tools, regression-locked (#155)

### DIFF
--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -99,6 +99,11 @@ A few details worth knowing:
   address a specific bot with `/yolo-on@botname`, and the grant applies only in that chat
   (a bare `/yolo-on`, addressed to no bot, toggles nothing). The setting persists across
   restarts until you turn it off.
+- **Command menu** — each bot publishes its commands to Telegram's ☰ menu / `/`
+  autocomplete on startup (`/new`, `/jobs`, `/yolo_on`, `/yolo_off` — Telegram forbids
+  `-` in menu command names, so YOLO shows with an underscore; `/yolo-on` still works too).
+  In a group each bot lists its own commands, `@bot`-suffixed, so tapping one targets that
+  bot. The menu is a full replace, so the list simply tracks whatever the version ships.
 - **Upgrade note** — enabling group rooms re-keys a group's history from per-sender to
   per-group, so a previously-active group starts fresh (old per-sender history is left in
   place, just not carried forward).

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -42,6 +42,13 @@ log = logging.getLogger(__name__)
 # "@bot" target so a command never acts on the wrong bot in a multi-agent room.
 _AGENT_COMMANDS = frozenset({"/new", "/clear", "/yolo-on", "/yolo-off"})
 
+# Collapse identical back-to-back inbound text from the same sender within this
+# window (#154): Telegram/network redelivery or a client burst can deliver the
+# same message several times, and a duplicated control command ("/yolo-on") would
+# otherwise fold into one merged turn and be processed as text. A short window so
+# a deliberate repeat seconds later still counts as a new turn.
+_DEDUP_WINDOW_S = 3.0
+
 # Callback data prefix for approval buttons
 _APPROVE_PREFIX = "perm_approve:"
 _DENY_PREFIX = "perm_deny:"
@@ -134,6 +141,9 @@ class TelegramChannel:
         # Last chat a user wrote from, used to route approval prompts. Holds a
         # folded "<chat>:<thread>" string when the message came from a topic.
         self._last_chat_for_user: dict[int, int | str] = {}
+        # Last inbound text per (sender, chat) + when, to drop duplicate deliveries
+        # (#154). Keyed by sender so two people saying the same thing don't collide.
+        self._last_inbound: dict[tuple[int, str], tuple[str, float]] = {}
         # This bot's own identity, cached lazily from the first update (the Bot
         # API has it only once polling is initialised). Used to detect @mentions
         # and replies aimed at this bot in group rooms (#30).
@@ -384,6 +394,19 @@ class TelegramChannel:
             return
 
         text = (message.text or "").strip()
+
+        # Drop an identical back-to-back message from the same sender (#154):
+        # redelivery or a client burst would otherwise become several turns (or a
+        # folded, unmatchable "/yolo-on\n\n/yolo-on"). Empty text is left alone.
+        dedup_key = (sender_id, str(chat_id))
+        now = time.monotonic()
+        prev = self._last_inbound.get(dedup_key)
+        if text:
+            self._last_inbound[dedup_key] = (text, now)
+        if text and prev and prev[0] == text and now - prev[1] < _DEDUP_WINDOW_S:
+            log.debug("Dropping duplicate inbound (chat=%s): %r", chat_id, text[:40])
+            return
+
         respond = routing["respond"]
         first = text.split(maxsplit=1)[0] if text else ""
         base, _, target = first.partition("@") if first.startswith("/") else ("", "", "")

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from telegram import (
+    BotCommand,
     CallbackQuery,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
@@ -40,7 +41,20 @@ log = logging.getLogger(__name__)
 # Plain-text commands the agent handles in process() (not Telegram CommandHandlers).
 # _on_text sends these bare (no speaker tag / reply-quote) and honours an explicit
 # "@bot" target so a command never acts on the wrong bot in a multi-agent room.
-_AGENT_COMMANDS = frozenset({"/new", "/clear", "/yolo-on", "/yolo-off"})
+_AGENT_COMMANDS = frozenset({"/new", "/clear", "/yolo-on", "/yolo-off", "/yolo_on", "/yolo_off"})
+
+# The command menu surfaced in Telegram's ☰ button / "/" autocomplete
+# (setMyCommands). This is the single source of truth: set_my_commands is a full
+# REPLACE, so future versions add/remove/edit commands just by editing this list —
+# removed entries drop out of the menu on the next startup, no delta logic needed.
+# Command names may only be [a-z0-9_], so the hyphenated /yolo-on is registered
+# under its /yolo_on alias (the runtime accepts both — see _COMMAND_ALIASES).
+_MENU_COMMANDS = [
+    BotCommand("new", "Clear the conversation"),
+    BotCommand("jobs", "Show scheduled jobs"),
+    BotCommand("yolo_on", "Run actions without asking for approval"),
+    BotCommand("yolo_off", "Restore approval prompts"),
+]
 
 # Collapse identical back-to-back inbound text from the same sender within this
 # window (#154): Telegram/network redelivery or a client burst can deliver the
@@ -248,6 +262,21 @@ class TelegramChannel:
             # False this once and the next update retries once it is available.
             self._bot_id = None
             self._bot_username = None
+
+    async def register_commands(self) -> None:
+        """Publish the ``_MENU_COMMANDS`` list to Telegram's ☰ menu / autocomplete.
+
+        A full replace (setMyCommands), so editing the list is enough to add,
+        remove, or rename commands across versions. Per-bot: in a group each bot
+        shows its own commands, ``@bot``-suffixed, which is exactly the addressed
+        form the runtime routes on. Best-effort — a failure here must never stop
+        the bot from polling."""
+        try:
+            await self.app.bot.set_my_commands(_MENU_COMMANDS)
+        except Exception:
+            log.warning(
+                "Could not set Telegram command menu (%s)", self.channel_name, exc_info=True
+            )
 
     @staticmethod
     def _entity_text(message, text: str, ent) -> str:

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -401,11 +401,13 @@ class TelegramChannel:
         dedup_key = (sender_id, str(chat_id))
         now = time.monotonic()
         prev = self._last_inbound.get(dedup_key)
-        if text:
-            self._last_inbound[dedup_key] = (text, now)
         if text and prev and prev[0] == text and now - prev[1] < _DEDUP_WINDOW_S:
+            # Anchor the window to the last *processed* message (don't refresh on a
+            # drop) so a deliberate repeat after the window still counts as a turn.
             log.debug("Dropping duplicate inbound (chat=%s): %r", chat_id, text[:40])
             return
+        if text:
+            self._last_inbound[dedup_key] = (text, now)
 
         respond = routing["respond"]
         first = text.split(maxsplit=1)[0] if text else ""

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -231,6 +231,31 @@ def _strip_command_suffix(message: str) -> str:
     return text.lower()
 
 
+_CONTROL_COMMANDS = ("/yolo-on", "/yolo-off", "/new", "/clear")
+
+
+def _control_command(message: str) -> str:
+    """The control command a message *is*, tolerant of the ``@bot`` suffix and of
+    duplicate/merged self-repetition (#154).
+
+    Inbound coalescing or a redelivering client can hand the runtime a command as
+    ``"/yolo-on\\n\\n/yolo-on"`` or ``"/yolo-on@bot\\n\\n/yolo-on"``; a bare
+    exact-match misses those and the command is processed as ordinary text (YOLO
+    never actually toggles). Returns the command only when *every* whitespace-
+    separated token normalises to the same control command — mixed text (e.g.
+    ``"/new please"``) returns ``""`` so a command is never silently pulled out of
+    a real message."""
+    tokens = message.split()
+    if not tokens:
+        return ""
+    normalised = {_strip_command_suffix(tok) for tok in tokens}
+    if len(normalised) == 1:
+        (only,) = tuple(normalised)
+        if only in _CONTROL_COMMANDS:
+            return only
+    return ""
+
+
 # -- Tool definitions the LLM can call --
 
 TOOLS = [
@@ -1165,7 +1190,7 @@ class AgentCore:
             await self._record_inbound(channel, user_id, chat_id, message, attachments)
             return AgentResponse(text="")
 
-        command = _strip_command_suffix(message)
+        command = _control_command(message)
 
         # Resolve the agent for this turn — a per-chat binding wins over the default
         # (#14); an explicit override (scheduler) skips the ladder (#29).

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -233,10 +233,22 @@ def _strip_command_suffix(message: str) -> str:
 
 _CONTROL_COMMANDS = ("/yolo-on", "/yolo-off", "/new", "/clear")
 
+# Telegram command names (setMyCommands) may only be [a-z0-9_], so the hyphenated
+# /yolo-on is menu-registered under a /yolo_on underscore alias; canonicalise it
+# back here so the runtime treats both forms identically.
+_COMMAND_ALIASES = {"/yolo_on": "/yolo-on", "/yolo_off": "/yolo-off"}
+
+
+def _normalize_command(token: str) -> str:
+    """Strip the ``@bot`` suffix and fold a menu underscore alias to its canonical
+    hyphenated command."""
+    stripped = _strip_command_suffix(token)
+    return _COMMAND_ALIASES.get(stripped, stripped)
+
 
 def _control_command(message: str) -> str:
-    """The control command a message *is*, tolerant of the ``@bot`` suffix and of
-    duplicate/merged self-repetition (#154).
+    """The control command a message *is*, tolerant of the ``@bot`` suffix, the
+    ``/yolo_on`` menu alias, and duplicate/merged self-repetition (#154).
 
     Inbound coalescing or a redelivering client can hand the runtime a command as
     ``"/yolo-on\\n\\n/yolo-on"`` or ``"/yolo-on@bot\\n\\n/yolo-on"``; a bare
@@ -248,7 +260,7 @@ def _control_command(message: str) -> str:
     tokens = message.split()
     if not tokens:
         return ""
-    normalised = {_strip_command_suffix(tok) for tok in tokens}
+    normalised = {_normalize_command(tok) for tok in tokens}
     if len(normalised) == 1:
         (only,) = tuple(normalised)
         if only in _CONTROL_COMMANDS:

--- a/humux/core/main.py
+++ b/humux/core/main.py
@@ -134,6 +134,7 @@ async def _start_agent(config_store: ConfigStore):
             await tg.app.start()
             if tg.app.updater is not None:
                 await tg.app.updater.start_polling()
+            await tg.register_commands()  # publish the ☰ command menu (best-effort)
             agent.channels[channel_name] = tg  # registered only once it is actually polling
             log.info("Telegram bot started (%s)", channel_name)
         except Exception:

--- a/humux/tests/test_coding.py
+++ b/humux/tests/test_coding.py
@@ -302,9 +302,7 @@ def _call(name, params):
 async def test_yolo_auto_approves_coding_tools(tmp_path, name, params):
     """Under YOLO these ASK-level write tools run without an approval prompt (#155)."""
     agent = _yolo_gate_agent(tmp_path)
-    result = await agent._execute_tool_inner(
-        _call(name, params), "telegram", "u1", {"yolo": True}
-    )
+    result = await agent._execute_tool_inner(_call(name, params), "telegram", "u1", {"yolo": True})
     assert "error" not in result  # dispatched, not denied
     agent._request_approval.assert_not_awaited()
 

--- a/humux/tests/test_coding.py
+++ b/humux/tests/test_coding.py
@@ -263,3 +263,70 @@ def test_workspace_config_defaults_off():
     cfg = Config()
     assert cfg.workspace.enabled is False
     assert cfg.workspace.directory == ""
+
+
+# --- #155: YOLO covers the coding-harness write tools ---
+
+
+def _yolo_gate_agent(tmp_path):
+    """Bare AgentCore wired only for the _execute_tool_inner permission gate, with
+    the actual tool dispatch stubbed so nothing touches the filesystem."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from core.agent import AgentCore
+
+    agent = object.__new__(AgentCore)
+    agent.permissions = PermissionEngine(db_path=str(tmp_path / "config.db"))
+    agent._request_approval = AsyncMock(return_value="approved")
+    agent._tool_write_file = MagicMock(return_value={"ok": True})
+    agent._tool_edit_file = MagicMock(return_value={"ok": True})
+    agent._tool_run_command_in_dir = AsyncMock(return_value={"exit_code": 0})
+    return agent
+
+
+def _call(name, params):
+    from core.llm import LLMToolCall
+
+    return LLMToolCall(id="t1", name=name, arguments=params)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name,params",
+    [
+        ("write_file", {"path": "a.txt", "content": "x"}),
+        ("edit_file", {"path": "a.txt", "old": "x", "new": "y"}),
+        ("run_command_in_dir", {"command": "make test"}),
+    ],
+)
+async def test_yolo_auto_approves_coding_tools(tmp_path, name, params):
+    """Under YOLO these ASK-level write tools run without an approval prompt (#155)."""
+    agent = _yolo_gate_agent(tmp_path)
+    result = await agent._execute_tool_inner(
+        _call(name, params), "telegram", "u1", {"yolo": True}
+    )
+    assert "error" not in result  # dispatched, not denied
+    agent._request_approval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_without_yolo_coding_tools_still_prompt(tmp_path):
+    """Without YOLO the same tool prompts for approval as before (#155)."""
+    agent = _yolo_gate_agent(tmp_path)
+    await agent._execute_tool_inner(
+        _call("write_file", {"path": "a.txt", "content": "x"}), "telegram", "u1", {"yolo": False}
+    )
+    agent._request_approval.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_yolo_still_refuses_never_actions(tmp_path):
+    """A NEVER-rail action is refused even under YOLO, with no prompt (#155)."""
+    agent = _yolo_gate_agent(tmp_path)
+    drop = {"command": 'sqlite3 /app/data/x.db "DROP TABLE t"'}
+    result = await agent._execute_tool_inner(
+        _call("run_command_in_dir", drop), "telegram", "u1", {"yolo": True}
+    )
+    assert result == {"error": "This action is not allowed."}
+    agent._request_approval.assert_not_awaited()
+    agent._tool_run_command_in_dir.assert_not_awaited()

--- a/humux/tests/test_group_chat.py
+++ b/humux/tests/test_group_chat.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from core.agent import AgentCore, _strip_command_suffix
+from core.agent import AgentCore, _control_command, _strip_command_suffix
 from core.config import GroupChatConfig, TelegramConfig
 from core.history import ConversationHistory
 from core.llm import _coalesce_user_messages
@@ -111,6 +111,27 @@ def test_coalesce_empty() -> None:
 )
 def test_strip_command_suffix(raw: str, expected: str) -> None:
     assert _strip_command_suffix(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("/yolo-on", "/yolo-on"),
+        ("/yolo-on@coachbot", "/yolo-on"),
+        ("  /New  ", "/new"),
+        # Duplicated / merged deliveries still resolve to the one command (#154).
+        ("/yolo-on\n\n/yolo-on", "/yolo-on"),
+        ("/yolo-on@coachbot\n\n/yolo-on", "/yolo-on"),
+        ("/new /new@bot", "/new"),
+        # Mixed with real text → not a command (never pulled out of a message).
+        ("/new please", ""),
+        ("/yolo-on then /yolo-off", ""),
+        ("hello there", ""),
+        ("", ""),
+    ],
+)
+def test_control_command(raw: str, expected: str) -> None:
+    assert _control_command(raw) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -217,6 +238,27 @@ async def test_yolo_toggle_requires_addressing_and_scopes_per_chat(tmp_path) -> 
     assert agent.permissions.is_yolo(agent._yolo_scope("telegram", "g2")) is False
 
     resp = await agent.process("/yolo-off@coachbot", channel="telegram", user_id="g1", chat_id="g1")
+    assert "YOLO mode OFF" in resp.text
+    assert agent.permissions.is_yolo(scope) is False
+
+
+@pytest.mark.asyncio
+async def test_yolo_on_toggles_when_duplicated_or_merged(tmp_path) -> None:
+    """A duplicated/merged '/yolo-on' still toggles instead of reaching the LLM as
+    ordinary text — the swallow behind #154 (and the observed #155 symptom)."""
+    agent = _bare_agent(tmp_path, "injection")
+    agent.permissions = PermissionEngine(db_path=str(tmp_path / "config.db"))
+    scope = agent._yolo_scope("telegram", "g1")
+
+    resp = await agent.process(
+        "/yolo-on@coachbot\n\n/yolo-on", channel="telegram", user_id="g1", chat_id="g1"
+    )
+    assert "YOLO mode ON" in resp.text
+    assert agent.permissions.is_yolo(scope) is True
+
+    resp = await agent.process(
+        "/yolo-off\n\n/yolo-off", channel="telegram", user_id="g1", chat_id="g1"
+    )
     assert "YOLO mode OFF" in resp.text
     assert agent.permissions.is_yolo(scope) is False
 

--- a/humux/tests/test_group_chat.py
+++ b/humux/tests/test_group_chat.py
@@ -119,6 +119,10 @@ def test_strip_command_suffix(raw: str, expected: str) -> None:
         ("/yolo-on", "/yolo-on"),
         ("/yolo-on@coachbot", "/yolo-on"),
         ("  /New  ", "/new"),
+        # Menu underscore alias folds to the canonical hyphenated command.
+        ("/yolo_on", "/yolo-on"),
+        ("/yolo_off@coachbot", "/yolo-off"),
+        ("/yolo_on\n\n/yolo-on", "/yolo-on"),  # alias + canonical, same command
         # Duplicated / merged deliveries still resolve to the one command (#154).
         ("/yolo-on\n\n/yolo-on", "/yolo-on"),
         ("/yolo-on@coachbot\n\n/yolo-on", "/yolo-on"),
@@ -261,6 +265,19 @@ async def test_yolo_on_toggles_when_duplicated_or_merged(tmp_path) -> None:
     )
     assert "YOLO mode OFF" in resp.text
     assert agent.permissions.is_yolo(scope) is False
+
+
+@pytest.mark.asyncio
+async def test_yolo_menu_underscore_alias_toggles(tmp_path) -> None:
+    """The /yolo_on menu alias (Telegram forbids '-' in command names) toggles the
+    same grant as /yolo-on."""
+    agent = _bare_agent(tmp_path, "injection")
+    agent.permissions = PermissionEngine(db_path=str(tmp_path / "config.db"))
+    scope = agent._yolo_scope("telegram", "g1")
+
+    resp = await agent.process("/yolo_on@coachbot", channel="telegram", user_id="g1", chat_id="g1")
+    assert "YOLO mode ON" in resp.text
+    assert agent.permissions.is_yolo(scope) is True
 
 
 # ---------------------------------------------------------------------------

--- a/humux/tests/test_telegram_channel.py
+++ b/humux/tests/test_telegram_channel.py
@@ -1,10 +1,11 @@
 import asyncio
+import re
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
-from channels.telegram import TELEGRAM_LIMIT, TelegramChannel, _chunk
+from channels.telegram import _MENU_COMMANDS, TELEGRAM_LIMIT, TelegramChannel, _chunk
 
 
 def _dedup_channel() -> TelegramChannel:
@@ -50,6 +51,33 @@ async def test_same_text_from_different_senders_not_deduped() -> None:
     await ch._on_text(_text_update("hi", user_id=8), None)  # a different person
     await asyncio.sleep(0)
     assert ch._handle_text.await_count == 2
+
+
+def test_menu_command_names_are_telegram_valid() -> None:
+    """Telegram rejects command names with anything but [a-z0-9_] — a hyphenated
+    entry (e.g. yolo-on) would make set_my_commands fail at startup."""
+    for cmd in _MENU_COMMANDS:
+        assert re.fullmatch(r"[a-z0-9_]{1,32}", cmd.command), cmd.command
+        assert cmd.description
+
+
+@pytest.mark.asyncio
+async def test_register_commands_full_replaces_menu() -> None:
+    ch = object.__new__(TelegramChannel)
+    ch.channel_name = "telegram"
+    ch.app = SimpleNamespace(bot=AsyncMock())
+    await ch.register_commands()
+    ch.app.bot.set_my_commands.assert_awaited_once_with(_MENU_COMMANDS)
+
+
+@pytest.mark.asyncio
+async def test_register_commands_swallows_failure() -> None:
+    """A menu-registration error must never stop the bot from polling."""
+    ch = object.__new__(TelegramChannel)
+    ch.channel_name = "telegram"
+    ch.app = SimpleNamespace(bot=AsyncMock())
+    ch.app.bot.set_my_commands.side_effect = RuntimeError("boom")
+    await ch.register_commands()  # does not raise
 
 
 @pytest.mark.asyncio

--- a/humux/tests/test_telegram_channel.py
+++ b/humux/tests/test_telegram_channel.py
@@ -52,6 +52,22 @@ async def test_same_text_from_different_senders_not_deduped() -> None:
     assert ch._handle_text.await_count == 2
 
 
+@pytest.mark.asyncio
+async def test_dedup_window_anchored_to_last_processed(monkeypatch) -> None:
+    """A repeat within the window drops, but one after it is a fresh turn — the
+    window is anchored to the last processed message, not slid on every drop."""
+    ch = _dedup_channel()
+    clock = {"t": 0.0}
+    monkeypatch.setattr("channels.telegram.time.monotonic", lambda: clock["t"])
+    await ch._on_text(_text_update("ping"), None)  # processed
+    clock["t"] = 1.0
+    await ch._on_text(_text_update("ping"), None)  # within 3s → dropped
+    clock["t"] = 10.0
+    await ch._on_text(_text_update("ping"), None)  # window passed → processed
+    await asyncio.sleep(0)
+    assert ch._handle_text.await_count == 2
+
+
 def _channel_with_mock_bot(delay: float = 0.0) -> TelegramChannel:
     # Skip __init__ (it builds a real Application needing a bot token); _typing
     # only touches self.app.bot, the static _route helper and _PLACEHOLDER_DELAY.

--- a/humux/tests/test_telegram_channel.py
+++ b/humux/tests/test_telegram_channel.py
@@ -7,6 +7,51 @@ import pytest
 from channels.telegram import TELEGRAM_LIMIT, TelegramChannel, _chunk
 
 
+def _dedup_channel() -> TelegramChannel:
+    """Bare channel wired only for _on_text up to the create_task dispatch (#154)."""
+    ch = object.__new__(TelegramChannel)
+    ch.channel_name = "telegram"
+    ch._bot_username = "coachbot"
+    ch._last_inbound = {}
+    ch._fold = lambda chat: None
+    ch._remember_chat = lambda *a: None
+    ch._reply_context = lambda m: ""
+    ch._may_act = AsyncMock(return_value=True)
+    ch._handle_text = AsyncMock()
+    ch._turn_routing = lambda u, m, c: {
+        "user_id": str(u.effective_user.id),
+        "speaker_tag": "",
+        "respond": True,
+        "addressed": True,
+    }
+    return ch
+
+
+def _text_update(text: str, user_id: int = 7, chat_id: int = 100) -> SimpleNamespace:
+    msg = SimpleNamespace(text=text, message_id=1)
+    user = SimpleNamespace(id=user_id, is_bot=False)
+    chat = SimpleNamespace(id=chat_id, type="private")
+    return SimpleNamespace(effective_user=user, message=msg, effective_chat=chat)
+
+
+@pytest.mark.asyncio
+async def test_duplicate_inbound_collapsed_to_one_turn() -> None:
+    ch = _dedup_channel()
+    await ch._on_text(_text_update("/yolo-on"), None)
+    await ch._on_text(_text_update("/yolo-on"), None)  # redelivery
+    await asyncio.sleep(0)
+    assert ch._handle_text.await_count == 1  # second dropped
+
+
+@pytest.mark.asyncio
+async def test_same_text_from_different_senders_not_deduped() -> None:
+    ch = _dedup_channel()
+    await ch._on_text(_text_update("hi", user_id=7), None)
+    await ch._on_text(_text_update("hi", user_id=8), None)  # a different person
+    await asyncio.sleep(0)
+    assert ch._handle_text.await_count == 2
+
+
 def _channel_with_mock_bot(delay: float = 0.0) -> TelegramChannel:
     # Skip __init__ (it builds a real Application needing a bot token); _typing
     # only touches self.app.bot, the static _route helper and _PLACEHOLDER_DELAY.

--- a/humux/uv.lock
+++ b/humux/uv.lock
@@ -698,7 +698,7 @@ wheels = [
 
 [[package]]
 name = "humux"
-version = "0.15.0"
+version = "0.16.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Fixes #154 and #155 together — they share the `/yolo-on` control surface, and #155's observed symptom turned out to be a consequence of #154.

## #154 — control commands swallowed by coalescing/duplication

**Root cause:** the command shortcuts in `_process_impl` match on the *exact* normalised message text. When an inbound is duplicated or merged (e.g. `"/yolo-on\n\n/yolo-on"`), the exact match misses and the command is processed as ordinary LLM text — YOLO/`/new` silently never fire.

**Fix (channel-agnostic, so it covers Telegram, repl, and any future channel):**
- New `_control_command()` normaliser tolerates the `@bot` suffix, the `/yolo_on` menu alias, **and** self-repetition: it returns the command only when *every* whitespace-separated token normalises to the same control command. Mixed text (`"/new please"`) is left as a normal message, so a command is never silently pulled out of real text.
- Telegram channel drops identical back-to-back messages from the **same sender** within a short window, anchored to the last *processed* message (keyed by sender so two people saying the same thing in a group don't collide).

Deliberate group semantics unchanged: a bare, unaddressed `/yolo-on` still toggles nothing, and a silent (unaddressed) `/new` is still recorded as context rather than clearing.

## #155 — YOLO over the coding-harness write tools

The generic YOLO auto-approve in `_execute_tool_inner` is already tool-agnostic (`level == ASK && yolo → ALWAYS`), and `write_file` / `edit_file` / `run_command_in_dir` are all `ASK`-level write actions — so they already ride the same path as `send_email` etc., with `NEVER` rails still hard-blocked. The reported symptom ("writes still prompt under YOLO") was really #154: the `/yolo-on` that was supposed to enable it got swallowed, so YOLO was never actually on.

This PR **locks that behaviour with regression tests** rather than re-implementing an already-present code path:
- under YOLO, all three coding tools dispatch without an approval prompt;
- a `NEVER`-rail action is still refused under YOLO, with no prompt;
- without YOLO, they prompt as before.

## Bonus — Telegram command menu (`setMyCommands`)

Requested alongside the fix: each bot publishes its commands to Telegram's ☰ menu / `/` autocomplete on startup (`/new`, `/jobs`, `/yolo_on`, `/yolo_off`).
- **Single source of truth, full replace.** `set_my_commands` overwrites the whole menu, so future versions add/remove/edit commands by editing one list — removed entries drop out on next startup, no delta logic.
- **Hyphen constraint.** Telegram command names allow only `[a-z0-9_]`, so the hyphenated `/yolo-on` is registered under a `/yolo_on` alias; the runtime canonicalises both to the same toggle (`/yolo-on` typed by hand still works).
- **Multi-bot groups.** Per-bot registration; Telegram merges bots' commands `@bot`-suffixed in group autocomplete, so tapping one targets exactly that bot — the addressing the runtime already routes on.
- Best-effort: a menu-registration error never stops the bot from polling.

## Tests
- `_control_command` matrix (suffix, underscore alias, duplicate, merged, mixed-text, empty).
- Process-level: duplicated/merged `/yolo-on` and the `/yolo_on` alias both toggle the grant.
- Telegram: duplicate collapsed to one turn; same text from different senders is not; window anchored to last processed; menu names are Telegram-valid; `register_commands` full-replaces and swallows failures.
- Coding: the three #155 acceptance criteria.

Full suite green (884 passed). Docs updated (`channels.mdx`).