### PR TITLE
Surface run_command allowlist + reconcile with installed binaries (#153)

### DIFF
--- a/docs/content/docs/architecture.mdx
+++ b/docs/content/docs/architecture.mdx
@@ -103,6 +103,8 @@ ALLOWED_PREFIXES = [
 ]
 ```
 
+The effective list is injected into the system prompt (`core/prompt_builder.py`) so the model constructs valid commands on the first try instead of discovering the whitelist by "Command not allowed" errors. Every prefix must resolve to a binary installed in the image — the `Dockerfile` apt layer is kept in sync with this list.
+
 ### Config System (`core/config.py`, `core/config_store.py`)
 
 Dual-layer configuration:

--- a/docs/content/docs/extending.mdx
+++ b/docs/content/docs/extending.mdx
@@ -32,6 +32,8 @@ ALLOWED_PREFIXES = [
 ]
 ```
 
+If `my-tool` is a real binary (not one of the bundled `python3 /app/tools/` scripts), also install it in the `Dockerfile` apt layer — a prefix on the allowlist that isn't installed passes the guard but fails at exec with `not found`. The allowlist is surfaced to the model automatically, so it must resolve to something that actually runs.
+
 ### 3. Write a skill file
 
 Create `skills/my-tool.md`:

--- a/humux/Dockerfile
+++ b/humux/Dockerfile
@@ -4,10 +4,14 @@ WORKDIR /app
 
 # System deps (ffmpeg for voice pipeline, curl for health checks, sqlite3 for memory)
 # golang + build-essential build wacli (CGO, sqlite_fts5) from the pinned upstream tag.
+# The run_command allowlist (core/executor.py ALLOWED_PREFIXES) promises these CLIs
+# exist — keep this list in sync with it: git (coding harness clone/commit),
+# ripgrep (rg), w3m, pandoc, poppler-utils (pdftotext), yt-dlp, ncal (cal).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg curl ca-certificates jq sqlite3 \
     bash tar gzip xz-utils \
     golang build-essential pkg-config \
+    git ripgrep w3m pandoc poppler-utils yt-dlp ncal \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Himalaya CLI (pre-built Rust binary for email management)

--- a/humux/core/executor.py
+++ b/humux/core/executor.py
@@ -53,6 +53,7 @@ class ToolExecutor:
         "rg",
         "yt-dlp",
         "cal",
+        "cp",
     ]
 
     def _resolve_command(self, command: str) -> str:

--- a/humux/core/permissions.py
+++ b/humux/core/permissions.py
@@ -162,6 +162,8 @@ DEFAULT_RULES: dict[str, str] = {
     "run_command:rg*": "ALWAYS",
     "run_command:yt-dlp*": "ALWAYS",
     "run_command:cal*": "ALWAYS",
+    # cp writes files (into the workspace) — treat like other write ops: ask first.
+    "run_command:cp*": "ASK",
     "run_command:git*log*": "ALWAYS",
     "run_command:git*status*": "ALWAYS",
     "run_command:git*diff*": "ALWAYS",

--- a/humux/core/prompt_builder.py
+++ b/humux/core/prompt_builder.py
@@ -6,8 +6,26 @@ from dataclasses import dataclass
 
 from core.agents import Agent
 from core.config import Config
+from core.executor import ToolExecutor
 from core.goal_decomposition import DecomposedGoal
 from core.tools import active_tool_prompts
+
+
+def _allowlist_note() -> str:
+    """A short, always-shown block listing the run_command prefix allowlist, so the
+    model builds valid commands on the first try instead of discovering the whitelist
+    by trial-and-error (#153). Derived from ToolExecutor.ALLOWED_PREFIXES — the one
+    source of truth — so it can never drift from what the guard actually permits."""
+    prefixes = ", ".join(f"`{p}`" for p in ToolExecutor.ALLOWED_PREFIXES)
+    filters = ", ".join(f"`{f}`" for f in sorted(ToolExecutor._SAFE_FILTERS))
+    return (
+        "\n\n`run_command` is allowlisted: every piped/chained segment must start with "
+        f"one of these prefixes — {prefixes}. After a real pipe you may also use a "
+        f'read-only filter ({filters}). Anything else returns "Command not allowed"; '
+        "subshells and live command substitution are rejected (single-quote a Markdown "
+        "body so its backticks stay literal). Copy a file with `cp`."
+    )
+
 
 DEFAULT_TOOL_USAGE_BLOCK = """For write actions that have a dedicated structured tool —
 sending or replying to emails, sending messages, creating calendar events, and
@@ -150,9 +168,14 @@ def build_prompt_sections(
     cfg = config.agent
 
     about_user_block = config.you.personalia.strip()
-    tool_usage_text = resolve_prompt_block(
-        DEFAULT_TOOL_USAGE_BLOCK,
-        getattr(config.prompt, "tool_usage_override", ""),
+    # Append the allowlist AFTER resolving the (overridable) block, so it is shown
+    # even when the owner overrides tool_usage — the model must always see it (#153).
+    tool_usage_text = (
+        resolve_prompt_block(
+            DEFAULT_TOOL_USAGE_BLOCK,
+            getattr(config.prompt, "tool_usage_override", ""),
+        )
+        + _allowlist_note()
     )
     history_handling_text = resolve_prompt_block(
         DEFAULT_HISTORY_HANDLING_BLOCK,

--- a/humux/tests/test_executor.py
+++ b/humux/tests/test_executor.py
@@ -34,6 +34,19 @@ async def test_run_command_allows_whitelisted_prefix(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_command_allows_cp(monkeypatch) -> None:
+    # #153: copying a file within the workspace must be permitted.
+    executor = ToolExecutor()
+    mock_exec = AsyncMock(return_value={"stdout": "", "stderr": "", "exit_code": 0})
+    monkeypatch.setattr(executor, "_exec", mock_exec)
+
+    result = await executor.run_command("cp a.txt b.txt")
+
+    assert "error" not in result
+    mock_exec.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_run_command_forwards_cwd(monkeypatch) -> None:
     # #151: the harness passes the workspace root so git operates in the same
     # tree the file tools resolve under.


### PR DESCRIPTION
Closes #153.

## Problem

The executor `ALLOWED_PREFIXES` whitelist was (a) invisible to the model — the agent discovered it by trial-and-error, burning turns on "Command not allowed", and (b) drifted from the image — `rg` was allowlisted but not installed (`rg: not found`), and several other prefixes (`w3m`, `pandoc`, `pdftotext`, `yt-dlp`, `cal`, plus `git` used by the coding harness) were likewise not guaranteed present. There was also no allowlisted way to copy a file.

## Changes

- **Surface the allowlist to the model.** `core/prompt_builder.py` appends a short block to `<tool_usage>` listing the effective prefixes (and the post-#152 read-only pipe filters), derived from `ToolExecutor.ALLOWED_PREFIXES` — single source of truth, can't drift. Appended *after* the overridable block so it shows even when the owner overrides `tool_usage`.
- **Reconcile with installed binaries.** The `Dockerfile` apt layer now installs everything the allowlist promises: `ripgrep` (rg), `git`, `w3m`, `pandoc`, `poppler-utils` (pdftotext), `yt-dlp`, `ncal` (cal). A comment ties the two lists together.
- **Copy files.** Added a `cp` prefix (ASK-gated in `permissions.py`, like other write ops).
- **Docs.** `architecture.mdx` / `extending.mdx` note that the allowlist is surfaced to the model and must stay in sync with the image.

Rebased on current `main` — the #152 shell-metachar hardening (`_SAFE_FILTERS`, single-quote-safe substitution guard) is preserved; this PR only adds `cp` to the prefix list on top of it.

## Acceptance criteria

- [x] The agent sees the permitted prefixes without triggering a failure first.
- [x] Every prefix resolves to an installed binary.
- [x] A file can be copied within the workspace via `cp`.

## Tests

`test_run_command_allows_cp` added; full suite green (875 passed).

> The reflection-hygiene sub-item ("use rg instead of grep" advice) is tracked separately per the issue; installing `rg` makes that advice valid regardless.