### PR TITLE
Memory & reflection hygiene: dedup, subject/transient guards (#156)

### DIFF
--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -542,8 +542,9 @@ TOOLS = [
         "description": (
             "Save a durable long-term memory — a fact, preference, or relationship about "
             "the owner or their contacts. Use it proactively whenever you learn something "
-            "worth keeping. Reading is automatic: relevant memories are injected each turn, "
-            "and recall_memory searches the rest."
+            "worth keeping. Do NOT store transient action-confirmations (e.g. 'filed issue "
+            "#12', 'created PR #40') — those are not durable facts. Reading is automatic: "
+            "relevant memories are injected each turn, and recall_memory searches the rest."
         ),
         "input_schema": {
             "type": "object",
@@ -554,7 +555,10 @@ TOOLS = [
                 },
                 "subject": {
                     "type": "string",
-                    "description": "Who or what it is about, e.g. 'matteo' or a contact's name.",
+                    "description": (
+                        "Who or what it is about, e.g. 'matteo' or a contact's name. Leave "
+                        "empty rather than repeating the category (not 'work'/'fact')."
+                    ),
                 },
                 "category": {
                     "type": "string",
@@ -3222,10 +3226,15 @@ class AgentCore:
         category = str(params.get("category", "") or "fact").strip()
         scope = (request_state or {}).get("agent_name") or ""
         try:
-            await self.memory.remember(content, subject=subject, category=category, scope=scope)
+            stored = await self.memory.remember(
+                content, subject=subject, category=category, scope=scope
+            )
         except Exception:
             log.exception("remember failed for: %s", content[:80])
             return {"error": "Saving the memory failed."}
+        if not stored:
+            log.info("Tool call: remember — skipped transient/empty: %s", content[:80])
+            return {"ok": True, "skipped": "transient confirmation; not stored as a durable memory"}
         log.info("Tool call: remember — %s/%s", category, subject or "-")
         return {"ok": True, "remembered": content}
 

--- a/humux/core/memory.py
+++ b/humux/core/memory.py
@@ -359,6 +359,30 @@ def _normalize_subject(subject: str) -> str:
     return (subject or "").strip().lower()
 
 
+# Category words must never land in the subject slot (#156): the model sometimes
+# echoes the category there, producing entries like "[work] work: ...".
+_CATEGORY_WORDS = frozenset(
+    {"fact", "preference", "relationship", "work", "routine", "health", "travel", "general"}
+)
+
+# Transient action-confirmations ("filed issue #12", "created PR #40") duplicate
+# what GitHub already records and shouldn't become durable memories (#156).
+# ponytail: heuristic (verb + tracking-noun/#N); widen if new phrasings slip through.
+_TRANSIENT_CONFIRMATION_RE = re.compile(
+    r"\b(filed|created|opened|closed|merged|submitted|sent|posted|drafted|pushed)\b"
+    r".{0,40}(\b(issue|pr|pull request|ticket|email|message|comment|commit)\b|#\d+)",
+    re.IGNORECASE,
+)
+
+
+def _clean_subject(subject: str, category: str) -> str:
+    """Drop a subject that is just the category word echoed back (#156)."""
+    s = _normalize_subject(subject)
+    if not s or s == (category or "").strip().lower() or s in _CATEGORY_WORDS:
+        return ""
+    return s
+
+
 def _extraction_scope_block(agent_scope: str) -> str:
     """Scope instruction injected into the extraction prompt (#42).
 
@@ -1081,15 +1105,26 @@ class MemoryStore:
 
     async def remember(
         self, content: str, *, subject: str = "", category: str = "fact", scope: str = ""
-    ) -> None:
+    ) -> bool:
         """Public entry point for the ``remember`` tool (#13): store a durable fact.
 
         Thin wrapper over ``_insert_long_term`` so memory writes go through a
         parameterised INSERT instead of the model hand-building sqlite3 SQL (which
         broke on quoting and was injectable). ponytail: dedup is left to the
         consolidation job; add a similarity pre-check here if repeats pile up.
+
+        Rejects transient action-confirmations and normalises a category-echo
+        subject (#156). Returns True if stored, False if skipped.
         """
+        content = (content or "").strip()
+        if not content:
+            return False
+        if _TRANSIENT_CONFIRMATION_RE.search(content):
+            log.debug("Skipping transient confirmation, not a durable memory: %s", content[:80])
+            return False
+        subject = _clean_subject(subject, category or "fact")
         await self._insert_long_term(category or "fact", subject, content, scope=scope)
+        return True
 
     async def _insert_long_term(
         self,

--- a/humux/core/task_reflection.py
+++ b/humux/core/task_reflection.py
@@ -20,8 +20,19 @@ from pathlib import Path
 import aiosqlite
 
 from core.llm import LLMClient
+from core.memory import _similarity, _tokens  # reuse lexical sim — no new dep (#156)
 
 log = logging.getLogger(__name__)
+
+# Lessons that steer toward a binary that isn't installed are worse than none —
+# they send the agent at a missing tool. rg is allowlisted but absent on the host
+# (see the executor allowlist issue #156), so drop advice recommending it.
+# ponytail: extend this set if other phantom-tool lessons surface.
+_PHANTOM_TOOL_RE = re.compile(r"\b(rg|ripgrep)\b", re.IGNORECASE)
+
+# Two lessons this similar (Jaccard over content tokens) are the same advice
+# reworded — the store fills with near-duplicate variants otherwise (#156).
+_NEAR_DUP_THRESHOLD = 0.6
 
 _SCHEMA_FILE = Path(__file__).resolve().parent.parent / "schema" / "reflections.sql"
 
@@ -66,6 +77,8 @@ Rules:
   - "himalaya list --folder flag is case-sensitive; use 'INBOX' not 'inbox'"
 - Do NOT record trivial observations like "task completed successfully"
   or "user said thank you".
+- Do NOT recommend switching to a different tool or binary ("use X instead
+  of Y"); the runtime's command allowlist already defines what is available.
 - Be concise. Lessons should be 1-2 sentences max.
 
 Respond with ONLY the JSON object, no other text."""
@@ -174,11 +187,17 @@ class ReflectionStore:
             return ""
 
         lines: list[str] = []
-        seen: set[str] = set()  # #5: drop exact-duplicate lessons (the store has many repeats)
+        # #156: drop phantom-tool advice and near-duplicate lessons (the store
+        # accumulates reworded repeats), not just byte-identical ones.
+        kept_tokens: list[set[str]] = []
         for r in reflections:
-            if r["lesson"] in seen:
+            lesson = r["lesson"]
+            if _PHANTOM_TOOL_RE.search(lesson):
                 continue
-            seen.add(r["lesson"])
+            toks = _tokens(lesson)
+            if any(_similarity(toks, prev) >= _NEAR_DUP_THRESHOLD for prev in kept_tokens):
+                continue
+            kept_tokens.append(toks)
             outcome_marker = ""
             if r["outcome"] != "success":
                 outcome_marker = f" [{r['outcome']}]"
@@ -276,6 +295,11 @@ class ReflectionStore:
         if not lesson:
             return False
 
+        # Drop advice that points at a tool that isn't installed (#156).
+        if _PHANTOM_TOOL_RE.search(lesson):
+            log.debug("Skipping reflection recommending an uninstalled tool: %s", lesson[:80])
+            return False
+
         # Validate outcome
         if outcome not in ("success", "partial", "failure"):
             outcome = "success"
@@ -289,14 +313,16 @@ class ReflectionStore:
 
         await self._ensure_schema()
         async with aiosqlite.connect(self.db_path) as db:
-            # Check for duplicate lessons (same lesson text)
-            cursor = await db.execute(
-                "SELECT id FROM reflections WHERE lesson = ?",
-                (lesson,),
-            )
-            if await cursor.fetchone():
-                log.debug("Skipping duplicate reflection: %s", lesson[:80])
-                return False
+            # Skip exact OR near-duplicate lessons — the store fills with reworded
+            # variants of the same advice otherwise (#156).
+            cursor = await db.execute("SELECT lesson FROM reflections")
+            new_tokens = _tokens(lesson)
+            for (existing,) in await cursor.fetchall():
+                if existing == lesson or _similarity(new_tokens, _tokens(existing)) >= (
+                    _NEAR_DUP_THRESHOLD
+                ):
+                    log.debug("Skipping duplicate reflection: %s", lesson[:80])
+                    return False
 
             await db.execute(
                 "INSERT INTO reflections (task_summary, outcome, lesson, tool_issues, category) "

--- a/humux/pa.md
+++ b/humux/pa.md
@@ -687,7 +687,8 @@ sqlite3 /app/data/memory.db "DELETE FROM short_term WHERE id = 7;"
 ## Important Notes
 - Always use `-json` flag when you need to parse results programmatically
 - Use LIKE with % wildcards for fuzzy content search
-- For long-term memories, always set `category` and `subject` — these are used for filtering
+- For long-term memories, set `category` and a meaningful `subject` (who/what it is about) — never the category word itself (no `[work] work: …`); leave `subject` empty when no clear who/what applies
+- Do not store transient action-confirmations (e.g. "filed issue #12", "created PR #40") as long-term memories — GitHub already records them
 - Short-term facts are auto-cleaned every 8 hours; set `expires_at` appropriately
 - When you learn something new that contradicts an existing memory, UPDATE the old one rather than inserting a duplicate
 - Before inserting a long-term memory, check if a similar one already exists to avoid duplicates

--- a/humux/skills/memory.md
+++ b/humux/skills/memory.md
@@ -97,7 +97,8 @@ sqlite3 data/memory.db "DELETE FROM short_term WHERE id = 7;"
 
 - Always use `-json` flag when you need to parse results programmatically.
 - Use `LIKE` with `%` wildcards for fuzzy content search.
-- For long-term memories, always set `category` and `subject` — these are used for filtering.
+- For long-term memories, set `category` and a meaningful `subject` (who/what it is about, e.g. `matteo`, `alex`). Never put the category word in `subject` (no `[work] work: …`); leave `subject` empty when no clear who/what applies.
+- Do not store transient action-confirmations (e.g. "filed issue #12", "created PR #40") as long-term memories — GitHub already records them.
 - Short-term facts are auto-cleaned every 8 hours; set `expires_at` appropriately.
 - When you learn something new that contradicts an existing memory, UPDATE the old one rather than inserting a duplicate.
 - Before inserting a long-term memory, check if a similar one already exists.

--- a/humux/tests/test_memory_update_pipeline.py
+++ b/humux/tests/test_memory_update_pipeline.py
@@ -280,3 +280,47 @@ class TestHelpers:
         assert _similarity({"a", "b"}, {"c", "d"}) == 0.0
         assert _similarity(set(), {"a"}) == 0.0
         assert _similarity({"a", "b", "c"}, {"a"}) == pytest.approx(1 / 3)
+
+
+# -- #156: remember() subject normalization + transient-confirmation guard --
+
+
+async def _all_rows(store: MemoryStore) -> list[dict]:
+    async with aiosqlite.connect(store.db_path) as db:
+        db.row_factory = aiosqlite.Row
+        cursor = await db.execute("SELECT category, subject, content FROM long_term")
+        return [dict(r) for r in await cursor.fetchall()]
+
+
+@pytest.mark.asyncio
+async def test_remember_drops_category_echo_subject(store) -> None:
+    """Subject that just echoes the category is blanked, not stored as '[work] work'."""
+    stored = await store.remember(
+        "Ships the payroll run every month-end", subject="work", category="work"
+    )
+    assert stored is True
+    rows = await _all_rows(store)
+    assert rows == [
+        {"category": "work", "subject": "", "content": "Ships the payroll run every month-end"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remember_keeps_meaningful_subject(store) -> None:
+    stored = await store.remember("Prefers oat milk", subject="matteo", category="preference")
+    assert stored is True
+    assert (await _all_rows(store))[0]["subject"] == "matteo"
+
+
+@pytest.mark.asyncio
+async def test_remember_rejects_transient_confirmations(store) -> None:
+    for content in ("Filed issue #156 on GitHub", "Created PR #40", "Sent the email to Marco"):
+        assert await store.remember(content) is False
+    assert await _all_rows(store) == []
+
+
+@pytest.mark.asyncio
+async def test_remember_keeps_durable_fact_with_number(store) -> None:
+    """A durable fact that happens to contain a number is still stored."""
+    assert await store.remember("Lives at 12 Baker Street", subject="matteo") is True
+    assert len(await _all_rows(store)) == 1

--- a/humux/tests/test_task_reflection.py
+++ b/humux/tests/test_task_reflection.py
@@ -347,3 +347,58 @@ class TestFormatToolLog:
         log = [{"name": "run_command", "result": {"stdout": "x" * 1000}}]
         result = ReflectionStore._format_tool_log(log)
         assert "run_command: OK" in result
+
+
+# -- #156: dedup / phantom-tool hygiene --
+
+
+@pytest.mark.asyncio
+async def test_store_drops_phantom_tool_lesson(store) -> None:
+    """A lesson recommending an uninstalled binary (rg) is not stored."""
+    stored = await store._store_reflection(
+        {"lesson": "Use rg instead of grep for faster search", "category": "tool"}
+    )
+    assert stored is False
+    assert await _count_rows(store.db_path) == 0
+
+
+@pytest.mark.asyncio
+async def test_store_drops_near_duplicate_lesson(store) -> None:
+    """A reworded variant of an existing lesson is not stored again."""
+    first = await store._store_reflection(
+        {"lesson": "Obtain user confirmation before sending email", "category": "communication"}
+    )
+    second = await store._store_reflection(
+        {
+            "lesson": "Always get user confirmation before sending an email",
+            "category": "communication",
+        }
+    )
+    assert first is True
+    assert second is False
+    assert await _count_rows(store.db_path) == 1
+
+
+@pytest.mark.asyncio
+async def test_format_filters_phantom_and_near_dupes(store) -> None:
+    """format_for_prompt drops phantom-tool advice and near-duplicate lessons."""
+    # Insert directly (bypassing store-time filters) to simulate a legacy DB.
+    async with aiosqlite.connect(store.db_path) as db:
+        for lesson in (
+            "Use rg instead of grep to search files",
+            "Obtain user confirmation before sending email",
+            "Always get user confirmation before sending an email",
+            "Calendar events need an end time; default to one hour",
+        ):
+            await db.execute(
+                "INSERT INTO reflections (task_summary, outcome, lesson, category) "
+                "VALUES ('', 'success', ?, 'general')",
+                (lesson,),
+            )
+        await db.commit()
+
+    out = await store.format_for_prompt()
+    assert "rg instead of grep" not in out
+    # Exactly one of the two confirmation variants survives.
+    assert out.count("confirmation before sending") == 1
+    assert "Calendar events need an end time" in out


### PR DESCRIPTION
Closes #156.

## What

Two low-signal sources bloat and mislead the per-turn context: near-duplicate/wrong task reflections, and misused `remember` calls. This tightens both.

### Task reflections (`core/task_reflection.py`)
- **Near-duplicate suppression**: drop lessons with Jaccard token overlap ≥ 0.6 (reworded repeats), not just byte-identical ones — enforced at both store time and prompt-injection time. Reuses the existing lexical `_similarity`/`_tokens` from `core/memory.py` (no new dep).
- **Phantom-tool filter**: drop any lesson recommending an uninstalled binary (`rg`/`ripgrep`) so the wrong "use rg instead of grep" advice never reaches context, wherever it originated (including rows already in the DB).
- **Prompt rule**: instruct the reflection model not to give tool-switching advice.

### Memory `remember` tool (`core/memory.py`, `core/agent.py`)
- **Subject semantics**: blank a `subject` that just echoes the category word — fixes entries like `[work] work: …`.
- **Transient guard**: reject action-confirmations (`filed issue #N`, `created PR #N`, …) as durable memories; GitHub already records them. `remember()` now returns whether it stored, and the tool reports a skip.
- Tightened the `remember` tool schema wording + memory docs (`pa.md`, `skills/memory.md`).

## Acceptance criteria
- ✅ Reflection preamble has no obvious near-duplicates and references no uninstalled tool.
- ✅ New `remember` calls carry a meaningful `subject` (never the category).
- ✅ Transient "did X" confirmations are not persisted.

## Tests
Added focused tests in `tests/test_task_reflection.py` (phantom-tool drop, near-dup drop at store + format) and `tests/test_memory_update_pipeline.py` (subject normalization, transient rejection, durable-fact-with-number kept). Full suite: **881 passed**, ruff clean.