### PR TITLE
feat: edit memory entries from the admin UI (#158)

### DIFF
--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -76,6 +76,7 @@ This is the real inference payload, captured in memory at send time, so it shows
 Inspect and manage the agent's memories, and tune the memory engine live:
 
 - View all long-term memories by category, and active short-term context
+- Edit any memory inline: long-term (category, subject, content, scope) and short-term (content, scope, expiry). Scope offers `shared` plus every known agent slug, so a memory mis-filed as shared/private can be re-scoped without deleting it. Content/subject edits re-embed the row so semantic search stays correct.
 - Delete individual memories
 - Trigger manual memory consolidation
 - **Semantic memory (embeddings)** — toggle on/off, pick the backend (Local / OpenAI / Google), set the model, base URL, and injected-memories-per-turn (top-k). A status line shows whether the local model is downloaded, with **Download model** and **Test** buttons. Changes apply live (the local model loads on first use). See [Memory → Tier 2](/docs/memory#tier-2-semantic-retrieval-relevance-ranked-injection).

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1710,6 +1710,10 @@ def create_admin_app(
             "hygiene_threshold": await _cfg("memory.hygiene_similarity_threshold", "0.45"),
         }
 
+        # Agent slugs for the scope dropdown in the edit forms (#158).
+        agent_store = await _agent_store_from_config(config_store)
+        ctx["agent_slugs"] = [a.name for a in await agent_store.list_agents()]
+
         # Memory data — read directly from DB (works even when agent is stopped)
         memory_db = await config_store.get("memory.db_path") or "data/memory.db"
         long_term: list[dict] = []
@@ -3216,6 +3220,49 @@ def create_admin_app(
                 raise HTTPException(404, f"Memory {memory_id} not found in {tier}")
 
         # Return refreshed memory partial (full config + tables)
+        return await _render_memory_partial()
+
+    @app.post("/memory/update", dependencies=[Depends(auth)])
+    async def update_memory(request: Request) -> HTMLResponse:
+        """Edit a memory entry (#158). Returns refreshed memory partial for HTMX."""
+        agent = agent_state.agent
+        if not agent:
+            raise HTTPException(503, "Agent not running")
+        content_type = request.headers.get("content-type", "")
+        if "x-www-form-urlencoded" in content_type:
+            body = await request.form()
+        else:
+            body = await request.json()
+        tier = str(body.get("tier", ""))
+        if tier not in ("long-term", "short-term"):
+            raise HTTPException(400, "Tier must be 'long-term' or 'short-term'")
+        try:
+            memory_id = int(cast(str, body.get("memory_id")))
+        except TypeError, ValueError:
+            raise HTTPException(400, "memory_id must be an integer")
+
+        await agent.memory._ensure_schema()
+        if tier == "long-term":
+            rows = await agent.memory.update_long_term(
+                memory_id,
+                category=str(body.get("category", "fact")),
+                subject=str(body.get("subject", "")),
+                content=str(body.get("content", "")),
+                scope=str(body.get("scope", "")),
+            )
+        else:
+            # datetime-local sends "YYYY-MM-DDTHH:MM"; store SQLite's space form.
+            expires = str(body.get("expires_at", "")).replace("T", " ")
+            if len(expires) == 16:  # noqa: PLR2004 — no seconds → add them
+                expires += ":00"
+            rows = await agent.memory.update_short_term(
+                memory_id,
+                content=str(body.get("content", "")),
+                scope=str(body.get("scope", "")),
+                expires_at=expires,
+            )
+        if rows == 0:
+            raise HTTPException(404, f"Memory {memory_id} not found in {tier}")
         return await _render_memory_partial()
 
     @app.get("/memory/embedding/status", dependencies=[Depends(auth)])

--- a/humux/api/templates/partials/memory.html
+++ b/humux/api/templates/partials/memory.html
@@ -284,15 +284,39 @@
         </tr>
       </thead>
       <tbody>
+        {% set categories = ['preference','relationship','fact','routine','work','health','travel'] %}
         {% for m in long_term %}
-        <tr>
+        <tr x-data="{editing:false}">
           <td class="text-xs">{{ m.id }}</td>
-          <td class="text-xs">{{ m.category }}</td>
-          <td class="text-xs">{{ m.subject }}</td>
-          <td class="text-xs break-all">{{ m.content }}</td>
-          <td class="text-xs">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</td>
-          <td>
-            <button class="btn-danger btn-sm"
+          <td class="text-xs">
+            <span x-show="!editing">{{ m.category }}</span>
+            <select name="category" class="input-sm" x-show="editing">
+              {% for c in categories %}<option value="{{ c }}" {% if m.category == c %}selected{% endif %}>{{ c }}</option>{% endfor %}
+            </select>
+          </td>
+          <td class="text-xs">
+            <span x-show="!editing">{{ m.subject }}</span>
+            <input name="subject" class="input-sm" value="{{ m.subject }}" x-show="editing">
+          </td>
+          <td class="text-xs break-all">
+            <span x-show="!editing">{{ m.content }}</span>
+            <textarea name="content" class="input-sm w-full" rows="2" x-show="editing">{{ m.content }}</textarea>
+          </td>
+          <td class="text-xs">
+            <span x-show="!editing">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</span>
+            <select name="scope" class="input-sm" x-show="editing">
+              <option value="" {% if not m.scope %}selected{% endif %}>shared</option>
+              {% for s in agent_slugs %}<option value="{{ s }}" {% if m.scope == s %}selected{% endif %}>{{ s }}</option>{% endfor %}
+            </select>
+          </td>
+          <td class="whitespace-nowrap">
+            <button class="btn btn-sm" x-show="!editing" @click="editing=true">edit</button>
+            <button class="btn-primary btn-sm" x-show="editing"
+                    hx-post="/memory/update" hx-target="#tab-content" hx-swap="innerHTML"
+                    hx-include="closest tr"
+                    hx-vals='{"tier": "long-term", "memory_id": "{{ m.id }}"}'>save</button>
+            <button class="btn btn-sm" x-show="editing" @click="editing=false">cancel</button>
+            <button class="btn-danger btn-sm" x-show="!editing"
                     hx-post="/memory/delete" hx-target="#tab-content" hx-swap="innerHTML"
                     hx-vals='{"tier": "long-term", "memory_id": "{{ m.id }}"}'
                     hx-confirm="Delete this memory?">
@@ -323,13 +347,32 @@
       </thead>
       <tbody>
         {% for m in short_term %}
-        <tr>
+        <tr x-data="{editing:false}">
           <td class="text-xs">{{ m.id }}</td>
-          <td class="text-xs break-all">{{ m.content }}</td>
-          <td class="text-xs">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</td>
-          <td class="text-xs">{{ m.expires_at }}</td>
-          <td>
-            <button class="btn-danger btn-sm"
+          <td class="text-xs break-all">
+            <span x-show="!editing">{{ m.content }}</span>
+            <input name="content" class="input-sm w-full" value="{{ m.content }}" x-show="editing">
+          </td>
+          <td class="text-xs">
+            <span x-show="!editing">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</span>
+            <select name="scope" class="input-sm" x-show="editing">
+              <option value="" {% if not m.scope %}selected{% endif %}>shared</option>
+              {% for s in agent_slugs %}<option value="{{ s }}" {% if m.scope == s %}selected{% endif %}>{{ s }}</option>{% endfor %}
+            </select>
+          </td>
+          <td class="text-xs">
+            <span x-show="!editing">{{ m.expires_at }}</span>
+            <input type="datetime-local" name="expires_at" step="1" class="input-sm"
+                   value="{{ m.expires_at[:19]|replace(' ','T') }}" x-show="editing">
+          </td>
+          <td class="whitespace-nowrap">
+            <button class="btn btn-sm" x-show="!editing" @click="editing=true">edit</button>
+            <button class="btn-primary btn-sm" x-show="editing"
+                    hx-post="/memory/update" hx-target="#tab-content" hx-swap="innerHTML"
+                    hx-include="closest tr"
+                    hx-vals='{"tier": "short-term", "memory_id": "{{ m.id }}"}'>save</button>
+            <button class="btn btn-sm" x-show="editing" @click="editing=false">cancel</button>
+            <button class="btn-danger btn-sm" x-show="!editing"
                     hx-post="/memory/delete" hx-target="#tab-content" hx-swap="innerHTML"
                     hx-vals='{"tier": "short-term", "memory_id": "{{ m.id }}"}'
                     hx-confirm="Delete this memory?">

--- a/humux/api/templates/partials/memory.html
+++ b/humux/api/templates/partials/memory.html
@@ -291,6 +291,7 @@
           <td class="text-xs">
             <span x-show="!editing">{{ m.category }}</span>
             <select name="category" class="input-sm" x-show="editing">
+              {% if m.category not in categories %}<option value="{{ m.category }}" selected>{{ m.category }}</option>{% endif %}
               {% for c in categories %}<option value="{{ c }}" {% if m.category == c %}selected{% endif %}>{{ c }}</option>{% endfor %}
             </select>
           </td>
@@ -306,6 +307,7 @@
             <span x-show="!editing">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</span>
             <select name="scope" class="input-sm" x-show="editing">
               <option value="" {% if not m.scope %}selected{% endif %}>shared</option>
+              {% if m.scope and m.scope not in agent_slugs %}<option value="{{ m.scope }}" selected>{{ m.scope }} (no agent)</option>{% endif %}
               {% for s in agent_slugs %}<option value="{{ s }}" {% if m.scope == s %}selected{% endif %}>{{ s }}</option>{% endfor %}
             </select>
           </td>
@@ -357,6 +359,7 @@
             <span x-show="!editing">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</span>
             <select name="scope" class="input-sm" x-show="editing">
               <option value="" {% if not m.scope %}selected{% endif %}>shared</option>
+              {% if m.scope and m.scope not in agent_slugs %}<option value="{{ m.scope }}" selected>{{ m.scope }} (no agent)</option>{% endif %}
               {% for s in agent_slugs %}<option value="{{ s }}" {% if m.scope == s %}selected{% endif %}>{{ s }}</option>{% endfor %}
             </select>
           </td>

--- a/humux/core/memory.py
+++ b/humux/core/memory.py
@@ -1155,6 +1155,47 @@ class MemoryStore:
             log.debug("Stored short-term memory (TTL %dh): %s", ttl_hours, content[:80])
             return 1
 
+    async def update_long_term(
+        self, memory_id: int, *, category: str, subject: str, content: str, scope: str
+    ) -> int:
+        """Edit a long-term row from the admin UI (#158). Re-embeds only when
+        subject/content changed, so a scope-only fix never nukes the vector when
+        the embedder is momentarily off. Returns rows affected (0 = not found)."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT subject, content, embedding FROM long_term WHERE id = ?", (memory_id,)
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                return 0
+            old_subject, old_content, old_blob = row
+            if subject != old_subject or content != old_content:
+                blob = await self._embed_blob(f"{subject}: {content}")
+            else:
+                blob = old_blob
+            cursor = await db.execute(
+                "UPDATE long_term SET category = ?, subject = ?, content = ?, embedding = ?, "
+                "scope = ?, updated_at = datetime('now') WHERE id = ?",
+                (category, subject, content, blob, scope, memory_id),
+            )
+            await db.commit()
+            return cursor.rowcount
+
+    async def update_short_term(
+        self, memory_id: int, *, content: str, scope: str, expires_at: str
+    ) -> int:
+        """Edit a short-term row from the admin UI (#158). No embedding column on
+        short_term, so this is a plain UPDATE. Returns rows affected."""
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "UPDATE short_term SET content = ?, scope = ?, expires_at = ? WHERE id = ?",
+                (content, scope, expires_at, memory_id),
+            )
+            await db.commit()
+            return cursor.rowcount
+
     # -- Consolidation & cleanup --
 
     async def consolidate_and_cleanup(self, llm: LLMClient, model: str) -> dict:

--- a/humux/tests/test_memory_scope.py
+++ b/humux/tests/test_memory_scope.py
@@ -154,3 +154,68 @@ def test_extraction_scope_block():
     assert _extraction_scope_block("") == ""
     block = _extraction_scope_block("coach")
     assert "coach" in block and "private" in block
+
+
+# --- inline editing from the admin UI (#158) --------------------------------
+
+
+async def _one_id(store, table: str) -> int:
+    async with aiosqlite.connect(store.db_path) as db:
+        cursor = await db.execute(f"SELECT id FROM {table} LIMIT 1")  # noqa: S608
+        return (await cursor.fetchone())[0]
+
+
+async def test_update_long_term_changes_fields_and_scope(store):
+    await store._insert_long_term("fact", "matteo", "old content", scope="")
+    n = await store.update_long_term(
+        await _one_id(store, "long_term"),
+        category="work",
+        subject="matteo",
+        content="new content",
+        scope="coach",
+    )
+    assert n == 1
+    # Moved to the coach scope with the new category.
+    coach = {r["content"]: r for r in await store.get_long_term("coach")}
+    assert coach["new content"]["category"] == "work"
+
+
+async def test_update_long_term_reembeds_only_on_text_change(store, monkeypatch):
+    calls = []
+
+    async def fake_blob(text):
+        calls.append(text)
+        return b"vec"
+
+    monkeypatch.setattr(store, "_embed_blob", fake_blob)
+    await store._insert_long_term("fact", "s", "content", scope="")
+    mid = await _one_id(store, "long_term")
+    calls.clear()
+
+    # Scope-only edit → no re-embed.
+    await store.update_long_term(mid, category="fact", subject="s", content="content", scope="x")
+    assert calls == []
+    # Content edit → re-embed.
+    await store.update_long_term(mid, category="fact", subject="s", content="changed", scope="x")
+    assert calls == ["s: changed"]
+
+
+async def test_update_long_term_missing_returns_zero(store):
+    assert (
+        await store.update_long_term(999, category="fact", subject="s", content="c", scope="") == 0
+    )
+
+
+async def test_update_short_term(store):
+    await store._store_short_term(
+        {"content": "temp fact", "context": "", "ttl_hours": 24}, scope=""
+    )
+    n = await store.update_short_term(
+        await _one_id(store, "short_term"),
+        content="edited",
+        scope="coach",
+        expires_at="2099-01-01 00:00:00",
+    )
+    assert n == 1
+    coach = {r["content"] for r in await store.get_short_term("coach")}
+    assert "edited" in coach


### PR DESCRIPTION
Closes #158.

## What

The memory tab only supported **deleting** entries. This adds **inline editing** to both tables. The painful case — a memory stored as `shared` when it should be scoped to an agent (or vice versa) — is now a scope-dropdown change instead of delete-and-hope.

### Long-term
Edit category (dropdown), subject, content, scope (dropdown: `shared` + every known agent slug).

### Short-term
Edit content, scope, expiry (datetime picker).

## How

- **`core/memory.py`** — `update_long_term()` / `update_short_term()`. Long-term **re-embeds only when subject/content actually changed**, so a scope-only fix never nukes the vector when the embedder is momentarily off. Short-term has no embedding column → plain UPDATE.
- **`api/admin.py`** — `POST /memory/update` (mirrors `/memory/delete`: needs the running agent for its embedder; returns the refreshed partial). Agent slugs added to the partial context for the scope dropdown.
- **`memory.html`** — Alpine per-row `editing` toggle swaps display spans ↔ inputs; Save posts via HTMX `hx-include="closest tr"` and swaps the refreshed table in. Delete unchanged.

## Acceptance criteria

- [x] Edit content, category, subject, scope of any long-term memory
- [x] Edit content, scope, expiry of any short-term memory
- [x] Scope dropdown offers `shared` + all agent slugs
- [x] Changes persist to SQLite immediately
- [x] Embedding regenerated on content/subject change (only then)
- [x] Delete keeps working
- [x] No regression — full memory suite green (102 passed)

## Tests

Store-level update tests in `test_memory_scope.py` (field/scope change, re-embed-only-on-text-change, missing-id → 0, short-term update). Verified the full partial renders end-to-end with a seeded DB: 3 edit rows, category/scope dropdowns, datetime picker.