### PR TITLE
feat: pre-approve common read-only Unix commands (#148)

### DIFF
--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -32,9 +32,15 @@ humux ships with sensible defaults:
 "run_command:sqlite3*/app/data/memory.db*INSERT*"    # Memory writes
 "run_command:sqlite3*/app/data/memory.db*UPDATE*"    # Memory updates
 "run_command:sqlite3*/app/data/memory.db*DELETE*"    # Memory deletes
+"run_command:cat*"  "run_command:ls*"  "run_command:echo*"   # Common read-only
+"run_command:head*" "run_command:tail*" "run_command:date*"  # Unix commands —
+"run_command:pwd*"  "run_command:whoami*" "run_command:id*"  # cat/ls/wc/df/…
+"run_command:wc*"   "run_command:df*"   "run_command:du*"    # (see note below)
 "web_search"                                          # Web searches
 "set_reaction"                                        # Emoji reactions (Telegram)
 ```
+
+The read-only Unix commands above (`cat`, `ls`, `echo`, `head`, `tail`, `date`, `pwd`, `whoami`, `id`, `uname`, `hostname`, `which`, `wc`, `sort`, `uniq`, `cut`, `tr`, `du`, `df`, `file`, `basename`, `dirname`, `printenv`) are pre-approved so a fresh agent isn't prompted for trivial inspection. They stay safe because the shell-control guard still forces an **ASK** whenever the command redirects, chains, or substitutes (`cat x > y`, `date; rm -rf /`, `echo x | sh`). `env` is **not** pre-approved — as an exec-wrapper (`env A=1 python3 -c …`) it can run arbitrary code with no shell-control character, so it stays ASK alongside `xargs`, `sudo`, `find`, and the file-mutating commands (`rm`, `mv`, `cp`, `chmod`, `mkdir`, …).
 
 ### Ask first (write operations)
 

--- a/humux/core/permissions.py
+++ b/humux/core/permissions.py
@@ -162,6 +162,37 @@ DEFAULT_RULES: dict[str, str] = {
     "run_command:rg*": "ALWAYS",
     "run_command:yt-dlp*": "ALWAYS",
     "run_command:cal*": "ALWAYS",
+    # Common read-only Unix commands (#148) — noisy to ASK for on every fresh
+    # agent. Safe because the check() shell-control guard still blocks any
+    # wildcard auto-approval of a command carrying ; | & $() ` < > (redirects,
+    # chaining, substitution), so `cat >x`, `date; rm -rf /`, `echo x|sh` all
+    # still ASK. Deliberately EXCLUDED: `env` (exec-wrapper — `env A=1 python3 -c
+    # …` runs arbitrary code with no shell-control char, so the guard can't catch
+    # it; it stays ASK, same as xargs/sudo). `tr` uses a `tr *` pattern, not
+    # `tr*`, so it can't bleed onto destructive `truncate`.
+    "run_command:cat*": "ALWAYS",
+    "run_command:ls*": "ALWAYS",
+    "run_command:echo*": "ALWAYS",
+    "run_command:head*": "ALWAYS",
+    "run_command:tail*": "ALWAYS",
+    "run_command:date*": "ALWAYS",
+    "run_command:pwd*": "ALWAYS",
+    "run_command:whoami*": "ALWAYS",
+    "run_command:id*": "ALWAYS",
+    "run_command:uname*": "ALWAYS",
+    "run_command:hostname*": "ALWAYS",
+    "run_command:which*": "ALWAYS",
+    "run_command:wc*": "ALWAYS",
+    "run_command:sort*": "ALWAYS",
+    "run_command:uniq*": "ALWAYS",
+    "run_command:cut*": "ALWAYS",
+    "run_command:tr *": "ALWAYS",
+    "run_command:du*": "ALWAYS",
+    "run_command:df*": "ALWAYS",
+    "run_command:file*": "ALWAYS",
+    "run_command:basename*": "ALWAYS",
+    "run_command:dirname*": "ALWAYS",
+    "run_command:printenv*": "ALWAYS",
     # cp writes files (into the workspace) — treat like other write ops: ask first.
     "run_command:cp*": "ASK",
     "run_command:git*log*": "ALWAYS",

--- a/humux/tests/test_permissions.py
+++ b/humux/tests/test_permissions.py
@@ -372,3 +372,48 @@ def test_format_approval_message_truncates_huge_command() -> None:
     )
     assert len(text) < 400
     assert "…" in text
+
+
+def test_readonly_unix_commands_are_default_always() -> None:
+    # #148: fresh agent runs common read-only commands without a prompt.
+    engine = PermissionEngine()
+    for cmd in (
+        "cat notes.txt",
+        "ls -la",
+        "echo hi",
+        "date",
+        "pwd",
+        "whoami",
+        "head -5 f",
+        "tail f",
+        "wc -l f",
+        "df -h",
+        "du -sh .",
+        "which python3",
+        "tr a-z A-Z",
+        "file f",
+    ):
+        assert engine.check("run_command", {"command": cmd}) == PermissionLevel.ALWAYS, cmd
+
+
+def test_readonly_wildcard_still_asks_on_shell_control() -> None:
+    # The shell-control guard must survive the new rules: redirect/chain/subst
+    # commands whose prefix matches an ALWAYS rule still ASK.
+    engine = PermissionEngine()
+    for cmd in ("cat secret > /etc/passwd", "date; rm -rf /", "echo x | sh", "ls $(rm -rf /)"):
+        assert engine.check("run_command", {"command": cmd}) == PermissionLevel.ASK, cmd
+
+
+def test_exec_wrapper_env_stays_ask() -> None:
+    # `env` is an exec-wrapper: `env A=1 python3 -c 'evil'` runs arbitrary code
+    # with no shell-control char, so it is deliberately NOT pre-approved.
+    engine = PermissionEngine()
+    got = engine.check("run_command", {"command": "env A=1 python3 -c 'x'"})
+    assert got == PermissionLevel.ASK
+
+
+def test_tr_rule_does_not_bleed_onto_truncate() -> None:
+    # `tr *` (with space) must not auto-approve destructive `truncate`.
+    engine = PermissionEngine()
+    got = engine.check("run_command", {"command": "truncate -s 0 important.db"})
+    assert got == PermissionLevel.ASK


### PR DESCRIPTION
Closes #148.

## What

Adds `ALWAYS` default rules so a fresh agent isn't prompted for trivial, inherently read-only Unix commands:

`cat` `ls` `echo` `head` `tail` `date` `pwd` `whoami` `id` `uname` `hostname` `which` `wc` `sort` `uniq` `cut` `tr` `du` `df` `file` `basename` `dirname` `printenv`

## Why it's safe

The existing `check()` shell-control guard still forces **ASK** whenever a command redirects, chains, or substitutes (`;` `|` `&` `$()` `` ` `` `<` `>`), so `cat x > y`, `date; rm -rf /`, and `echo x | sh` all still prompt even though their prefix matches an ALWAYS rule.

## Deviations from the issue's list (deliberate)

- **`env` excluded.** It's an exec-wrapper: `env A=1 python3 -c '…'` runs arbitrary code with **no** shell-control character, so the guard can't catch it. It stays ASK, consistent with the existing `xargs`/`sudo` handling. The issue listed it under ALWAYS, but that would be a code-execution hole.
- **`tr` uses `tr *` (trailing space), not `tr*`.** A bare `tr*` prefix would bleed onto destructive `truncate` and silently flip it from ASK to ALWAYS. The space-form matches `tr a-z A-Z` but not `truncate`.

Commands that stay ASK (find, xargs, tee, dd, rm, mv, cp, chmod, chown, mkdir, touch, ln, kill) are unchanged.

## Tests

`tests/test_permissions.py`:
- read-only commands resolve ALWAYS
- shell-control variants of those same commands still ASK
- `env A=1 python3 -c …` stays ASK
- `truncate` stays ASK (no `tr` bleed)

All 32 permission tests pass.

## Docs

`docs/content/docs/permissions.mdx` — added the commands to the "Always allowed" list with a note on the guard and the `env`/`tr` reasoning.