### PR TITLE
fix: placeholder reflects approval wait, not stale 'Thinking…' (#147)

### DIFF
--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -69,6 +69,10 @@ _DENY_PREFIX = "perm_deny:"
 _ALWAYS_PREFIX = "perm_always:"
 # Callback data prefix for subagent-run cancel buttons (issue #15)
 _SUB_CANCEL_PREFIX = "sub_cancel:"
+# Placeholder labels for the "working" bubble (#57, #147). The label tracks the
+# agent's real state so a permission wait never reads as "still thinking".
+_THINKING = "🤔 Thinking…"
+_WAITING_APPROVAL = "✋ Waiting for your approval…"
 _HTML_TAG_RE = re.compile(
     r"</?(b|strong|i|em|u|ins|s|strike|del|code|pre|a|tg-spoiler)(\s+[^>]*)?>",
     re.IGNORECASE,
@@ -631,6 +635,13 @@ class TelegramChannel:
 
         data = query.data or ""
 
+        if data.startswith((_APPROVE_PREFIX, _DENY_PREFIX, _ALWAYS_PREFIX)):
+            # Decision made: the agent unblocks and resumes, so the placeholder
+            # goes back to "Thinking…" (#147). A timeout has no button press and so
+            # can't clear here — the label is corrected on the next approval or gone
+            # when the turn ends; that 120s edge isn't worth agent-side plumbing.
+            self._set_typing_waiting(chat_id, False)
+
         if data.startswith(_APPROVE_PREFIX):
             request_id = data[len(_APPROVE_PREFIX) :]
             resolved = self.agent.permissions.resolve_approval(request_id, True)
@@ -720,6 +731,9 @@ class TelegramChannel:
         )
         text = f"Permission request:\n\n{description}"
         cid, kw = self._route(chat_id)
+        # The agent is now blocked awaiting this decision — reflect that on the
+        # placeholder so it stops claiming to think (#147).
+        self._set_typing_waiting(chat_id, True)
         if image_path:
             try:
                 with open(image_path, "rb") as photo:
@@ -769,6 +783,15 @@ class TelegramChannel:
                 pass
 
         turn_over = asyncio.Event()
+        # State shared with the approval hooks (#147): while the agent is blocked on
+        # a permission prompt it is waiting, not thinking, so the placeholder label
+        # must say so instead of a stale "Thinking…". send_approval_request /
+        # _on_approval_callback flip ``waiting`` and poke ``changed`` to re-render.
+        # ponytail: one entry per routed chat, assumes turns in a chat don't overlap
+        # (approvals are interactive/serial anyway) — key by (chat, turn) if they do.
+        state = {"waiting": False, "changed": asyncio.Event()}
+        waits = self.__dict__.setdefault("_typing_waits", {})
+        waits[str(cid)] = state
 
         async def _placeholder():
             # Wait out the delay; a turn that finishes first never posts (no flash).
@@ -779,13 +802,39 @@ class TelegramChannel:
                 pass
             # disable_notification: deleting a message does NOT retract its push, so
             # a notifying placeholder would ping the user every turn. Keep it silent.
-            # ponytail: static "Thinking…". Streaming the real per-step CoT would
-            # need a progress callback threaded through agent.process() — add that
-            # if the generic signal proves not enough.
-            msg = await self.app.bot.send_message(
-                cid, "🤔 Thinking…", disable_notification=True, **kw
-            )
-            await turn_over.wait()  # leave it up for the rest of the turn
+            # ponytail: static labels. Streaming the real per-step CoT would need a
+            # progress callback threaded through agent.process() — add that if the
+            # generic signal proves not enough.
+            try:
+                msg = await self.app.bot.send_message(
+                    cid, _THINKING, disable_notification=True, **kw
+                )
+            except Exception:
+                return  # send failed → nothing posted, nothing to re-render or delete
+            shown = _THINKING
+            # Re-render the label on each state change until the turn ends. A failed
+            # edit is swallowed: a stale label is cosmetic, never worth a crash.
+            while not turn_over.is_set():
+                want = _WAITING_APPROVAL if state["waiting"] else _THINKING
+                if want != shown:
+                    try:
+                        await self.app.bot.edit_message_text(
+                            want, chat_id=cid, message_id=msg.message_id
+                        )
+                        shown = want
+                    except Exception:
+                        pass
+                state["changed"].clear()
+                wakers = [
+                    asyncio.ensure_future(turn_over.wait()),
+                    asyncio.ensure_future(state["changed"].wait()),
+                ]
+                try:
+                    await asyncio.wait(wakers, return_when=asyncio.FIRST_COMPLETED)
+                finally:
+                    for w in wakers:
+                        w.cancel()
+                    await asyncio.gather(*wakers, return_exceptions=True)
             try:
                 await self.app.bot.delete_message(cid, msg.message_id)
             except Exception:
@@ -800,12 +849,24 @@ class TelegramChannel:
             yield
         finally:
             turn_over.set()
+            waits.pop(str(cid), None)
             typing_task.cancel()
             for t in (typing_task, placeholder_task):
                 try:
                     await t
                 except asyncio.CancelledError, Exception:
                     pass
+
+    def _set_typing_waiting(self, chat_id: int | str, waiting: bool) -> None:
+        """Flip the active turn's placeholder between "Thinking…" and "Waiting for
+        your approval…" (#147). No-op when no turn is showing a placeholder for
+        this chat (e.g. a subagent or admin-API approval with no _typing wrapper)."""
+        cid, _ = self._route(chat_id)
+        state = self.__dict__.get("_typing_waits", {}).get(str(cid))
+        if state is None:
+            return
+        state["waiting"] = waiting
+        state["changed"].set()
 
     @asynccontextmanager
     async def _progress(self, chat_id: int | str):

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -815,6 +815,9 @@ class TelegramChannel:
             # Re-render the label on each state change until the turn ends. A failed
             # edit is swallowed: a stale label is cosmetic, never worth a crash.
             while not turn_over.is_set():
+                # Clear BEFORE reading state: a toggle that lands between the read
+                # and the clear would otherwise be dropped (lost wakeup).
+                state["changed"].clear()
                 want = _WAITING_APPROVAL if state["waiting"] else _THINKING
                 if want != shown:
                     try:
@@ -824,7 +827,6 @@ class TelegramChannel:
                         shown = want
                     except Exception:
                         pass
-                state["changed"].clear()
                 wakers = [
                     asyncio.ensure_future(turn_over.wait()),
                     asyncio.ensure_future(state["changed"].wait()),

--- a/humux/tests/test_telegram_channel.py
+++ b/humux/tests/test_telegram_channel.py
@@ -196,6 +196,35 @@ async def test_placeholder_send_failure_is_non_fatal() -> None:
     ch.app.bot.delete_message.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_placeholder_reflects_approval_wait_then_thinking() -> None:
+    # #147: while the agent is blocked on a permission prompt the placeholder must
+    # say it's waiting, not still "Thinking…", and flip back once a decision lands.
+    ch = _channel_with_mock_bot()
+
+    async with ch._typing(123):
+        await _wait_for(lambda: ch.app.bot.send_message.await_count > 0)
+        # Agent hits an approval → the label switches to "Waiting…".
+        ch._set_typing_waiting(123, True)
+        await _wait_for(lambda: ch.app.bot.edit_message_text.await_count > 0)
+        text, kwargs = ch.app.bot.edit_message_text.call_args
+        assert "Waiting" in text[0]
+        assert kwargs["message_id"] == 4242
+        # User decides → back to "Thinking…".
+        ch._set_typing_waiting(123, False)
+        await _wait_for(lambda: ch.app.bot.edit_message_text.await_count > 1)
+        assert "Thinking" in ch.app.bot.edit_message_text.call_args[0][0]
+
+    ch.app.bot.delete_message.assert_awaited_once_with(123, 4242)
+
+
+def test_set_typing_waiting_is_noop_without_active_placeholder() -> None:
+    # A subagent / admin-API approval has no _typing wrapper for the chat; toggling
+    # must not raise (registry miss), it just does nothing.
+    ch = _channel_with_mock_bot()
+    ch._set_typing_waiting(999, True)  # no entry for 999 → silent no-op
+
+
 def test_chunk_keeps_pieces_under_limit_and_loses_nothing() -> None:
     # 50 lines of 200 chars = 10000 chars, well over the 4096 limit (#80).
     text = "\n".join(f"line{i} " + "x" * 200 for i in range(50))


### PR DESCRIPTION
Closes #147.

## Problem

The `🤔 Thinking…` placeholder is owned by the `_typing()` context manager in `channels/telegram.py`, which wraps the entire `agent.process()` tool loop. It's only removed when that whole loop ends. So while the agent is **blocked on a permission prompt** — after a **Deny** or during the **120s timeout** — the bubble kept saying "Thinking…" across every round of the loop, when the agent is actually *waiting*, not thinking.

## Fix

Make the placeholder track the agent's real state, entirely channel-side (issue's Option A UX, without threading a callback through `agent.process()`):

- `send_approval_request` — the agent is about to block → flip the active turn's placeholder to **`✋ Waiting for your approval…`**.
- `_on_approval_callback` — any decision (Approve / Deny / Always) lands → flip it back to **`🤔 Thinking…`**; the agent resumes.

Both transition points already hold the chat id, so the fix needs no plumbing through the agent. The placeholder task now re-renders its label on each state change (via a small per-chat `{waiting, changed}` entry) until the turn ends, then deletes as before.

### Why channel-side, not `agent.py`

The issue's Option A proposed an `on_state_change` callback threaded through `request_state` in `agent.py`. Not needed: the enter/leave-wait boundaries are *already* Telegram methods (`send_approval_request` / the button callback) with the chat id in hand. Keeping it in the channel means zero changes to the agent core.

## Acceptance criteria

- ✅ "Thinking" does not stay visible while the agent waits for approval — it reads "Waiting for your approval…".
- ✅ On Deny, the label reflects the actual state and flips back to "Thinking…" when the agent resumes.
- ✅ No regression: Approve / Always / fast-turn / slow-turn / send-failure / turn-ends-mid-send paths all still pass.
- ✅ Placeholder is never permanently stuck — still deleted at turn end.

### Known edge (documented in-code)

A **120s timeout** has no button press, so the channel can't clear the "Waiting…" label at the moment of timeout; it's corrected on the next approval prompt or removed when the turn ends. Clearing it exactly at timeout would need agent-side plumbing for a rare edge — deliberately skipped.

## Tests

`tests/test_telegram_channel.py`:
- `test_placeholder_reflects_approval_wait_then_thinking` — label switches to Waiting on approval, back to Thinking on decision, deleted at end.
- `test_set_typing_waiting_is_noop_without_active_placeholder` — a subagent/admin approval with no active `_typing` wrapper toggles harmlessly.

Full suite: 910 passed, ruff clean.