### PR TITLE
feat: /stop command + Stop button to abort a running turn (#146)

### DIFF
--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -36,7 +36,7 @@ agent's row, after which every bot is configured per-agent. See
 
 - **Text messages** — standard chat with the agent
 - **Voice messages** — automatically transcribed via Whisper, agent can respond with synthesized voice
-- **Inline keyboards** — used for permission approval flow (Approve / Edit / Deny)
+- **Inline keyboards** — used for permission approval flow (Approve / Deny / Always allow / Stop)
 - **User ID whitelist** — only allowed users can interact with the bot
 - **Bot-per-agent** — every agent has its own bot token, so it's a separate Telegram contact, all running in one process; see below
 - **Group rooms** — several agent-bots share one group sanely: each replies only when addressed, ignores other bots, and tags who said what; see below
@@ -92,6 +92,10 @@ A few details worth knowing:
 
 - **Clearing context** — in a group, clear a specific bot with `/new@botname` (a bare
   `/new` is not addressed to any one bot, so it's recorded as context, not a clear).
+- **Stopping a turn** — press **⛔ Stop** on any approval prompt, or send `/stop`, to abort
+  the whole running turn (not just one action). `/stop` works mid-turn and in YOLO mode
+  where there are no prompts; it's scoped to that chat and is a no-op when nothing is
+  running. See [Permissions](/docs/permissions#stopping-a-turn).
 - **YOLO mode** — `/yolo-on` lets a bot act without asking for approval; `/yolo-off`
   restores prompting. Only the short hard-blocked (`NEVER`) list is still refused (e.g.
   direct DB drops/alters) — **everything else, including filesystem and network commands,
@@ -100,7 +104,7 @@ A few details worth knowing:
   (a bare `/yolo-on`, addressed to no bot, toggles nothing). The setting persists across
   restarts until you turn it off.
 - **Command menu** — each bot publishes its commands to Telegram's ☰ menu / `/`
-  autocomplete on startup (`/new`, `/jobs`, `/yolo_on`, `/yolo_off` — Telegram forbids
+  autocomplete on startup (`/new`, `/jobs`, `/yolo_on`, `/yolo_off`, `/stop` — Telegram forbids
   `-` in menu command names, so YOLO shows with an underscore; `/yolo-on` still works too).
   In a group each bot lists its own commands, `@bot`-suffixed, so tapping one targets that
   bot. The menu is a full replace, so the list simply tracks whatever the version ships.

--- a/docs/content/docs/permissions.mdx
+++ b/docs/content/docs/permissions.mdx
@@ -100,12 +100,23 @@ When the agent wants to perform an action with `ASK` permission, it sends a mess
 I'd like to send this WhatsApp message to Simge (+41 78 ...):
 "Hey, I'll be home a bit late tonight"
 
-[Approve] [Edit] [Deny]
+[Approve] [Deny] [Always allow]
+[⛔ Stop]
 ```
 
-- **Approve** — execute the action as-is
-- **Edit** — modify the action before executing (agent will ask for changes)
-- **Deny** — cancel the action
+- **Approve** — execute this one action, then continue the turn
+- **Deny** — skip this one action, then continue the turn
+- **Always allow** — approve and persist a rule for this command shape, then continue
+- **Stop** — abort the **entire** current turn, not just this action. The turn ends immediately (after any in-flight action finishes) and a notice is recorded so the agent knows on your next message that it was interrupted.
+
+## Stopping a turn
+
+Once a turn is running you can cancel it without waiting for it to finish:
+
+- Press **⛔ Stop** on any approval prompt.
+- Send **`/stop`** — works even in YOLO mode (where there are no prompts) and mid-turn. It aborts the running turn for that chat only; if nothing is running it's a no-op. Available from Telegram's `/` command menu.
+
+The turn stops at the next tool round, so an action already in flight finishes first. What ran up to that point stands; the turn simply doesn't continue.
 
 ## Managing rules
 

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -41,7 +41,9 @@ log = logging.getLogger(__name__)
 # Plain-text commands the agent handles in process() (not Telegram CommandHandlers).
 # _on_text sends these bare (no speaker tag / reply-quote) and honours an explicit
 # "@bot" target so a command never acts on the wrong bot in a multi-agent room.
-_AGENT_COMMANDS = frozenset({"/new", "/clear", "/yolo-on", "/yolo-off", "/yolo_on", "/yolo_off"})
+_AGENT_COMMANDS = frozenset(
+    {"/new", "/clear", "/yolo-on", "/yolo-off", "/yolo_on", "/yolo_off", "/stop"}
+)
 
 # The command menu surfaced in Telegram's ☰ button / "/" autocomplete
 # (setMyCommands). This is the single source of truth: set_my_commands is a full
@@ -54,6 +56,7 @@ _MENU_COMMANDS = [
     BotCommand("jobs", "Show scheduled jobs"),
     BotCommand("yolo_on", "Run actions without asking for approval"),
     BotCommand("yolo_off", "Restore approval prompts"),
+    BotCommand("stop", "Stop the current turn"),
 ]
 
 # Collapse identical back-to-back inbound text from the same sender within this
@@ -67,6 +70,7 @@ _DEDUP_WINDOW_S = 3.0
 _APPROVE_PREFIX = "perm_approve:"
 _DENY_PREFIX = "perm_deny:"
 _ALWAYS_PREFIX = "perm_always:"
+_STOP_PREFIX = "perm_stop:"
 # Callback data prefix for subagent-run cancel buttons (issue #15)
 _SUB_CANCEL_PREFIX = "sub_cancel:"
 _HTML_TAG_RE = re.compile(
@@ -646,6 +650,16 @@ class TelegramChannel:
             resolved = self.agent.permissions.resolve_approval(request_id, True, always_allow=True)
             await self._finalize_approval_response(query, resolved, "♾️ Always allowed")
 
+        elif data.startswith(_STOP_PREFIX):
+            # Stop button (#146): resolve THIS pending prompt as denied so the
+            # awaiting tool unblocks, then flag the turn to abort at the next round.
+            # request_stop is keyed by the same (convo_user, chat_id) as the turn.
+            request_id = data[len(_STOP_PREFIX) :]
+            self.agent.permissions.resolve_approval(request_id, False)
+            active = self.agent.request_stop(self.channel_name, str(convo_user), str(chat_id))
+            label = "⏹️ Stopping…" if active else "⏹️ Stopped"
+            await self._finalize_approval_response(query, True, label)
+
         elif data.startswith(_SUB_CANCEL_PREFIX):
             run_id = data[len(_SUB_CANCEL_PREFIX) :]
             ok = self.agent.subagents.cancel(run_id)
@@ -715,7 +729,11 @@ class TelegramChannel:
                     InlineKeyboardButton(
                         "Always allow", callback_data=f"{_ALWAYS_PREFIX}{request_id}"
                     ),
-                ]
+                ],
+                # Stop rides its own row (#146): aborts the WHOLE turn, not just this
+                # one action — a different scope from the three per-action buttons, and
+                # Telegram gives no button colour to signal that, so the row does.
+                [InlineKeyboardButton("⛔ Stop", callback_data=f"{_STOP_PREFIX}{request_id}")],
             ]
         )
         text = f"Permission request:\n\n{description}"

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -231,7 +231,14 @@ def _strip_command_suffix(message: str) -> str:
     return text.lower()
 
 
-_CONTROL_COMMANDS = ("/yolo-on", "/yolo-off", "/new", "/clear")
+_CONTROL_COMMANDS = ("/yolo-on", "/yolo-off", "/new", "/clear", "/stop")
+
+# Shown as the reply of an aborted turn AND stored as its assistant history entry,
+# so the next turn's model sees it was interrupted mid-work (#146).
+_STOPPED_MESSAGE = (
+    "⏹️ Stopped at your request — I halted this turn before finishing, so some "
+    "actions may already have run and others were skipped. Tell me how to proceed."
+)
 
 # Telegram command names (setMyCommands) may only be [a-z0-9_], so the hyphenated
 # /yolo-on is menu-registered under a /yolo_on underscore alias; canonicalise it
@@ -1126,6 +1133,18 @@ class AgentCore:
         cross-chat concurrency is unchanged. The turn logic lives in
         ``_process_impl``.
         """
+        # /stop — abort the active turn for this chat. Handled BEFORE the chat lock
+        # (#146): a running turn HOLDS that lock, so a queued /stop would otherwise
+        # wait for the very turn it means to cancel. Gated on ``respond`` so an
+        # unaddressed "/stop@otherbot" in a group doesn't act. No-op (brief note)
+        # when nothing is running.
+        if respond and _control_command(message) == "/stop":
+            if self.request_stop(channel, user_id, chat_id):
+                # The aborting turn delivers _STOPPED_MESSAGE itself; stay silent
+                # here so the user isn't answered twice.
+                return AgentResponse(text="")
+            return AgentResponse(text="Nothing to stop — no turn is running.")
+
         async with self._chat_lock(channel, user_id, chat_id):
             return await self._process_impl(
                 message,
@@ -1138,6 +1157,31 @@ class AgentCore:
                 addressed=addressed,
                 message_id=message_id,
             )
+
+    def _active_turns_map(self) -> dict:
+        """Conversation key → abort Event for the turn currently running there.
+
+        Lazy like ``_chat_locks`` so it also works on a bare-``__new__`` instance
+        (the test pattern). A turn registers its Event in ``_process_impl`` and
+        pops it on exit; ``request_stop`` sets it to break the tool loop (#146)."""
+        turns = getattr(self, "_active_turns", None)
+        if turns is None:
+            turns = self._active_turns = {}
+        return turns
+
+    def request_stop(self, channel: str, user_id: str, chat_id: str) -> bool:
+        """Ask the running turn of one chat to abort at the next tool round.
+
+        Returns True if a turn was active (its abort Event was set), False if the
+        chat was idle. Scoped per conversation key, so a stop never crosses into
+        another chat (#146). The turn checks the flag between rounds/tool calls, so
+        it takes effect after the in-flight LLM call or tool returns, not instantly.
+        """
+        ev = self._active_turns_map().get((channel, user_id, chat_id))
+        if ev is None:
+            return False
+        ev.set()
+        return True
 
     def _chat_lock(self, channel: str, user_id: str, chat_id: str) -> asyncio.Lock:
         """The turn lock for one chat key, created on first use.
@@ -1358,6 +1402,12 @@ class AgentCore:
                 prompt=system,
             )
 
+        # Register this turn's abort Event so /stop and the Stop button can reach it
+        # (#146). The chat lock serialises turns of one key, so there's never a live
+        # entry to clobber; popped in finally whether the turn returns or raises.
+        turn_key = (channel, user_id, chat_id)
+        self._active_turns_map()[turn_key] = asyncio.Event()
+
         # Record every generate() this turn under this context so the admin
         # Inspect tab can show the exact last-sent payload (#99). Reset in finally
         # so a context never leaks onto an unrelated later turn on the same task.
@@ -1390,6 +1440,7 @@ class AgentCore:
             )
         finally:
             reset_capture_context(cap_token)
+            self._active_turns_map().pop(turn_key, None)
 
     async def _resolve_agent(self, channel: str, user_id: str, chat_id: str) -> Agent | None:
         """Resolve the agent for this request, in precedence order:
@@ -1903,8 +1954,13 @@ class AgentCore:
         tool_log: list[dict] = []
         truncations = 0
         rounds = 0
+        abort = self._active_turns_map().get((channel, user_id, chat_id))
+        stopped = False
         while response.tool_calls and rounds < _MAX_TOOL_ROUNDS:
             rounds += 1
+            if abort and abort.is_set():  # /stop or the Stop button fired (#146)
+                stopped = True
+                break
             if response.truncated:
                 truncations += 1
                 if truncations > _MAX_TRUNCATION_RETRIES:
@@ -1918,6 +1974,11 @@ class AgentCore:
                 )
                 tool_results = []
                 for call in response.tool_calls:
+                    if abort and abort.is_set():
+                        # Stop pressed mid-batch — let the in-flight call finish,
+                        # skip the rest, and break the loop on the next check (#146).
+                        stopped = True
+                        break
                     result = await self._execute_tool(call, channel, user_id, request_state)
                     tool_log.append({"name": call.name, "args": call.arguments, "result": result})
                     tool_results.append(
@@ -1927,6 +1988,8 @@ class AgentCore:
                             "content": json.dumps(result),
                         }
                     )
+                if stopped:
+                    break
 
             # Feed tool results back to the LLM
             messages.append(self.llm.assistant_message(response))
@@ -1938,11 +2001,14 @@ class AgentCore:
                 messages=messages,
                 tools=cast(Any, tools),
             )
-        final_text = response.text
-        if response.truncated and not final_text:
-            final_text = _TRUNCATION_GIVEUP_MESSAGE
-        elif response.tool_calls and not final_text:
-            final_text = _LOOP_ABORT_MESSAGE
+        if stopped:
+            final_text = _STOPPED_MESSAGE
+        else:
+            final_text = response.text
+            if response.truncated and not final_text:
+                final_text = _TRUNCATION_GIVEUP_MESSAGE
+            elif response.tool_calls and not final_text:
+                final_text = _LOOP_ABORT_MESSAGE
         log.info("Response: %s", final_text[:200])
 
         # Check if the LLM wants to respond with voice
@@ -2044,8 +2110,13 @@ class AgentCore:
         tool_log: list[dict] = []
         truncations = 0
         rounds = 0
+        abort = self._active_turns_map().get((channel, user_id, chat_id))
+        stopped = False
         while response.tool_calls and rounds < _MAX_TOOL_ROUNDS:
             rounds += 1
+            if abort and abort.is_set():  # /stop or the Stop button fired (#146)
+                stopped = True
+                break
             if response.truncated:
                 truncations += 1
                 if truncations > _MAX_TRUNCATION_RETRIES:
@@ -2059,6 +2130,11 @@ class AgentCore:
                 )
                 tool_results = []
                 for call in response.tool_calls:
+                    if abort and abort.is_set():
+                        # Stop pressed mid-batch — let the in-flight call finish,
+                        # skip the rest, and break the loop on the next check (#146).
+                        stopped = True
+                        break
                     result = await self._execute_tool(call, channel, user_id, request_state)
                     tool_log.append({"name": call.name, "args": call.arguments, "result": result})
                     tool_results.append(
@@ -2068,6 +2144,12 @@ class AgentCore:
                             "content": json.dumps(result),
                         }
                     )
+                if stopped:
+                    # Don't persist a half-batch: the assistant tool_use turn below
+                    # would name calls whose results we're dropping, leaving an
+                    # orphan tool_use in the session. Break with only whole rounds
+                    # recorded; _STOPPED_MESSAGE becomes the assistant turn (#146).
+                    break
 
             # Append tool exchange to session
             assistant_msg = self.llm.assistant_message(response)
@@ -2090,11 +2172,14 @@ class AgentCore:
                 tools=cast(Any, tools),
             )
 
-        final_text = response.text
-        if response.truncated and not final_text:
-            final_text = _TRUNCATION_GIVEUP_MESSAGE
-        elif response.tool_calls and not final_text:
-            final_text = _LOOP_ABORT_MESSAGE
+        if stopped:
+            final_text = _STOPPED_MESSAGE
+        else:
+            final_text = response.text
+            if response.truncated and not final_text:
+                final_text = _TRUNCATION_GIVEUP_MESSAGE
+            elif response.tool_calls and not final_text:
+                final_text = _LOOP_ABORT_MESSAGE
 
         # Append the final assistant response to the session. Skip an empty final
         # (a react-only turn sends nothing): the reaction is already recorded as the

--- a/humux/tests/test_stop_turn.py
+++ b/humux/tests/test_stop_turn.py
@@ -1,0 +1,102 @@
+"""/stop command + Stop-button turn abort (#146).
+
+A running turn holds the per-chat lock, so the abort signal reaches it out of
+band via ``_active_turns`` (set by ``request_stop``); the tool loop checks the
+flag between rounds and bails with ``_STOPPED_MESSAGE`` instead of running the
+rest of the turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core.agent import _STOPPED_MESSAGE
+from core.config import Config
+from core.llm import LLMResponse, LLMToolCall
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from core.agent import AgentCore
+
+    cfg = Config()
+    cfg.agent.llm_provider = "deepseek"
+    cfg.agent.model = "deepseek-v4-flash"
+    cfg.memory.embedding.enabled = False
+    cfg.task_reflection.enabled = False
+    cfg.goal_decomposition.enabled = False
+    return AgentCore(cfg)
+
+
+class _LoopingLLM:
+    """Always wants another tool call — a turn that never ends on its own."""
+
+    provider = "deepseek"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate(self, **_kw) -> LLMResponse:
+        self.calls += 1
+        return LLMResponse(
+            text="",
+            tool_calls=[LLMToolCall(id=f"c{self.calls}", name="web_search", arguments={"q": "x"})],
+        )
+
+    def assistant_message(self, response: LLMResponse) -> dict:
+        return {"role": "assistant", "content": response.text}
+
+    def tool_result_messages(self, results: list[dict]) -> list[dict]:
+        return [{"role": "user", "content": results}]
+
+
+def test_request_stop_idle_vs_active(agent) -> None:
+    key = ("telegram", "u", "55")
+    assert agent.request_stop(*key) is False  # nothing running
+    agent._active_turns_map()[key] = asyncio.Event()
+    assert agent.request_stop(*key) is True  # active turn → flagged
+    assert agent._active_turns_map()[key].is_set()
+
+
+@pytest.mark.asyncio
+async def test_stop_command_idle_is_noop(agent) -> None:
+    resp = await agent.process("/stop", "telegram", "u", chat_id="55")
+    assert "Nothing to stop" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_stop_command_aborts_running_turn(agent) -> None:
+    agent.llm = _LoopingLLM()
+
+    async def fake_tool(call, channel, user_id, request_state):
+        await asyncio.sleep(0.01)  # pace rounds so /stop lands well before the cap
+        return {"ok": True}
+
+    agent._execute_tool = fake_tool
+
+    async def run_turn():
+        return await agent.process("do a lot", "telegram", "u", chat_id="55", message_id=1)
+
+    turn = asyncio.create_task(run_turn())
+    # Wait for the turn to register its abort Event (it does so before the tool loop).
+    for _ in range(200):
+        await asyncio.sleep(0.005)
+        if ("telegram", "u", "55") in agent._active_turns_map():
+            break
+    else:
+        turn.cancel()
+        pytest.fail("turn never registered an abort Event")
+
+    stop = await agent.process("/stop", "telegram", "u", chat_id="55")
+    assert stop.text == ""  # the aborting turn delivers the notice, not /stop
+
+    resp = await asyncio.wait_for(turn, timeout=2)
+    assert resp.text == _STOPPED_MESSAGE
+    # The loop broke instead of spinning to the round cap.
+    assert agent.llm.calls < 50
+    # History records the stop so the next turn knows it was interrupted.
+    msgs = await agent.history.get_messages("telegram", "u", "55")
+    assert msgs[-1]["role"] == "assistant" and msgs[-1]["content"] == _STOPPED_MESSAGE


### PR DESCRIPTION
Closes #146.

## Problem
Once a turn started, the user could only deny tool prompts one at a time or wait the whole turn out — and in YOLO mode, not even that. Wasted tokens and a frustrating "deny one by one" experience.

## What this adds
- **⛔ Stop button** on every approval prompt (its own keyboard row, since Telegram gives buttons no colour to signal it aborts the *whole* turn vs. one action). Pressing it resolves the pending prompt and flags the turn to abort.
- **`/stop` command** — aborts the running turn for that chat. Works mid-turn and in YOLO mode where there are no prompts. Handled **before** the per-chat lock: a running turn holds that lock, so a queued `/stop` would otherwise wait for the very turn it means to cancel. No-op with a brief note when nothing is running.
- **Per-chat abort registry** (`request_stop` / `_active_turns`) reachable out of band from the button callback and `/stop`. Both tool loops (injection + session) check the flag between rounds and between calls in a batch, then end the turn with a notice that is stored as the assistant turn — so the next message sees it was interrupted. A half-batch is never persisted (no orphan `tool_use` in the session).
- `/stop` registered in the Telegram command menu (`setMyCommands`) and the control-command set.

## Scope & behaviour
- Stop is **scoped per chat** (keyed by the conversation triple) — a stop in one chat never touches another.
- Takes effect at the next tool round, so an action already in flight finishes gracefully first; what ran up to that point stands.
- A pure text turn (no tool loop) has nothing to abort — `/stop` there is a harmless no-op.

## Acceptance criteria
- [x] Approval prompts show four buttons: Approve · Deny · Always allow · Stop
- [x] Stop aborts the entire current turn (after any in-flight action finishes)
- [x] `/stop` works between turns and mid-turn, including YOLO mode
- [x] Turn history records a notice so the agent knows it was stopped
- [x] Stop is scoped per-chat
- [x] `/stop` with no active turn is a no-op with a brief message

## Tests / docs
- `tests/test_stop_turn.py`: idle no-op, active abort (loop breaks + notice stored), and the registry. Full suite: 915 passed.
- Docs updated: `permissions.mdx` (button set + a "Stopping a turn" section) and `channels.mdx` (command menu + stop note).