### PR TITLE
Remove LLM SysPrompt sub-tab & History injection-mode selector (#137, #138)

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -41,8 +41,6 @@ from core.goal_decomposition import classify_complexity, decompose_goal
 from core.llm import LLMClient, get_sent_payload
 from core.log_streams import current_stream, current_subagent
 from core.prompt_builder import (
-    DEFAULT_HISTORY_HANDLING_BLOCK,
-    DEFAULT_TOOL_USAGE_BLOCK,
     build_prompt_sections,
 )
 from core.tools import gh_token_secret_name, tool_env
@@ -1310,12 +1308,6 @@ def create_admin_app(
         vision_enabled = vision_enabled if vision_enabled is not None else "false"
         vision_provider = await config_store.get("vision.provider") or "anthropic"
         vision_model = await config_store.get("vision.model") or "claude-haiku-4-5"
-        prompt_tool_usage_override = await config_store.get("prompt.tool_usage_override") or ""
-        prompt_history_override = await config_store.get("prompt.history_handling_override") or ""
-        prompt_capture_enabled = await config_store.get("admin.capture_prompts")
-        prompt_capture_enabled = False
-        if prompt_capture_enabled is not None:
-            prompt_capture_enabled = str(prompt_capture_enabled).lower() == "true"
         return _render_partial(
             "partials/llm.html",
             provider=provider,
@@ -1368,11 +1360,6 @@ def create_admin_app(
             vision_enabled=vision_enabled,
             vision_provider=vision_provider,
             vision_model=vision_model,
-            prompt_tool_usage_override=prompt_tool_usage_override,
-            prompt_history_override=prompt_history_override,
-            default_tool_usage=DEFAULT_TOOL_USAGE_BLOCK,
-            default_history_handling=DEFAULT_HISTORY_HANDLING_BLOCK,
-            prompt_capture_enabled=prompt_capture_enabled,
             # History sub-tab (included into the LLM tab) needs its config too.
             **(await _history_ctx()),
         )
@@ -1752,8 +1739,6 @@ def create_admin_app(
         tab (included there) and the standalone /partials/history route."""
         c_enabled = await config_store.get("compaction.enabled")
         return {
-            "mode": await config_store.get("history.mode") or "injection",
-            "max_turns": await config_store.get("history.max_turns") or "10",
             "compaction_enabled": c_enabled if c_enabled is not None else "true",
             "compaction_threshold_type": await config_store.get("compaction.threshold_type")
             or "percent",

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -112,21 +112,22 @@
     }
     window.previewVoice = previewVoice;
 
-    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, openrouterKey, openrouterBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, promptToolUsageOverride, promptHistoryOverride, defaultToolUsage, defaultHistoryHandling, promptCaptureEnabled, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens, temperature, trMaxReflections) {
+    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, openrouterKey, openrouterBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens, temperature, trMaxReflections) {
       const currentProvider = provider || 'anthropic';
       return {
-        // Sub-tab within the LLM tab (issue #114): sysprompt | inference | providers.
+        // Sub-tab within the LLM tab (issue #114): inference | providers | history.
         // Persisted so switching away and back, or a partial reload after a
-        // provider save, lands on the same sub-tab.
+        // provider save, lands on the same sub-tab. (SysPrompt sub-tab removed
+        // in #137 — superseded by the Inspect tab.)
         section: (() => {
-          const allowed = ['sysprompt', 'inference', 'providers', 'history'];
+          const allowed = ['inference', 'providers', 'history'];
           try {
             const q = new URLSearchParams(window.location.search).get('llmsub');
             if (allowed.includes(q)) return q;
             const ls = localStorage.getItem('llm_section');
             if (allowed.includes(ls)) return ls;
           } catch (e) {}
-          return 'sysprompt';
+          return 'inference';
         })(),
         setSection(s) {
           this.section = s;
@@ -181,24 +182,6 @@
         trProvider: trProvider || 'anthropic',
         trModel: trModel || 'claude-haiku-4-5',
         trMaxReflections: trMaxReflections || '12',
-        promptToolUsageOverride: promptToolUsageOverride || '',
-        promptHistoryOverride: promptHistoryOverride || '',
-        defaultToolUsage: defaultToolUsage || '',
-        defaultHistoryHandling: defaultHistoryHandling || '',
-        promptCaptureEnabled: promptCaptureEnabled === true || promptCaptureEnabled === 'true',
-        promptPreviewMessage: '',
-        includePreviewMemories: true,
-        includePreviewReflections: true,
-        promptPreviewResult: '',
-        promptPreviewOk: false,
-        promptPreviewLoading: false,
-        promptPreviewRaw: '',
-        promptPreviewSections: null,
-        promptPreviewMeta: null,
-        recentPrompts: [],
-        recentPromptsLoading: false,
-        promptSaveResult: '',
-        promptSaveOk: false,
         memoryResult: '',
         memoryResultOk: false,
         gdResult: '',
@@ -569,88 +552,6 @@
             .then(() => { if (window.showToast) { window.showToast('Copied'); } })
             .catch(() => { if (window.showToast) { window.showToast('Copy failed', false); } });
         },
-        previewSystemPrompt() {
-          this.promptPreviewLoading = true;
-          this.promptPreviewResult = '';
-          fetch('/debug/system-prompt/preview', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
-            },
-            body: JSON.stringify({
-              message: this.promptPreviewMessage,
-              include_memories: this.includePreviewMemories,
-              include_reflections: this.includePreviewReflections
-            })
-          })
-            .then(r => { this.promptPreviewOk = r.ok; return r.json(); })
-            .then(d => {
-              this.promptPreviewRaw = d.full_prompt || '';
-              this.promptPreviewSections = d.sections || null;
-              this.promptPreviewMeta = {
-                generated_at: d.generated_at,
-                history_mode: d.history_mode,
-                token_estimate: d.token_estimate,
-                flags: d.flags || {}
-              };
-              this.promptPreviewResult = this.promptPreviewOk ? 'Prompt preview generated' : (d.detail || 'Failed to preview prompt');
-            })
-            .catch(e => {
-              this.promptPreviewOk = false;
-              this.promptPreviewResult = e.message || 'Failed to preview prompt';
-            })
-            .finally(() => {
-              this.promptPreviewLoading = false;
-            });
-        },
-        fetchRecentPrompts() {
-          this.recentPromptsLoading = true;
-          fetch('/debug/system-prompt/recent', {
-            headers: {
-              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
-            }
-          })
-            .then(r => r.json())
-            .then(d => {
-              this.recentPrompts = Array.isArray(d.items) ? d.items : [];
-            })
-            .catch(() => {
-              this.recentPrompts = [];
-            })
-            .finally(() => {
-              this.recentPromptsLoading = false;
-            });
-        },
-        resetPromptOverrides() {
-          this.promptToolUsageOverride = '';
-          this.promptHistoryOverride = '';
-          this.promptSaveResult = 'Overrides reset locally';
-          this.promptSaveOk = true;
-        },
-        savePromptConfig() {
-          fetch('/config', {
-            method: 'PATCH',
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
-            },
-            body: JSON.stringify({values: {
-              'prompt.tool_usage_override': this.promptToolUsageOverride,
-              'prompt.history_handling_override': this.promptHistoryOverride,
-              'admin.capture_prompts': this.promptCaptureEnabled ? 'true' : 'false'
-            }})
-          })
-            .then(r => { this.promptSaveOk = r.ok; return r.json(); })
-            .then(d => {
-              this.promptSaveResult = this.promptSaveOk ? 'Prompt settings saved' : (d.detail || 'Error');
-              if (this.promptSaveOk && window.showToast) { window.showToast('Prompt settings saved'); }
-            })
-            .catch(e => {
-              this.promptSaveOk = false;
-              this.promptSaveResult = e.message || 'Error';
-            });
-        }
       };
     }
     window.llmTab = llmTab;

--- a/humux/api/templates/partials/history.html
+++ b/humux/api/templates/partials/history.html
@@ -1,83 +1,16 @@
-{# History tab partial #}
+{# History tab partial.
+   Injection-mode selector removed (#138): the agent always runs in sticky
+   session mode now, so this tab hosts only compaction settings. #}
 <div class="space-y-6" x-data="{
-  mode: {{ mode|default('injection', true)|tojson|forceescape }},
-  maxTurns: {{ max_turns|default('10', true)|tojson|forceescape }},
   compactionEnabled: {{ compaction_enabled|default('true', true)|tojson|forceescape }},
   thresholdType: {{ compaction_threshold_type|default('percent', true)|tojson|forceescape }},
   thresholdPercent: {{ compaction_threshold_percent|default('80', true)|tojson|forceescape }},
   thresholdTokens: {{ compaction_threshold_tokens|default('150000', true)|tojson|forceescape }},
   contextWindow: {{ compaction_context_window|default('200000', true)|tojson|forceescape }},
   keepRecentTurns: {{ compaction_keep_recent_turns|default('4', true)|tojson|forceescape }},
-  result: '',
-  resultOk: false,
   cResult: '',
   cResultOk: false
 }">
-  <div class="card">
-    <h2 class="text-base mb-1">Conversation History</h2>
-    <p class="text-muted text-xs mb-4">Configure how conversation history is stored and how much context the agent sees when processing messages.</p>
-
-    <div class="space-y-3">
-      <div>
-        <label class="label">Mode</label>
-        <div class="flex gap-4 mt-1">
-          <label class="flex items-center gap-2 cursor-pointer">
-            <input type="radio" name="history_mode" value="injection"
-                   x-model="mode" class="accent-primary">
-            <span class="text-sm">History injection</span>
-          </label>
-          <label class="flex items-center gap-2 cursor-pointer">
-            <input type="radio" name="history_mode" value="session"
-                   x-model="mode" class="accent-primary">
-            <span class="text-sm">Sticky session</span>
-          </label>
-        </div>
-        <p class="text-muted text-xs mt-1" x-show="mode === 'injection'">Recent conversation turns are replayed as context with each request. Older messages fall off after the configured limit.</p>
-        <p class="text-muted text-xs mt-1" x-show="mode === 'session'">A persistent session is maintained per channel. The full conversation is sent to the LLM, preserving tool call history and enabling prompt caching. Reset via the channel's clear command.</p>
-      </div>
-
-      <div x-show="mode === 'injection'" x-transition>
-        <label class="label">Max turns</label>
-        <input type="number" class="input-sm" style="max-width:120px"
-               x-model="maxTurns" min="1" max="50">
-        <p class="text-muted text-xs mt-1">Number of recent user-assistant pairs included as context. Lower values reduce noise from old conversations; higher values give more continuity.</p>
-        {% include "partials/restart_note.html" %}
-      </div>
-    </div>
-
-    <div class="flex items-center gap-2 mt-4">
-      <button class="btn-primary btn-sm"
-              @click="
-                const vals = {
-                  'history.mode': mode,
-                  'history.max_turns': String(maxTurns)
-                };
-                fetch('/config', {
-                  method: 'PATCH',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
-                  },
-                  body: JSON.stringify({values: vals})
-                })
-                .then(r => { resultOk = r.ok; return r.json(); })
-                .then(d => {
-                  result = resultOk ? 'History settings saved' : (d.detail || 'Error');
-                  if (resultOk && window.showToast) { window.showToast('History settings saved'); }
-                  if (resultOk && d.restart_required && window.notifyRestartRequired) { notifyRestartRequired(); }
-                })
-                .catch(e => { resultOk = false; result = e.message; })
-              ">
-        Save
-      </button>
-    </div>
-
-    <template x-if="result">
-      <div :class="resultOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="result"></div>
-    </template>
-  </div>
-
-  {# Compaction — only relevant in session mode #}
   <div class="card">
     <div class="flex items-center justify-between gap-3 mb-1">
       <h2 class="text-base">Context compaction</h2>
@@ -88,10 +21,10 @@
       </div>
     </div>
     <p class="text-muted text-xs mb-4">
-      In <strong>session</strong> mode, when the conversation approaches the model's
-      context window, the oldest turns are summarized by a small model (configured in
-      the <strong>LLM</strong> tab) while recent turns are kept verbatim. The user is
-      notified with a system message when this happens. Has no effect in injection mode.
+      When the conversation approaches the model's context window, the oldest turns
+      are summarized by a small model (configured in the <strong>LLM</strong> tab)
+      while recent turns are kept verbatim. The user is notified with a system
+      message when this happens.
     </p>
 
     <div class="space-y-3" :class="(compactionEnabled === 'true' || compactionEnabled === true) ? '' : 'opacity-50'">

--- a/humux/api/templates/partials/llm.html
+++ b/humux/api/templates/partials/llm.html
@@ -50,11 +50,6 @@
   {{ tr_enabled|default('true', true)|tojson|forceescape }},
   {{ tr_provider|default('deepseek', true)|tojson|forceescape }},
   {{ tr_model|default('deepseek-v4-flash', true)|tojson|forceescape }},
-  {{ prompt_tool_usage_override|default('', true)|tojson|forceescape }},
-  {{ prompt_history_override|default('', true)|tojson|forceescape }},
-  {{ default_tool_usage|default('', true)|tojson|forceescape }},
-  {{ default_history_handling|default('', true)|tojson|forceescape }},
-  {{ prompt_capture_enabled|default(false, true)|tojson|forceescape }},
   {{ compaction_provider|default('deepseek', true)|tojson|forceescape }},
   {{ compaction_model|default('deepseek-v4-flash', true)|tojson|forceescape }},
   {{ thinking_level|default('', true)|tojson|forceescape }},
@@ -77,138 +72,16 @@
   {{ temperature|default('0.5', true)|tojson|forceescape }},
   {{ tr_max_reflections|default('12', true)|tojson|forceescape }}
 )">
-  {# Sub-tabs (issue #114): split the crowded LLM settings into three views. #}
+  {# Sub-tabs (issue #114): split the crowded LLM settings into views.
+     SysPrompt sub-tab removed (#137) — the Inspect tab shows the full
+     assembled system prompt directly. #}
   <div class="flex border-b border-border mb-4 overflow-x-auto">
-    <button type="button" class="tab-link" :class="section === 'sysprompt' && 'tab-link-active'" @click="setSection('sysprompt')">SysPrompt</button>
     <button type="button" class="tab-link" :class="section === 'inference' && 'tab-link-active'" @click="setSection('inference')">Inference</button>
     <button type="button" class="tab-link" :class="section === 'providers' && 'tab-link-active'" @click="setSection('providers')">Providers</button>
     <button type="button" class="tab-link" :class="section === 'history' && 'tab-link-active'" @click="setSection('history')">History</button>
   </div>
 
-  <div class="space-y-6" x-show="section === 'sysprompt'">
-  <div class="card">
-    <h2 class="text-base mb-1">System Prompt Controls</h2>
-    <p class="text-muted text-xs mb-4">Preview the full assembled system prompt, edit override blocks, compare against defaults, and optionally capture recent runtime prompts. Debugging a live run? The <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'inspect')">Inspect</button> tab shows the exact last-sent payload per chat.</p>
-
-    <form class="space-y-4" @submit.prevent>
-      <div class="space-y-2">
-        <label class="label">Tool usage override</label>
-        <textarea class="textarea"
-                  style="min-height:200px; font-size:0.8rem; line-height:1.5; tab-size:2"
-                  x-model="promptToolUsageOverride"
-                  placeholder="Leave empty to use built-in defaults"></textarea>
-        <p class="text-muted text-xs">Effective value: override if non-empty, otherwise default block.</p>
-      </div>
-
-      <div class="space-y-2">
-        <label class="label">History handling override</label>
-        <textarea class="textarea"
-                  style="min-height:140px; font-size:0.8rem; line-height:1.5; tab-size:2"
-                  x-model="promptHistoryOverride"
-                  placeholder="Leave empty to use built-in defaults"></textarea>
-      </div>
-
-      <div class="space-y-2">
-        <label class="label">Default reference: tool usage</label>
-        <textarea class="textarea" style="min-height:160px; font-size:0.75rem" x-model="defaultToolUsage" readonly></textarea>
-      </div>
-
-      <div class="space-y-2">
-        <label class="label">Default reference: history handling</label>
-        <textarea class="textarea" style="min-height:100px; font-size:0.75rem" x-model="defaultHistoryHandling" readonly></textarea>
-      </div>
-
-      <div class="flex items-center gap-2">
-        <label class="label mb-0">Capture recent runtime prompts</label>
-        <input type="checkbox" x-model="promptCaptureEnabled" class="rounded border-border">
-      </div>
-
-      <div class="flex items-center gap-2">
-        <button class="btn-primary btn-sm" type="button" @click="savePromptConfig()">Save prompt settings</button>
-        <button class="btn btn-sm" type="button" @click="resetPromptOverrides()">Reset local overrides</button>
-      </div>
-      <template x-if="promptSaveResult">
-        <div :class="promptSaveOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="promptSaveResult"></div>
-      </template>
-    </form>
-
-    <hr class="border-border my-4">
-
-    <form class="space-y-3" @submit.prevent="previewSystemPrompt()">
-      <div>
-        <label class="label">Preview with test user message (optional)</label>
-        <textarea class="textarea" style="min-height:90px" x-model="promptPreviewMessage" placeholder="Example: Plan my week and draft two emails"></textarea>
-      </div>
-      <div class="flex items-center gap-4">
-        <label class="inline-flex items-center gap-2 text-xs text-muted">
-          <input type="checkbox" x-model="includePreviewMemories" class="rounded border-border">
-          Include memories
-        </label>
-        <label class="inline-flex items-center gap-2 text-xs text-muted">
-          <input type="checkbox" x-model="includePreviewReflections" class="rounded border-border">
-          Include task reflections
-        </label>
-      </div>
-      <div class="flex items-center gap-2">
-        <button class="btn-primary btn-sm" type="submit" :disabled="promptPreviewLoading">
-          <span x-show="!promptPreviewLoading">Generate preview</span>
-          <span x-show="promptPreviewLoading">Generating...</span>
-        </button>
-        <button class="btn btn-sm" type="button" @click="copyText(promptPreviewRaw)" :disabled="!promptPreviewRaw">Copy full prompt</button>
-      </div>
-    </form>
-
-    <template x-if="promptPreviewResult">
-      <div :class="promptPreviewOk ? 'alert-success' : 'alert-error'" class="mt-3" x-text="promptPreviewResult"></div>
-    </template>
-
-    <div class="mt-3" x-show="promptPreviewMeta">
-      <p class="text-muted text-xs" x-text="'Generated: ' + (promptPreviewMeta?.generated_at || '-') + ' · mode=' + (promptPreviewMeta?.history_mode || '-') + ' · ~tokens=' + (promptPreviewMeta?.token_estimate || 0)"></p>
-    </div>
-
-    <div class="mt-3" x-show="promptPreviewSections">
-      <h3 class="text-sm mb-2">Section view</h3>
-      <template x-for="entry in Object.entries(promptPreviewSections || {})" :key="entry[0]">
-        <details class="mb-2 rounded border border-border p-2">
-          <summary class="text-xs" x-text="entry[0]"></summary>
-          <pre class="mt-2 text-xs" style="white-space: pre-wrap" x-text="entry[1]"></pre>
-        </details>
-      </template>
-    </div>
-
-    <div class="mt-3" x-show="promptPreviewRaw">
-      <h3 class="text-sm mb-2">Raw assembled prompt</h3>
-      <pre class="text-xs" style="white-space: pre-wrap" x-text="promptPreviewRaw"></pre>
-    </div>
-
-    <hr class="border-border my-4">
-
-    <div>
-      <h3 class="text-sm mb-2">Recent runtime prompts</h3>
-      <div class="flex items-center gap-2 mb-2">
-        <button class="btn btn-sm" type="button" @click="fetchRecentPrompts()">Refresh captured prompts</button>
-        <span class="text-muted text-xs">Only available when capture is enabled and the agent is running.</span>
-      </div>
-      <template x-if="recentPromptsLoading">
-        <div class="text-muted text-xs">Loading...</div>
-      </template>
-      <template x-if="!recentPromptsLoading && (!recentPrompts || recentPrompts.length === 0)">
-        <div class="text-muted text-xs">No captured prompts yet.</div>
-      </template>
-      <template x-for="(item, idx) in (recentPrompts || [])" :key="idx">
-        <details class="mb-2 rounded border border-border p-2">
-          <summary class="text-xs" x-text="(item.captured_at || '-') + ' · ' + (item.channel || '-') + ' · user=' + (item.user_hash || '-')"></summary>
-          <div class="flex items-center gap-2 mt-2">
-            <button class="btn btn-sm" type="button" @click="copyText(item.prompt || '')">Copy</button>
-          </div>
-          <pre class="mt-2 text-xs" style="white-space: pre-wrap" x-text="item.prompt || ''"></pre>
-        </details>
-      </template>
-    </div>
-  </div>
-  </div>{# /sysprompt #}
-
-  <div class="space-y-6" x-show="section === 'inference'" style="display:none">
+  <div class="space-y-6" x-show="section === 'inference'">
   <div class="card">
     <h2 class="text-base mb-1">Active Inference Provider</h2>
     <p class="text-muted text-xs mb-4">Select the provider used for agent inference after testing its connection.</p>

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -215,8 +215,10 @@ class AdminConfig(BaseModel):
 
 class HistoryConfig(BaseModel):
     db_path: str = "data/history.db"
-    max_turns: int = 10  # number of user-assistant pairs to include
-    mode: str = "injection"  # "injection" (windowed history) or "session" (sticky per channel)
+    max_turns: int = 10  # number of user-assistant pairs to include (injection mode only)
+    # Sticky per-channel session is the only user-facing mode now (#138); the
+    # injection code path is kept for back-compat but no longer selectable in the UI.
+    mode: str = "session"  # "injection" (windowed history) or "session" (sticky per channel)
 
 
 class EmbeddingConfig(BaseModel):

--- a/humux/tests/test_admin_ui.py
+++ b/humux/tests/test_admin_ui.py
@@ -283,17 +283,19 @@ class TestVoicePreview:
         assert "workspace.directory" in resp.text
 
     def test_llm_partial_has_subtabs(self):
-        # The LLM tab is split into SysPrompt / Inference / Providers / History
-        # sub-tabs (#114 + History folded in), with a link to the Inspect tab.
+        # The LLM tab is split into Inference / Providers / History sub-tabs
+        # (#114 + History folded in). The SysPrompt sub-tab was removed (#137),
+        # superseded by the Inspect tab.
         client = _client(setup_complete=True)
         resp = client.get("/partials/llm", headers=AUTH)
         assert resp.status_code == 200
-        for sec in ("sysprompt", "inference", "providers", "history"):
+        for sec in ("inference", "providers", "history"):
             assert f"setSection('{sec}')" in resp.text
             assert f"section === '{sec}'" in resp.text
-        assert "$dispatch('switch-tab', 'inspect')" in resp.text  # SysPrompt -> Inspect
+        assert "setSection('sysprompt')" not in resp.text
+        assert "System Prompt Controls" not in resp.text
         # History sub-tab content is included, not a separate top-level tab.
-        assert "Conversation History" in resp.text
+        assert "Context compaction" in resp.text
 
     def test_llm_partial_has_vision_fallback(self):
         client = _client(setup_complete=True)
@@ -411,9 +413,10 @@ class TestVoicePreview:
         assert "text/html" in resp.headers["content-type"]
 
     def test_history_partial(self):
+        # #138: the injection-mode selector is gone; the tab hosts only
+        # compaction settings now.
         store = _ConfigStoreStub(setup_complete=True)
-        store._data["history.mode"] = "session"
-        store._data["history.max_turns"] = "15"
+        store._data["compaction.threshold_percent"] = "77"
         agent_state = AgentState(agent=cast(Any, _AgentStub()))
         app, _ = create_admin_app(agent_state, cast(ConfigStore, store))
         client = TestClient(app, follow_redirects=False)
@@ -421,15 +424,17 @@ class TestVoicePreview:
         resp = client.get("/partials/history", headers=AUTH)
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
-        assert "15" in resp.text
-        assert "session" in resp.text
+        assert "Context compaction" in resp.text
+        assert "77" in resp.text
+        # The removed mode selector must not resurface.
+        assert 'name="history_mode"' not in resp.text
 
     def test_history_partial_defaults(self):
         client = _client(setup_complete=True)
         resp = client.get("/partials/history", headers=AUTH)
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
-        assert "Conversation History" in resp.text
+        assert "Context compaction" in resp.text
 
     def test_partials_require_auth(self):
         client = _client(setup_complete=True)

--- a/humux/tests/test_reactions.py
+++ b/humux/tests/test_reactions.py
@@ -71,6 +71,7 @@ def agent(tmp_path, monkeypatch):
     cfg.agent.llm_provider = "deepseek"
     cfg.agent.model = "deepseek-v4-flash"
     cfg.memory.embedding.enabled = False
+    cfg.history.mode = "injection"  # asserts on the windowed get_messages store
     return AgentCore(cfg)
 
 

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -142,6 +142,7 @@ def agent(tmp_path, monkeypatch):
     cfg.agent.llm_provider = "deepseek"
     cfg.agent.model = "deepseek-v4-flash"
     cfg.memory.embedding.enabled = False  # keep retrieval lexical (no model load)
+    cfg.history.mode = "injection"  # exercises the windowed add_turn/get_messages store
     return AgentCore(cfg)
 
 

--- a/www/features.html
+++ b/www/features.html
@@ -426,7 +426,7 @@
           </div>
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Provider sub-tabs</h3>
-            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Admin UI splits LLM config into SysPrompt, Inference, and Providers sub-tabs. URL-based navigation for copy-pasteable links.</p>
+            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Admin UI splits LLM config into Inference, Providers, and History sub-tabs. URL-based navigation for copy-pasteable links.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #137, closes #138.

Two related admin-UI cleanups.

## #137 — Remove LLM > SysPrompt sub-tab
The **Inspect** tab already shows the exact assembled system prompt per chat, so the SysPrompt preview/override editor is redundant.

- Removed the SysPrompt sub-tab button + its whole section from `partials/llm.html`.
- Default LLM sub-tab is now **Inference**; `sysprompt` dropped from the allowed set.
- Removed the now-dead Alpine state/methods (`previewSystemPrompt`, `fetchRecentPrompts`, `savePromptConfig`, `resetPromptOverrides`, prompt-preview state) and the template plumbing that fed only that section.
- **Backend untouched otherwise:** the `prompt.tool_usage_override` / `prompt.history_handling_override` / `admin.capture_prompts` config still applies at runtime (`prompt_builder`, `agent`). Only the editor UI is gone. The `/debug/system-prompt/preview` + `/recent` endpoints stay (still tested).

## #138 — Remove History injection-mode selector
Only sticky **session** mode is actually useful (compaction depends on it), so the injection/session selector was pointless.

- Removed the mode selector + max-turns panel from `partials/history.html`; the tab now hosts **only compaction settings**.
- **Default `history.mode` flipped `injection` → `session`** so compaction is meaningful out of the box. ⚠️ *This is a runtime behaviour change* — see note below.
- The injection code path is retained for back-compat; two unit tests that assert on the windowed history store now pin `injection` explicitly.

## ⚠️ Please eyeball: the default-mode flip
The shipped default was previously `injection` (no `history:` block in `config.yml.example`). Keeping the compaction settings (session-only) implies session is the intended surviving mode, so I flipped the default. Existing deployments that explicitly saved `injection` keep it but can no longer switch via the UI. If you'd rather **not** change the runtime default and only hide the selector, say so and I'll revert the `config.py` one-liner.

## Verification
- `ruff check` + `ruff format` clean.
- Full suite: **916 passed**.
- `/partials/llm` and `/partials/history` render green (200) with the expected content and no SysPrompt / mode-selector leftovers.