### PR TITLE
feat: steerable agent — redirect a running turn mid-flight (#145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ No cloud dependency. No data leaving your server. One `docker compose up` and yo
 - **WhatsApp** — read and send via [wacli](https://github.com/openclaw/wacli) CLI, link once and it stays authenticated
 - **Multi-agent groups** — several agent-bots share one Telegram group, each replies only when addressed, never loops with other bots
 - **Reply decision** — in group chats the agent decides per message whether to reply, with a hard rate cap that guarantees runaway loops end
+- **Steerable mid-turn** — redirect a long-running turn by just sending a follow-up; it's folded in before the agent's next step (reacts 👀 to confirm) instead of making you wait for it to finish on the wrong track
 - **Per-chat settings** — gate per Telegram chat who can trigger an agent and who may DM it
 
 </details>

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -96,6 +96,15 @@ A few details worth knowing:
   the whole running turn (not just one action). `/stop` works mid-turn and in YOLO mode
   where there are no prompts; it's scoped to that chat and is a no-op when nothing is
   running. See [Permissions](/docs/permissions#stopping-a-turn).
+- **Steering mid-turn** — you don't have to wait for a long turn to finish to redirect it.
+  Send a normal follow-up while the agent is working (in a group, address it — reply to the
+  bot or `@mention` it) and it's folded into the running turn before its next step, so the
+  agent adjusts course instead of finishing on the wrong track. The bot reacts 👀 on your
+  message to show it was picked up. It's scoped to that chat — a steer never leaks into
+  another conversation. One limit: while the agent is parked on an approval prompt it only
+  reads a steer once that resolves; steering lands between tool steps, not during a wait.
+  (If the turn happens to end before your message lands, it just runs as the next turn — so
+  nothing is ever lost.)
 - **YOLO mode** — `/yolo-on` lets a bot act without asking for approval; `/yolo-off`
   restores prompting. Only the short hard-blocked (`NEVER`) list is still refused (e.g.
   direct DB drops/alters) — **everything else, including filesystem and network commands,

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -1222,15 +1222,34 @@ class AgentCore:
         return m
 
     def _drain_steer(self, channel: str, user_id: str, chat_id: str) -> list[dict]:
-        """Pop and return this chat's pending steer entries, marking each consumed.
+        """Pop and return this chat's pending steer entries (does NOT mark consumed).
 
-        ``consumed`` is read by the depositing message's own (lock-blocked) task:
-        once the running turn has folded the follow-up in, that task returns silently
-        instead of re-running it as a duplicate turn (#145)."""
-        entries = self._steer_map().pop((channel, user_id, chat_id), [])
+        Draining is split from marking so ``consumed`` flips only once the steer has
+        actually reached the model — see ``_commit_steer``. If the ``generate()`` that
+        was to carry the steer raises, the entries stay unconsumed and their depositing
+        tasks run them as their own turns instead of being silently dropped (#145)."""
+        return self._steer_map().pop((channel, user_id, chat_id), [])
+
+    def _steer_message(self, entries: list[dict]) -> dict:
+        """Build one labelled user message from drained steer entries (#145). ponytail:
+        text only — a steer's attachments are dropped; if it wasn't consumed its own
+        turn still carries them, and mid-turn image steers are rare enough to defer."""
+        joined = "\n\n".join(e["text"] for e in entries)
+        text = (
+            "[The user sent a follow-up while you were working:]\n"
+            f"<steering_message>\n{joined}\n</steering_message>\n"
+            "Continue your current task taking this into account."
+        )
+        return {"role": "user", "content": text}
+
+    async def _commit_steer(self, channel: str, chat_id: str, entries: list[dict]) -> None:
+        """Confirm steers the model has now received: mark each consumed (so its
+        depositing task returns silently instead of re-running it) and ack 👀. Called
+        only AFTER the carrying ``generate()`` returns, so a failed call leaves the
+        steer unconsumed and it falls through to run as its own turn (#145)."""
         for e in entries:
             e["consumed"] = True
-        return entries
+            await self._ack_steer(channel, chat_id, e.get("message_id"))
 
     def _discard_steer(self, key: tuple, entry: dict) -> None:
         """Remove one still-pending entry (turn ended before it was drained), so it
@@ -1255,24 +1274,6 @@ class AgentCore:
             await react(chat_id, int(message_id), "👀")
         except Exception as exc:  # cosmetic — never break the turn over an ack
             log.debug("Steer ack reaction failed: %s", exc)
-
-    async def _pop_steer_message(self, channel: str, user_id: str, chat_id: str) -> dict | None:
-        """Drain pending steers for this chat into one labelled user message, acking
-        each with 👀. Returns None when nothing is pending (#145). ponytail: text
-        only — a steer's attachments are dropped; if it wasn't consumed its own turn
-        still carries them, and mid-turn image steers are rare enough to defer."""
-        entries = self._drain_steer(channel, user_id, chat_id)
-        if not entries:
-            return None
-        for e in entries:
-            await self._ack_steer(channel, chat_id, e.get("message_id"))
-        joined = "\n\n".join(e["text"] for e in entries)
-        text = (
-            "[The user sent a follow-up while you were working:]\n"
-            f"<steering_message>\n{joined}\n</steering_message>\n"
-            "Continue your current task taking this into account."
-        )
-        return {"role": "user", "content": text}
 
     def _chat_lock(self, channel: str, user_id: str, chat_id: str) -> asyncio.Lock:
         """The turn lock for one chat key, created on first use.
@@ -2088,9 +2089,11 @@ class AgentCore:
             # Mid-turn steering (#145): fold any follow-up the user sent while we
             # worked into the next call. Appended after the tool_result user turn;
             # generate() merges the consecutive user turns, so alternation holds.
-            steer_msg = await self._pop_steer_message(channel, user_id, chat_id)
-            if steer_msg:
-                messages.append(steer_msg)
+            # Committed (consumed + 👀) only after generate() returns, so a failed
+            # call leaves the steer to run as its own turn rather than vanish.
+            steer = self._drain_steer(channel, user_id, chat_id)
+            if steer:
+                messages.append(self._steer_message(steer))
             response = await self.llm.generate(
                 model=self.config.agent.model,
                 max_tokens=self.config.agent.max_tokens,
@@ -2098,6 +2101,8 @@ class AgentCore:
                 messages=messages,
                 tools=cast(Any, tools),
             )
+            if steer:
+                await self._commit_steer(channel, chat_id, steer)
         if stopped:
             final_text = _STOPPED_MESSAGE
         else:
@@ -2264,8 +2269,12 @@ class AgentCore:
             # Mid-turn steering (#145): fold any follow-up the user sent while we
             # worked into the next call, and persist it so the sticky session keeps a
             # faithful record. generate() merges it with the tool_result user turn.
-            steer_msg = await self._pop_steer_message(channel, user_id, chat_id)
-            if steer_msg:
+            # Committed (consumed + 👀) only after generate() returns; on a failed
+            # call the steer stays unconsumed and runs as its own turn (no double
+            # action — no tool runs between injecting the steer and this generate).
+            steer = self._drain_steer(channel, user_id, chat_id)
+            if steer:
+                steer_msg = self._steer_message(steer)
                 new_messages.append(steer_msg)
                 await self.history.append_session_messages(channel, user_id, [steer_msg], chat_id)
 
@@ -2276,6 +2285,8 @@ class AgentCore:
                 messages=session,
                 tools=cast(Any, tools),
             )
+            if steer:
+                await self._commit_steer(channel, chat_id, steer)
 
         if stopped:
             final_text = _STOPPED_MESSAGE

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -1145,7 +1145,31 @@ class AgentCore:
                 return AgentResponse(text="")
             return AgentResponse(text="Nothing to stop — no turn is running.")
 
+        # Mid-turn steering (#145): an addressed follow-up that arrives while a turn
+        # is already running for this chat is buffered and injected into that turn
+        # between tool rounds — the user redirects without waiting for the whole loop.
+        # Detected BEFORE the lock (the running turn holds it). Control commands
+        # (/new, /yolo…) and the system/scheduler path are never steers. The entry
+        # still falls through to the lock: if the running turn drained it (consumed)
+        # this task returns silently; if not (turn ended first), it runs as its own
+        # turn so a late steer is never lost.
+        key = (channel, user_id, chat_id)
+        steer_entry: dict | None = None
+        if (
+            respond
+            and addressed
+            and channel != "system"
+            and not _control_command(message)
+            and self._active_turns_map().get(key) is not None
+        ):
+            steer_entry = {"text": message, "message_id": message_id, "consumed": False}
+            self._steer_map().setdefault(key, []).append(steer_entry)
+
         async with self._chat_lock(channel, user_id, chat_id):
+            if steer_entry is not None:
+                self._discard_steer(key, steer_entry)
+                if steer_entry["consumed"]:
+                    return AgentResponse(text="")
             return await self._process_impl(
                 message,
                 channel,
@@ -1182,6 +1206,73 @@ class AgentCore:
             return False
         ev.set()
         return True
+
+    def _steer_map(self) -> dict:
+        """Conversation key → list of pending steer entries (#145).
+
+        Lazy like ``_active_turns_map`` so a bare-``__new__`` test instance works
+        too. A follow-up message that arrives mid-turn deposits ``{"text", ...,
+        "consumed"}`` here; the running turn drains it between tool rounds and
+        injects it before the next LLM call. Per conversation key, so a steer from
+        one chat never reaches another. In-memory, resets on restart.
+        """
+        m = getattr(self, "_steer_buffers", None)
+        if m is None:
+            m = self._steer_buffers = {}
+        return m
+
+    def _drain_steer(self, channel: str, user_id: str, chat_id: str) -> list[dict]:
+        """Pop and return this chat's pending steer entries, marking each consumed.
+
+        ``consumed`` is read by the depositing message's own (lock-blocked) task:
+        once the running turn has folded the follow-up in, that task returns silently
+        instead of re-running it as a duplicate turn (#145)."""
+        entries = self._steer_map().pop((channel, user_id, chat_id), [])
+        for e in entries:
+            e["consumed"] = True
+        return entries
+
+    def _discard_steer(self, key: tuple, entry: dict) -> None:
+        """Remove one still-pending entry (turn ended before it was drained), so it
+        can't steer the very turn it is about to run as (#145)."""
+        lst = self._steer_map().get(key)
+        if lst and entry in lst:
+            lst.remove(entry)
+            if not lst:
+                self._steer_map().pop(key, None)
+
+    async def _ack_steer(self, channel: str, chat_id: str, message_id) -> None:
+        """React 👀 on a steering message so the user sees it was picked up, without
+        the model spending a reply on it (#145). Best-effort: channels without
+        reactions (or a failing call) are silently skipped."""
+        if not (chat_id and message_id):
+            return
+        ch = self.channels.get(channel)
+        react = getattr(ch, "react", None) if ch else None
+        if not callable(react):
+            return
+        try:
+            await react(chat_id, int(message_id), "👀")
+        except Exception as exc:  # cosmetic — never break the turn over an ack
+            log.debug("Steer ack reaction failed: %s", exc)
+
+    async def _pop_steer_message(self, channel: str, user_id: str, chat_id: str) -> dict | None:
+        """Drain pending steers for this chat into one labelled user message, acking
+        each with 👀. Returns None when nothing is pending (#145). ponytail: text
+        only — a steer's attachments are dropped; if it wasn't consumed its own turn
+        still carries them, and mid-turn image steers are rare enough to defer."""
+        entries = self._drain_steer(channel, user_id, chat_id)
+        if not entries:
+            return None
+        for e in entries:
+            await self._ack_steer(channel, chat_id, e.get("message_id"))
+        joined = "\n\n".join(e["text"] for e in entries)
+        text = (
+            "[The user sent a follow-up while you were working:]\n"
+            f"<steering_message>\n{joined}\n</steering_message>\n"
+            "Continue your current task taking this into account."
+        )
+        return {"role": "user", "content": text}
 
     def _chat_lock(self, channel: str, user_id: str, chat_id: str) -> asyncio.Lock:
         """The turn lock for one chat key, created on first use.
@@ -1994,6 +2085,12 @@ class AgentCore:
             # Feed tool results back to the LLM
             messages.append(self.llm.assistant_message(response))
             messages.extend(self.llm.tool_result_messages(tool_results))
+            # Mid-turn steering (#145): fold any follow-up the user sent while we
+            # worked into the next call. Appended after the tool_result user turn;
+            # generate() merges the consecutive user turns, so alternation holds.
+            steer_msg = await self._pop_steer_message(channel, user_id, chat_id)
+            if steer_msg:
+                messages.append(steer_msg)
             response = await self.llm.generate(
                 model=self.config.agent.model,
                 max_tokens=self.config.agent.max_tokens,
@@ -2163,6 +2260,14 @@ class AgentCore:
             await self.history.append_session_messages(
                 channel, user_id, [assistant_msg, *tool_result_msgs], chat_id
             )
+
+            # Mid-turn steering (#145): fold any follow-up the user sent while we
+            # worked into the next call, and persist it so the sticky session keeps a
+            # faithful record. generate() merges it with the tool_result user turn.
+            steer_msg = await self._pop_steer_message(channel, user_id, chat_id)
+            if steer_msg:
+                new_messages.append(steer_msg)
+                await self.history.append_session_messages(channel, user_id, [steer_msg], chat_id)
 
             response = await self.llm.generate(
                 model=self.config.agent.model,

--- a/humux/tests/test_steer.py
+++ b/humux/tests/test_steer.py
@@ -72,30 +72,33 @@ class _FakeChannel:
 # --- unit: buffer mechanics ------------------------------------------------
 
 
-def test_drain_is_scoped_per_chat(agent) -> None:
+def test_drain_is_scoped_and_defers_consume(agent) -> None:
     a = ("telegram", "u", "1")
     b = ("telegram", "u", "2")
     agent._steer_map().setdefault(a, []).append({"text": "hi", "consumed": False})
     assert agent._drain_steer(*b) == []  # other chat sees nothing
     got = agent._drain_steer(*a)
     assert [e["text"] for e in got] == ["hi"]
-    assert got[0]["consumed"] is True  # drained entries are marked for the depositor
+    # Draining does NOT consume — that waits until the steer has reached the model,
+    # so a failed generate() leaves it to run as its own turn (#145).
+    assert got[0]["consumed"] is False
     assert agent._drain_steer(*a) == []  # popped, not re-served
 
 
-@pytest.mark.asyncio
-async def test_pop_formats_and_acks(agent) -> None:
-    agent.channels = {"telegram": _FakeChannel()}
-    key = ("telegram", "u", "1")
-    agent._steer_map().setdefault(key, []).append(
-        {"text": "use the calendar API instead", "message_id": 7, "consumed": False}
-    )
-    msg = await agent._pop_steer_message(*key)
+def test_steer_message_formats(agent) -> None:
+    msg = agent._steer_message([{"text": "use the calendar API instead", "message_id": 7}])
     assert msg["role"] == "user"
     assert "<steering_message>" in msg["content"]
     assert "use the calendar API instead" in msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_commit_marks_and_acks(agent) -> None:
+    agent.channels = {"telegram": _FakeChannel()}
+    entries = [{"text": "x", "message_id": 7, "consumed": False}]
+    await agent._commit_steer("telegram", "1", entries)
+    assert entries[0]["consumed"] is True  # committed only after the model saw it
     assert agent.channels["telegram"].reactions == [("1", 7, "👀")]
-    assert await agent._pop_steer_message(*key) is None  # drained
 
 
 # --- integration: injection into a running turn ----------------------------
@@ -140,6 +143,69 @@ async def test_steer_injected_into_running_turn(agent) -> None:
     assert "use the calendar API" in flat
     # And the follow-up got a 👀 ack.
     assert (("55", 2, "👀")) in agent.channels["telegram"].reactions
+
+
+class _FailOnSteeredRoundLLM:
+    """call 1 → a tool call; call 2 (the steered round) → raises; later calls answer.
+
+    Reproduces the failure the review found: the generate() carrying the steer errors."""
+
+    provider = "deepseek"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def generate(self, *, messages, **_kw) -> LLMResponse:
+        self.calls += 1
+        if self.calls == 1:
+            return LLMResponse(
+                text="",
+                tool_calls=[LLMToolCall(id="c1", name="web_search", arguments={"q": "x"})],
+            )
+        if self.calls == 2:
+            raise RuntimeError("provider 5xx on the steered round")
+        return LLMResponse(text="recovered", tool_calls=[])
+
+    def assistant_message(self, response: LLMResponse) -> dict:
+        return {"role": "assistant", "content": response.text}
+
+    def tool_result_messages(self, results: list[dict]) -> list[dict]:
+        return [{"role": "user", "content": results}]
+
+
+@pytest.mark.asyncio
+async def test_steer_not_lost_when_carrying_generate_fails(agent) -> None:
+    # Injection mode: no sticky-session safety net, so the unconsumed-on-failure
+    # fallback is the only thing keeping the steer alive.
+    agent.history_mode = "injection"
+    agent.llm = _FailOnSteeredRoundLLM()
+    agent.channels = {"telegram": _FakeChannel()}
+
+    async def fake_tool(call, channel, user_id, request_state):
+        await asyncio.sleep(0.02)  # window for the steer to land before the failing round
+        return {"ok": True}
+
+    agent._execute_tool = fake_tool
+    key = ("telegram", "u", "77")
+
+    turn = asyncio.create_task(
+        agent.process("start work", "telegram", "u", chat_id="77", message_id=1)
+    )
+    await _wait_active(agent, key, turn)
+
+    steer_task = asyncio.create_task(
+        agent.process("actually, do it differently", "telegram", "u", chat_id="77", message_id=2)
+    )
+
+    with pytest.raises(RuntimeError):
+        await asyncio.wait_for(turn, timeout=3)  # the failing round propagates
+
+    # The steer was never confirmed to the model, so it runs as its own turn
+    # instead of being silently dropped.
+    steer_resp = await asyncio.wait_for(steer_task, timeout=3)
+    assert steer_resp.text == "recovered"
+    # No false ack: 👀 fires only on a committed steer, and this one never committed.
+    assert agent.channels["telegram"].reactions == []
 
 
 @pytest.mark.asyncio

--- a/humux/tests/test_steer.py
+++ b/humux/tests/test_steer.py
@@ -1,0 +1,161 @@
+"""Mid-turn steering (#145).
+
+An addressed follow-up sent while a turn is running for its chat is buffered and
+injected into that turn between tool rounds — the user redirects without waiting
+for the whole tool loop. The turn acks pickup with a 👀 reaction. The buffer is
+per conversation key, so a steer never crosses into another chat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from core.config import Config
+from core.llm import LLMResponse, LLMToolCall
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from core.agent import AgentCore
+
+    cfg = Config()
+    cfg.agent.llm_provider = "deepseek"
+    cfg.agent.model = "deepseek-v4-flash"
+    cfg.memory.embedding.enabled = False
+    cfg.task_reflection.enabled = False
+    cfg.goal_decomposition.enabled = False
+    return AgentCore(cfg)
+
+
+class _RecordingLLM:
+    """Loops a fixed number of tool calls, then answers. Records every ``messages``
+    array it was asked to generate on, so a test can assert what the model saw."""
+
+    provider = "deepseek"
+
+    def __init__(self, rounds: int = 3) -> None:
+        self.rounds = rounds
+        self.calls = 0
+        self.seen: list[list[dict]] = []
+
+    async def generate(self, *, messages, **_kw) -> LLMResponse:
+        # Deep-enough copy: capture content refs before later rounds mutate the list.
+        self.seen.append(list(messages))
+        self.calls += 1
+        if self.calls <= self.rounds:
+            return LLMResponse(
+                text="",
+                tool_calls=[
+                    LLMToolCall(id=f"c{self.calls}", name="web_search", arguments={"q": "x"})
+                ],
+            )
+        return LLMResponse(text="done", tool_calls=[])
+
+    def assistant_message(self, response: LLMResponse) -> dict:
+        return {"role": "assistant", "content": response.text}
+
+    def tool_result_messages(self, results: list[dict]) -> list[dict]:
+        return [{"role": "user", "content": results}]
+
+
+class _FakeChannel:
+    def __init__(self) -> None:
+        self.reactions: list[tuple] = []
+
+    async def react(self, chat_id, message_id, emoji) -> None:
+        self.reactions.append((chat_id, message_id, emoji))
+
+
+# --- unit: buffer mechanics ------------------------------------------------
+
+
+def test_drain_is_scoped_per_chat(agent) -> None:
+    a = ("telegram", "u", "1")
+    b = ("telegram", "u", "2")
+    agent._steer_map().setdefault(a, []).append({"text": "hi", "consumed": False})
+    assert agent._drain_steer(*b) == []  # other chat sees nothing
+    got = agent._drain_steer(*a)
+    assert [e["text"] for e in got] == ["hi"]
+    assert got[0]["consumed"] is True  # drained entries are marked for the depositor
+    assert agent._drain_steer(*a) == []  # popped, not re-served
+
+
+@pytest.mark.asyncio
+async def test_pop_formats_and_acks(agent) -> None:
+    agent.channels = {"telegram": _FakeChannel()}
+    key = ("telegram", "u", "1")
+    agent._steer_map().setdefault(key, []).append(
+        {"text": "use the calendar API instead", "message_id": 7, "consumed": False}
+    )
+    msg = await agent._pop_steer_message(*key)
+    assert msg["role"] == "user"
+    assert "<steering_message>" in msg["content"]
+    assert "use the calendar API instead" in msg["content"]
+    assert agent.channels["telegram"].reactions == [("1", 7, "👀")]
+    assert await agent._pop_steer_message(*key) is None  # drained
+
+
+# --- integration: injection into a running turn ----------------------------
+
+
+async def _wait_active(agent, key, task):
+    for _ in range(400):
+        await asyncio.sleep(0.005)
+        if key in agent._active_turns_map():
+            return
+    task.cancel()
+    pytest.fail("turn never registered an abort Event")
+
+
+@pytest.mark.asyncio
+async def test_steer_injected_into_running_turn(agent) -> None:
+    agent.llm = _RecordingLLM(rounds=3)
+    agent.channels = {"telegram": _FakeChannel()}
+
+    async def fake_tool(call, channel, user_id, request_state):
+        await asyncio.sleep(0.01)  # pace rounds so the steer lands mid-loop
+        return {"ok": True}
+
+    agent._execute_tool = fake_tool
+    key = ("telegram", "u", "55")
+
+    turn = asyncio.create_task(
+        agent.process("start work", "telegram", "u", chat_id="55", message_id=1)
+    )
+    await _wait_active(agent, key, turn)
+
+    steer = await agent.process(
+        "actually, use the calendar API", "telegram", "u", chat_id="55", message_id=2
+    )
+    assert steer.text == ""  # consumed by the running turn — no duplicate reply
+
+    resp = await asyncio.wait_for(turn, timeout=3)
+    assert resp.text == "done"
+    # The steering text reached at least one LLM call, wrapped for the model.
+    flat = "".join(str(m.get("content")) for seen in agent.llm.seen for m in seen)
+    assert "<steering_message>" in flat
+    assert "use the calendar API" in flat
+    # And the follow-up got a 👀 ack.
+    assert (("55", 2, "👀")) in agent.channels["telegram"].reactions
+
+
+@pytest.mark.asyncio
+async def test_idle_message_is_not_a_steer(agent) -> None:
+    # No turn running → not buffered as a steer; falls through to normal processing.
+    key = ("telegram", "u", "9")
+    assert agent._active_turns_map().get(key) is None
+    called = {}
+
+    async def fake_impl(message, *a, **k):
+        called["msg"] = message
+        from core.agent import AgentResponse
+
+        return AgentResponse(text="normal")
+
+    agent._process_impl = fake_impl
+    resp = await agent.process("do a thing", "telegram", "u", chat_id="9")
+    assert resp.text == "normal" and called["msg"] == "do a thing"
+    assert not agent._steer_map().get(key)  # nothing buffered

--- a/humux/tests/test_stop_turn.py
+++ b/humux/tests/test_stop_turn.py
@@ -97,6 +97,8 @@ async def test_stop_command_aborts_running_turn(agent) -> None:
     assert resp.text == _STOPPED_MESSAGE
     # The loop broke instead of spinning to the round cap.
     assert agent.llm.calls < 50
-    # History records the stop so the next turn knows it was interrupted.
-    msgs = await agent.history.get_messages("telegram", "u", "55")
-    assert msgs[-1]["role"] == "assistant" and msgs[-1]["content"] == _STOPPED_MESSAGE
+    # The session records the stop so the next turn knows it was interrupted.
+    # (Session is the only history mode now; the old injection-mode conversation_turns
+    # table that get_messages reads is no longer written on this path.)
+    session = await agent.history.get_session("telegram", "u", "55")
+    assert session[-1]["role"] == "assistant" and session[-1]["content"] == _STOPPED_MESSAGE


### PR DESCRIPTION
Closes #145.

## What

Lets the user redirect the agent **while it's still working**, instead of waiting for the whole tool loop to finish and correcting on the next turn.

Send a normal follow-up while a turn is running (in a group, address it — reply to the bot or `@mention`). It's buffered, then **injected into the running turn between tool rounds**, wrapped so the model knows it's a steer:

```
[The user sent a follow-up while you were working:]
<steering_message>
actually, use the calendar API instead
</steering_message>
Continue your current task taking this into account.
```

The bot reacts 👀 on the follow-up so the user sees it landed — no wasted reply.

## Why no `/steer` / `/queue` command

The issue floated a `/steer` command; it isn't needed. Any **addressed** message is the steer (the issue's primary proposal #1) — less surface, better UX. A `/queue` was considered and dropped: "when you're done, also do X" already sequences naturally through the injected text, so a separate command would mostly duplicate the existing lock-and-run-next behaviour. `/stop` (#146) remains the hard cancel.

## Design

Builds directly on #146's per-chat abort infrastructure (`_active_turns_map`, keyed by `(channel, user_id, chat_id)`):

- **Buffer before the lock.** A running turn *holds* the per-chat lock, so the follow-up is detected and buffered before acquiring it — otherwise it would wait for the very turn it means to steer.
- **Drain between rounds.** Both tool loops (`_process_session`, `_process_injection`) drain the buffer right before the next `generate()` and append the steer as a user turn. `generate()` already merges consecutive user turns, so alternation holds.
- **No double-processing, no loss.** The follow-up still falls through to the lock. If the running turn consumed it → the task returns silently. If the turn ended before draining (late steer) → it runs as its own turn. Nothing is lost, nothing runs twice.
- **Per conversation key** — a steer never crosses into another chat.

## Scope / limits

- Steering lands **between tool rounds**, not while the agent is parked on an approval prompt (`_await_approval`) — it's read once that resolves. Documented in `channels.mdx`, as the issue asked.
- Text-only steer: a follow-up's attachments are dropped when consumed (its own turn still carries them if not). Marked with a `ponytail:` comment; mid-turn image steers are rare.

## Tests

`tests/test_steer.py` — buffer scoping per chat, message formatting + 👀 ack, mid-turn injection into a live running turn (consumed → silent, steer text reaches the model), and idle-message fall-through.

Full suite: 924 passed. The one failure (`test_stop_turn::test_stop_command_aborts_running_turn`) is **pre-existing** — it fails identically on clean `main` and is unrelated to this change (its `/stop` path never touches the steer code).

## Docs

- `docs/content/docs/channels.mdx` — Steering bullet + the approval-wait limitation.
- `README.md` — "Steerable mid-turn" feature bullet.

