### PR TITLE
CLI channel: first-class terminal access to the agent (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,14 +249,21 @@ make setup       # creates venv, installs deps, copies example configs
 make run         # starts the agent
 ```
 
-### 4. Chat from the terminal (no Telegram needed)
+### 4. Chat from the terminal (the CLI channel)
 
 ```bash
 cd mpa/humux
-make repl        # interactive REPL — type your messages, see the agent think
-make repl AGENT=my-agent  # chat as a specific agent
-make repl YOLO=1          # auto-approve all permissions (local testing)
+make cli        # interactive CLI — type your messages, see the agent think
+make cli AGENT=my-agent  # chat as a specific agent
+make cli YOLO=1          # auto-approve all permissions (local testing)
 ```
+
+The CLI is a first-class channel — the same agent, same data, same tools as
+Telegram, just at your terminal. It's also reachable remotely over the deploy
+host's SSH (`ssh -t user@host docker exec -it humux uv run python -m core.cli`),
+supports resumable sessions (`--session` / `--sessions` / `--rm-session`), and
+runs concurrently with the live server (all databases run in WAL mode). See the
+**Channels → CLI** docs for details.
 
 ---
 

--- a/docs/content/docs/agents.mdx
+++ b/docs/content/docs/agents.mdx
@@ -121,13 +121,13 @@ assistant, pick one of any agents you've seeded, or skip and build agents later.
 
 ## Testing an agent from the terminal
 
-The REPL can start with a specific agent active, so you can iterate on one without touching
-the global setting:
+The [CLI channel](/docs/channels#cli) can start with a specific agent active, so you can
+iterate on one without touching the global setting:
 
 ```bash
-make repl AGENT=<slug>
+make cli AGENT=<slug>
 # or
-uv run python -m core.repl --agent <slug>
+uv run python -m core.cli --agent <slug>
 ```
 
 An unknown name fails loudly and lists the available agents.
@@ -151,7 +151,7 @@ default. Resolution runs a ladder in `AgentCore._resolve_agent(channel, user_id,
 2. the agent flagged as the default (`is_default`) — or `None` (the config base) if none is.
 
 Bindings live in the `chat_agent` table and work on **any** channel (Telegram, WhatsApp,
-REPL). They are set programmatically — by **bot-per-agent** routing — rather than
+CLI). They are set programmatically — by **bot-per-agent** routing — rather than
 hand-picked per chat; the project is built around **one agent = one bot** (a dedicated
 `telegram:<slug>` bot per identity), so the admin UI no longer offers a per-chat agent
 dropdown. A binding applies on the next turn; the open chat keeps its current identity

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -185,6 +185,75 @@ as repeated auth loss. The fix is a version bump:
 - Session may need re-authentication periodically (and after a wacli version bump)
 - WhatsApp may restrict accounts using unofficial clients
 
+## CLI
+
+The `cli` channel is a first-class terminal interface to the agent — the same
+agent, the same `data/*.db` stores, the same tools and permission flow as
+Telegram, just at a prompt. It was the old "REPL"; it is no longer a
+testing-only afterthought.
+
+```bash
+make cli                    # or: uv run python -m core.cli
+make cli AGENT=<slug>       # run as a specific agent (--agent <slug>)
+make cli YOLO=1             # auto-approve every permission this session (--yolo)
+```
+
+In the prompt: `ESC` interrupts a turn, `/img PATH [caption]` or `/paste
+[caption]` sends an image, `/clear` resets the current session's context, and
+`Ctrl-D` / `/exit` quits.
+
+### Remote access (SSH + docker exec)
+
+No in-app SSH server: the deploy host's own `sshd` already authenticates you
+(key-based, encrypted), then `docker exec` drops you into a live CLI against
+production data while the server keeps running:
+
+```bash
+ssh -t user@host docker exec -it humux uv run python -m core.cli
+```
+
+A host-side shell alias keeps it to one word:
+
+```bash
+alias humux='ssh -t user@host docker exec -it humux uv run python -m core.cli'
+```
+
+### Sessions
+
+Each run is its own **session** (its own chat row); it prints its id at startup:
+
+```
+session: 2026-07-03-a1b2 (new · resume with --session 2026-07-03-a1b2)
+```
+
+- `--session NAME` — resume a previous session (history persists in
+  `history.db` on the volume; sessions are just chat rows, no new store).
+- `--sessions` — list existing CLI sessions with last-activity timestamps.
+- `--rm-session NAME` — delete one. In-prompt `/clear` only clears the *current*
+  session's context.
+
+(Not to be confused with `history.mode == "session"`, the prompt-snapshot
+history mode — a different concept that happens to share the word.)
+
+### Scheduled jobs from the CLI
+
+A job you schedule from a CLI session fires later in the **server** process,
+where no `cli` channel exists. Its output is delivered to the owner's Telegram
+DM instead of the terminal, and the scheduling confirmation tells you so.
+
+### Cross-process notes
+
+The CLI builds its own `AgentCore` in a separate process that shares the
+SQLite stores with the live server. All `data/*.db` files are put in **WAL
+mode** at boot of either entrypoint, so concurrent reads/writes don't hit
+`SQLITE_BUSY`. Two quirks follow from the two processes not sharing memory:
+
+- **"Always allow" permission rules** load once at process start. A rule granted
+  in a CLI session is invisible to the live server until it restarts, and vice
+  versa.
+- **Config** is snapshotted at CLI boot; admin-UI config changes need a CLI
+  restart to take effect.
+
 ## Channel architecture
 
 Both channels implement the same interface:

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -237,9 +237,17 @@ history mode — a different concept that happens to share the word.)
 
 ### Scheduled jobs from the CLI
 
-A job you schedule from a CLI session fires later in the **server** process,
-where no `cli` channel exists. Its output is delivered to the owner's Telegram
-DM instead of the terminal, and the scheduling confirmation tells you so.
+A job you schedule from a CLI session is saved to the job store and fires in the
+**server** process, where no `cli` channel exists — so its output is delivered
+to the owner's Telegram DM instead of the terminal, and the scheduling
+confirmation tells you so.
+
+One caveat, from the same two-process split as the notes below: the CLI persists
+the job but does **not** notify the already-running server's scheduler, which
+only loads jobs at boot. A CLI-created job therefore becomes active on the
+server's next restart — a recurring **cron** job then fires normally, but a
+**one-shot** whose time has already passed by that restart is retired without
+firing. For time-sensitive one-shots, schedule from Telegram instead.
 
 ### Cross-process notes
 

--- a/humux/Makefile
+++ b/humux/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-hooks install install-dev sync lock lint format test run repl dev dev-agent dev-css dev-wa kokoro clean release css
+.PHONY: help setup setup-hooks install install-dev sync lock lint format test run cli dev dev-agent dev-css dev-wa kokoro clean release css
 
 PORT := 8001
 PYTHON := uv run python
@@ -30,9 +30,9 @@ help:
 	@echo "    make kokoro       Install Kokoro offline TTS + download its model (local runs)"
 	@echo ""
 	@echo "  Development:"
-	@echo "    make repl         Chat with the agent from the terminal (no Telegram)"
-	@echo "                      (make repl AGENT=<slug> to test a specific agent)"
-	@echo "                      (make repl YOLO=1 to auto-approve all permissions)"
+	@echo "    make cli          Chat with the agent from the terminal (no Telegram)"
+	@echo "                      (make cli AGENT=<slug> to test a specific agent)"
+	@echo "                      (make cli YOLO=1 to auto-approve all permissions)"
 	@echo "    make dev          Show instructions for running dev services"
 	@echo "    make dev-agent    Run agent with auto-reload"
 	@echo "    make dev-css      Run Tailwind CSS watcher"
@@ -96,9 +96,9 @@ test:
 run:
 	$(UV) run python -m core.main
 
-# Local REPL — chat with the agent from the terminal (no Telegram)
-repl:
-	$(PYTHON) -m core.repl $(if $(AGENT),--agent $(AGENT),) $(if $(YOLO),--yolo,)
+# Local CLI — chat with the agent from the terminal (no Telegram)
+cli:
+	$(PYTHON) -m core.cli $(if $(AGENT),--agent $(AGENT),) $(if $(YOLO),--yolo,)
 
 # Run in dev mode: instructions for running services in separate shells
 dev:

--- a/humux/api/templates/partials/tools.html
+++ b/humux/api/templates/partials/tools.html
@@ -535,7 +535,7 @@
         <input type="text" class="input-sm" style="max-width:100%" x-model="cdp"
                placeholder="ws://browser:9222 — empty = run locally">
         <p class="text-muted text-xs mt-1">
-          Empty launches Chromium locally (works in the REPL). Set to connect to a
+          Empty launches Chromium locally (works in the CLI). Set to connect to a
           sidecar Chromium and keep the main image lean.
         </p>
       </div>

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -894,7 +894,7 @@ class TelegramChannel:
 
         explore writes a per-step line to data/browser/last/explore.status; we
         poll it and edit a single Telegram message in place (the chat equivalent
-        of the REPL's self-updating spinner line). No-op when nothing is running.
+        of the CLI's self-updating spinner line). No-op when nothing is running.
         """
         # ponytail: the explore status file is a single global singleton, so only
         # the default bot mirrors it — otherwise a run triggered via one agent-bot

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -3383,8 +3383,10 @@ class AgentCore:
             origin_user_id = str(origin.get("user_id") or "")
             origin_chat_id = str(origin.get("chat_id") or "")
             cli_note = (
-                "This job runs in the server later; its output is delivered to your "
-                "Telegram DM, not this terminal."
+                "Saved to the job store. Output is delivered to your Telegram DM, not this "
+                "terminal. It becomes active when the server next reloads jobs (on restart) — "
+                "the running server isn't notified from this CLI process, so a time-sensitive "
+                "one-shot may not fire. Prefer a cron job, or schedule it from Telegram."
                 if from_cli
                 else None
             )

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -3372,10 +3372,22 @@ class AgentCore:
             origin = (request_state or {}).get("origin") or {}
             origin_agent = (request_state or {}).get("agent_name") or ""
             origin_channel = origin.get("channel") or ""
+            from_cli = origin_channel == "cli"
             if origin_channel == "telegram" or origin_channel.startswith("telegram:"):
                 channel = origin_channel
+            elif from_cli:
+                # The CLI channel only exists in this transient process; the job
+                # fires later in the server, where the scheduler falls back to
+                # the owner's Telegram DM (#168).
+                channel = "cli"
             origin_user_id = str(origin.get("user_id") or "")
             origin_chat_id = str(origin.get("chat_id") or "")
+            cli_note = (
+                "This job runs in the server later; its output is delivered to your "
+                "Telegram DM, not this terminal."
+                if from_cli
+                else None
+            )
 
             if cron_expr:
                 # Recurring cron job
@@ -3401,7 +3413,7 @@ class AgentCore:
                     origin_chat_id=origin_chat_id,
                 )
                 await self.scheduler.sync_job(job_id)
-                return {
+                result = {
                     "ok": True,
                     "job_id": job_id,
                     "schedule": "cron",
@@ -3409,6 +3421,9 @@ class AgentCore:
                     "task": task,
                     "channel": channel,
                 }
+                if cli_note:
+                    result["note"] = cli_note
+                return result
 
             elif run_at_str:
                 # One-shot job
@@ -3437,7 +3452,7 @@ class AgentCore:
                     origin_chat_id=origin_chat_id,
                 )
                 await self.scheduler.sync_job(job_id)
-                return {
+                result = {
                     "ok": True,
                     "job_id": job_id,
                     "schedule": "once",
@@ -3445,6 +3460,9 @@ class AgentCore:
                     "task": task,
                     "channel": channel,
                 }
+                if cli_note:
+                    result["note"] = cli_note
+                return result
             else:
                 return {"error": "Must specify 'cron' for recurring or 'run_at' for one-time jobs."}
 

--- a/humux/core/cli.py
+++ b/humux/core/cli.py
@@ -1,10 +1,19 @@
-"""Local REPL channel — talk to the agent from the terminal, no Telegram.
+"""CLI channel — a first-class terminal interface to the agent, no Telegram.
 
-Run:  make repl   (or  uv run python -m core.repl)
+Run:  make cli   (or  uv run python -m core.cli)
+
+Remote (single-operator deploy): the host's own sshd authenticates you, then
+``docker exec`` drops you into a live REPL against production data:
+
+    ssh -t user@host docker exec -it humux uv run python -m core.cli
 
 Builds the agent from the same config store the server uses, registers itself
-as the ``repl`` channel so permission approvals route to a y/n terminal prompt,
+as the ``cli`` channel so permission approvals route to a y/n terminal prompt,
 then loops on stdin. Ctrl-D or ``/exit`` quits.
+
+Each run is a fresh **session** (its own chat row) by default; ``--session`` /
+``--sessions`` / ``--rm-session`` resume, list and delete them. (Not to be
+confused with ``history.mode == "session"``, the prompt-snapshot history mode.)
 
 While the agent works, a spinner shows it's busy and the chain of thought
 (model reasoning + each tool call) streams live above it.
@@ -19,6 +28,8 @@ import mimetypes
 import os
 import sys
 import time
+import uuid
+from datetime import datetime
 from pathlib import Path
 
 from core.agent import AgentCore
@@ -38,7 +49,8 @@ except ImportError:  # pragma: no cover - non-POSIX
 
 log = logging.getLogger(__name__)
 
-USER_ID = "repl"
+CHANNEL = "cli"
+USER_ID = "cli"  # the operator; sessions differ by chat_id (cli:<session>)
 _PROMPT = "> "
 
 # Loggers whose INFO output is the agent's "chain of thought" / activity trail.
@@ -64,7 +76,7 @@ class _SpinnerHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         if record.getMessage().startswith("Processing message"):
-            return  # redundant in a REPL — you just typed it (and it shows "repl/repl/repl")
+            return  # redundant in the CLI — you just typed it
         color = _DIM if record.name == "core.llm.reasoning" else _CYAN
         line = f"  {color}· {record.getMessage()}{_RESET}"
         sys.stderr.write("\r\033[K" + line + "\n")
@@ -137,7 +149,7 @@ class Spinner:
         sys.stderr.flush()
 
 
-class ReplChannel:
+class CliChannel:
     """Minimal channel: prints approval prompts and reads a y/n from stdin."""
 
     def __init__(self, agent: AgentCore, spinner: Spinner, yolo: bool = False):
@@ -235,7 +247,7 @@ def _print_debug_config(config, agent=None) -> None:
         ("voice", "on" if config.voice.tts_enabled else "off"),
         ("timezone", a.timezone),
     ]
-    print(f"\n{_CYAN}── REPL debug config ──{_RESET}")
+    print(f"\n{_CYAN}── CLI debug config ──{_RESET}")
     for k, v in rows:
         print(f"  {_DIM}{k:>10}{_RESET}  {v}")
     print(
@@ -244,14 +256,16 @@ def _print_debug_config(config, agent=None) -> None:
     )
 
 
-async def _run_turn(agent: AgentCore, spinner: Spinner, text: str, attachments=None, agent_name=""):
+async def _run_turn(
+    agent: AgentCore, spinner: Spinner, text: str, chat_id: str, attachments=None, agent_name=""
+):
     """Run one turn, cancellable by pressing ESC. Returns None if interrupted."""
     proc = asyncio.create_task(
         agent.process(
             message=text,
-            channel="repl",
+            channel=CHANNEL,
             user_id=USER_ID,
-            chat_id=USER_ID,
+            chat_id=chat_id,
             attachments=attachments,
             agent_name=agent_name or None,
         )
@@ -269,7 +283,7 @@ async def _run_turn(agent: AgentCore, spinner: Spinner, text: str, attachments=N
         except OSError:
             pass
 
-    chan = agent.channels.get("repl")
+    chan = agent.channels.get(CHANNEL)
 
     def _pause() -> None:  # hand stdin back to a blocking input() prompt
         loop.remove_reader(fd)
@@ -298,6 +312,24 @@ async def _run_turn(agent: AgentCore, spinner: Spinner, text: str, attachments=N
         await spinner.stop()
 
 
+def _new_session_id() -> str:
+    """Short, human-readable session id, e.g. ``2026-07-03-a1b2``."""
+    return f"{datetime.now().strftime('%Y-%m-%d')}-{uuid.uuid4().hex[:4]}"
+
+
+async def _list_sessions(history) -> None:
+    chats = [c for c in await history.list_chats() if c["channel"] == CHANNEL]
+    if not chats:
+        print("No CLI sessions yet.")
+        return
+    print("CLI sessions (most recent first):")
+    for c in chats:
+        name = c["chat_id"].removeprefix(f"{CHANNEL}:")
+        when = c.get("last_active") or "—"
+        who = f"  [{c['agent']}]" if c.get("agent") else ""
+        print(f"  {name:<24} {when}{who}")
+
+
 async def main() -> None:
     import argparse
 
@@ -313,11 +345,32 @@ async def main() -> None:
         action="store_true",
         help="Auto-approve every permission prompt (no rules saved). Local testing only.",
     )
+    parser.add_argument(
+        "--session",
+        metavar="NAME",
+        default=None,
+        help="Resume a previous CLI session by name (default: start a fresh one).",
+    )
+    parser.add_argument(
+        "--sessions",
+        action="store_true",
+        help="List existing CLI sessions and exit.",
+    )
+    parser.add_argument(
+        "--rm-session",
+        metavar="NAME",
+        default=None,
+        help="Delete a CLI session by name and exit.",
+    )
     args = parser.parse_args()
 
     from dotenv import load_dotenv
 
     load_dotenv()  # HUMUX_MASTER_KEY / ADMIN_PASSWORD from .env, as main.py does at boot
+
+    from core.db import ensure_wal
+
+    ensure_wal()  # WAL is a persistent file property; safe to run every boot (#168)
 
     spinner = Spinner()
     _setup_logging(spinner)
@@ -327,7 +380,7 @@ async def main() -> None:
     await store.ensure_admin_password()
 
     # Wire the secrets vault the same way main.py does, so {{secret:}} / ${vault:}
-    # and list_secrets/request_secret work in the repl. ponytail: mirror boot, no abstraction.
+    # and list_secrets/request_secret work in the CLI. ponytail: mirror boot, no abstraction.
     from core.secret_store import SecretStore
 
     secret_store = SecretStore()
@@ -336,6 +389,21 @@ async def main() -> None:
     if seed_pw:  # unseals agent vault in-process (created on first set)
         await secret_store.ensure_wrapped_dek(seed_pw)
     config = await store.export_to_config(vault_resolve=secret_store.infra_resolve)
+
+    # Session management commands need only the history store — handle & exit.
+    if args.sessions or args.rm_session:
+        from core.history import ConversationHistory
+
+        history = ConversationHistory(db_path=config.history.db_path)
+        if args.rm_session:
+            await history.clear(CHANNEL, USER_ID, f"{CHANNEL}:{args.rm_session}")
+            print(f"Deleted session: {args.rm_session}")
+        else:
+            await _list_sessions(history)
+        return
+
+    session = args.session or _new_session_id()
+    chat_id = f"{CHANNEL}:{session}"
 
     if args.agent is not None:
         # Validate against the agent store so a typo fails loudly with options.
@@ -349,7 +417,7 @@ async def main() -> None:
 
     forced_agent = args.agent or ""  # per-turn identity override for this session
     agent = AgentCore(config, secret_store=secret_store)
-    agent.channels["repl"] = ReplChannel(agent, spinner, yolo=args.yolo)
+    agent.channels[CHANNEL] = CliChannel(agent, spinner, yolo=args.yolo)
     if args.yolo:
         print(f"{_DIM}⚠ --yolo: auto-approving all tool permissions this session.{_RESET}")
 
@@ -358,14 +426,16 @@ async def main() -> None:
         # would keep the previous identity. Clear it so the agent takes effect
         # on the first turn instead of after a manual /clear.
         if agent.history_mode == "session":
-            await agent.history.clear_session("repl", USER_ID, USER_ID)
+            await agent.history.clear_session(CHANNEL, USER_ID, chat_id)
         else:
-            await agent.history.clear("repl", USER_ID, USER_ID)
+            await agent.history.clear(CHANNEL, USER_ID, chat_id)
 
     session_agent = (
         await agent.agents.get(forced_agent) if forced_agent else await agent.agents.get_default()
     )
     _print_debug_config(config, session_agent)
+    resumed = "resumed" if args.session else "new"
+    print(f"{_DIM}session: {session} ({resumed} · resume with --session {session}){_RESET}\n")
 
     while True:
         spinner.awaiting_input = True
@@ -381,7 +451,7 @@ async def main() -> None:
         if text in ("/exit", "/quit"):
             break
         if text == "/clear":
-            await agent.history.clear("repl", USER_ID, USER_ID)
+            await agent.history.clear(CHANNEL, USER_ID, chat_id)
             print("[context cleared]\n")
             continue
         attachments = None
@@ -403,7 +473,9 @@ async def main() -> None:
                 continue
             attachments = [Attachment(data=data, mime_type=mime, filename="clipboard")]
             text = text[len("/paste") :].strip() or "What's in this image?"
-        response = await _run_turn(agent, spinner, text, attachments, agent_name=forced_agent)
+        response = await _run_turn(
+            agent, spinner, text, chat_id, attachments, agent_name=forced_agent
+        )
         if response is None:
             print("\n[interrupted]\n")
             continue

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -383,7 +383,7 @@ class BrowserToolConfig(BaseModel):
     enabled: bool = False
     headless: bool = True
     # Optional CDP endpoint of a sidecar Chromium. Empty = launch locally (works
-    # in the local REPL with no extra services). Set to keep the main image lean.
+    # in the local CLI with no extra services). Set to keep the main image lean.
     cdp_url: str = ""
     # Override the browser User-Agent. Empty = built-in desktop Chrome UA.
     user_agent: str = ""

--- a/humux/core/db.py
+++ b/humux/core/db.py
@@ -1,0 +1,51 @@
+"""One-shot WAL enablement for all SQLite stores (issue #168).
+
+``journal_mode=WAL`` is a *persistent* property of a SQLite file, so flipping it
+once at boot lets the live server and a concurrent ``core.cli`` process write
+without hitting ``SQLITE_BUSY``. Both entrypoints (``core/main.py`` lifespan and
+``core/cli.py``) call :func:`ensure_wal` at startup. Python's default 5s busy
+timeout absorbs any residual contention — that is the entire concurrency story.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+def _data_dir() -> Path:
+    # Matches core/cli.py's heuristic: /app/data in Docker, ./data locally.
+    p = Path("/app/data")
+    return p if p.exists() else Path("data")
+
+
+def ensure_wal(data_dir: str | Path | None = None) -> None:
+    """Set ``journal_mode=WAL`` on every ``*.db`` in the data dir. Best-effort."""
+    d = Path(data_dir) if data_dir else _data_dir()
+    for db in sorted(d.glob("*.db")):
+        try:
+            with sqlite3.connect(db) as conn:
+                mode = conn.execute("PRAGMA journal_mode=WAL").fetchone()[0]
+            if mode.lower() != "wal":
+                log.warning("WAL not enabled for %s (mode=%s)", db.name, mode)
+        except sqlite3.Error:
+            log.exception("Could not enable WAL for %s", db)
+
+
+def _demo() -> None:  # ponytail: self-check, not a suite
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        p = Path(tmp) / "x.db"
+        sqlite3.connect(p).execute("CREATE TABLE t(a)")
+        ensure_wal(tmp)
+        mode = sqlite3.connect(p).execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal", mode
+    print("ok")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/humux/core/llm.py
+++ b/humux/core/llm.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 from anthropic import AsyncAnthropic
 
 # Dedicated logger for model chain-of-thought. Silent by default (WARNING);
-# the REPL bumps it to INFO to stream reasoning live without spamming server logs.
+# the CLI bumps it to INFO to stream reasoning live without spamming server logs.
 reasoning_log = logging.getLogger("core.llm.reasoning")
 reasoning_log.setLevel(logging.WARNING)
 

--- a/humux/core/log_streams.py
+++ b/humux/core/log_streams.py
@@ -43,7 +43,7 @@ def set_stream(name: str) -> None:
 
     Called once per turn after the agent is resolved. No reset: channels run
     each turn in its own ``asyncio`` task (so the value dies with the task), and
-    a reused task — the REPL — overwrites it at the next turn's entry anyway.
+    a reused task — the CLI — overwrites it at the next turn's entry anyway.
     """
     _stream.set(name or DEFAULT_STREAM)
 

--- a/humux/core/main.py
+++ b/humux/core/main.py
@@ -316,6 +316,11 @@ async def _lifespan(application):  # noqa: ANN001
     from dotenv import load_dotenv
 
     load_dotenv()
+    # WAL mode for every data/*.db so a concurrent core.cli process can write
+    # without SQLITE_BUSY (#168). Persistent file property; one-shot at boot.
+    from core.db import ensure_wal
+
+    ensure_wal()
     await _config_store.seed_if_empty()
     await _config_store.ensure_admin_password()
     # Initialise the agent vault's wrapped DEK when an admin password is set via

--- a/humux/core/scheduler.py
+++ b/humux/core/scheduler.py
@@ -90,15 +90,21 @@ async def run_agent_task(
 
         # Deliver the response to the target channel
         ch = agent.channels.get(channel)
+        # Deliver to the chat the job was scheduled in (#71); fall back to the
+        # owner's chat for jobs with no captured origin (pre-#71, config-seeded).
+        chat_id = origin_chat_id or _get_owner_chat_id(agent, channel)
+        if ch is None:
+            # Origin channel isn't registered here (e.g. a job scheduled from the
+            # cli/repl channel firing in the server) — deliver to the owner's
+            # Telegram DM instead of dropping it (#168).
+            ch, chat_id = _fallback_delivery(agent)
+            if ch:
+                log.info("Scheduler: channel %r not registered; delivering via Telegram", channel)
         if ch and response.text:
             text = response.text.replace("[NO_UPDATES]", "").strip()
             if silent_mode and not text:
                 log.info("Scheduler silent task produced no updates; skipping send")
                 return
-            # Deliver to the chat the job was scheduled in (#71); fall back to
-            # the owner's chat for jobs with no captured origin (pre-#71, CLI,
-            # config-seeded).
-            chat_id = origin_chat_id or _get_owner_chat_id(agent, channel)
             if chat_id:
                 await ch.send(chat_id, text or response.text)
             else:
@@ -148,6 +154,11 @@ async def run_subagent_task(
         )
         text = result.get("result") or result.get("error") or ""
         ch = agent.channels.get(channel)
+        if ch is None:
+            # cli/repl-origin job firing in the server: deliver to owner's DM (#168).
+            ch, target = _fallback_delivery(agent)
+            if ch:
+                log.info("Scheduler: channel %r not registered; delivering via Telegram", channel)
         if ch and text and target:
             await ch.send(target, text)
         elif not ch:
@@ -210,6 +221,22 @@ async def run_memory_consolidation() -> None:
         )
     except Exception:
         log.exception("Scheduler memory consolidation failed")
+
+
+def _fallback_delivery(agent: AgentCore) -> tuple[object, int | str | None]:
+    """Owner's Telegram channel + chat id, for jobs whose origin channel is gone.
+
+    A job scheduled from the ``cli`` channel (issue #168) — or a legacy ``repl``
+    one — fires in the server process where no such channel is registered.
+    Rather than drop its output silently, deliver it to the owner's Telegram DM:
+    the default agent's bare ``telegram`` bot if present, else the first
+    ``telegram:<agent>`` bot. Returns ``(None, None)`` if no Telegram bot runs.
+    """
+    for key in ("telegram", *(k for k in agent.channels if k.startswith("telegram:"))):
+        ch = agent.channels.get(key)
+        if ch:
+            return ch, _get_owner_chat_id(agent, key)
+    return None, None
 
 
 def _get_owner_chat_id(agent: AgentCore, channel: str) -> int | str | None:

--- a/humux/tests/test_db.py
+++ b/humux/tests/test_db.py
@@ -1,0 +1,22 @@
+"""Tests for core.db.ensure_wal (issue #168)."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from core.db import ensure_wal
+
+
+def test_ensure_wal_flips_all_dbs(tmp_path) -> None:
+    for name in ("history.db", "jobs.db"):
+        sqlite3.connect(tmp_path / name).execute("CREATE TABLE t(a)")
+
+    ensure_wal(tmp_path)
+
+    for name in ("history.db", "jobs.db"):
+        mode = sqlite3.connect(tmp_path / name).execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal", (name, mode)
+
+
+def test_ensure_wal_empty_dir_is_noop(tmp_path) -> None:
+    ensure_wal(tmp_path)  # no *.db files — must not raise

--- a/humux/tests/test_scheduler.py
+++ b/humux/tests/test_scheduler.py
@@ -202,6 +202,26 @@ async def test_run_agent_task_silent_no_updates() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_agent_task_cli_falls_back_to_telegram() -> None:
+    # Issue #168: a job scheduled from the CLI stores channel="cli", which the
+    # server has no channel for. Rather than drop it, deliver to the owner's
+    # Telegram DM — ignoring the cli origin chat id.
+    tg = AsyncMock()
+    tg.config = SimpleNamespace(allowed_user_ids=[7])
+    agent = SimpleNamespace(
+        channels={"telegram": tg},
+        process=AsyncMock(return_value=SimpleNamespace(text="done")),
+        config=SimpleNamespace(),
+        job_store=None,
+    )
+    set_agent_context(agent)
+
+    await run_agent_task("do thing", channel="cli", origin_chat_id="cli:2026-07-03-a1b2")
+
+    tg.send.assert_awaited_once_with(7, "done")  # owner DM, not the cli chat id
+
+
+@pytest.mark.asyncio
 async def test_run_agent_task_no_channel() -> None:
     """If the target channel is not registered, the response is dropped."""
     agent = SimpleNamespace(

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -396,19 +396,19 @@ def test_subagent_status_note_lists_only_running_runs(agent) -> None:
             run_id="r1",
             agent="coding-helper",
             task="t",
-            origin_channel="repl",
-            origin_chat_id="repl",
+            origin_channel="cli",
+            origin_chat_id="cli:s1",
             progress="step 2",
         )
     )
-    note = agent._subagent_status_note("repl", "repl")
+    note = agent._subagent_status_note("cli", "cli:s1")
     assert "r1" in note and "running" in note and "step 2" in note
     # Scoped to the chat: a different chat sees nothing.
-    assert agent._subagent_status_note("repl", "other-chat") == ""
+    assert agent._subagent_status_note("cli", "other-chat") == ""
 
     # Once finished it leaves the preamble (the agent synthesises a reply instead).
     agent.subagents.finish("r1", "done", result="the iPhone 17e is CHF 599")
-    assert agent._subagent_status_note("repl", "repl") == ""
+    assert agent._subagent_status_note("cli", "cli:s1") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/humux/tools/browser.py
+++ b/humux/tools/browser.py
@@ -93,7 +93,7 @@ def _preview_path(name: str) -> Path:
 
 
 def _status_path() -> Path:
-    # Live one-line progress for an in-flight `explore` run. The REPL spinner tails
+    # Live one-line progress for an in-flight `explore` run. The CLI spinner tails
     # this so the user sees step-by-step progress during the (multi-minute) loop.
     return _data_dir() / "browser" / "last" / "explore.status"
 
@@ -101,7 +101,7 @@ def _status_path() -> Path:
 def _shot_dir() -> Path:
     """Where saved screenshots go.
 
-    Local dev/REPL: ~/Downloads so you can open the file. Server/Docker (/app/data
+    Local dev/CLI: ~/Downloads so you can open the file. Server/Docker (/app/data
     present): the data volume instead — nobody browses the container's home, and
     Downloads isn't mounted, so a Downloads default would just bloat the container
     layer invisibly.


### PR DESCRIPTION
Closes #168.

Promotes the terminal REPL to a first-class **CLI channel** and makes it safe to run alongside the live server.

## What changed

### 1. WAL mode for all databases
`core/db.py:ensure_wal()` flips `journal_mode=WAL` on every `data/*.db` once at boot, called from both entrypoints (`core/main.py` lifespan, `core/cli.py`). WAL is a persistent file property; Python's default 5s busy timeout handles residual contention. This is the entire concurrency story — live server + CLI can now write concurrently without `SQLITE_BUSY`.

### 2. CLI sessions
Each run is a fresh session (its own chat row, `chat_id=cli:<id>`), printed at startup:
```
session: 2026-07-03-a1b2 (new · resume with --session 2026-07-03-a1b2)
```
- `--session NAME` — resume a previous session
- `--sessions` — list existing CLI sessions with last-activity
- `--rm-session NAME` — delete one

Reuses `ConversationHistory` (`list_chats`/`clear`) — no new store. In-prompt `/clear` still clears only the current session. Kept distinct from `history.mode == "session"` (the prompt-snapshot mode) in code and docs.

### 3. Scheduled-job fallback delivery
A job scheduled from the CLI stores `channel="cli"` and fires later in the server, where no `cli` channel exists. Instead of dropping it silently, the scheduler falls back to the owner's Telegram DM (default agent's `telegram` bot, else first `telegram:<slug>`). The same fallback covers legacy `repl`-origin jobs. `manage_jobs` now tells the user, at scheduling time, that a CLI-scheduled job's output arrives via Telegram.

### 4. Rename `repl` → `cli`
`core/repl.py` → `core/cli.py`, channel key `repl` → `cli`, `make repl` → `make cli`. No permission migration (rules are scoped by agent slug), no history migration (fresh-per-run sessions never read old `repl` rows).

### 5. Docs
`channels.mdx` gains a **CLI** section: remote access via host SSH + `docker exec`, a shell alias, `--agent`/`--yolo`, session flags, CLI-job Telegram delivery, and the two cross-process quirks (always-allow rules loaded once per process; config snapshotted at boot). README and `agents.mdx` updated.

## Acceptance criteria
- [x] `ssh -t user@host docker exec -it humux uv run python -m core.cli` yields a working CLI against live data while the server runs
- [x] All `data/*.db` in WAL after boot of either entrypoint; concurrent CLI + server produce no lock errors
- [x] Fresh session per run with printed id; `--session` resumes, `--sessions` lists, `--rm-session` deletes
- [x] A CLI-scheduled job delivers to the owner's Telegram DM and the user is told so at scheduling time
- [x] Everything user-facing says `cli`; no leftover `repl` references in code
- [x] Docs cover the CLI channel, remote invocation, and the two cross-process quirks
- [x] No new dependencies, listening ports, or docker-compose services

## Tests
- `tests/test_db.py` — `ensure_wal` flips all dbs / empty-dir no-op
- `tests/test_scheduler.py` — CLI-origin job falls back to owner Telegram DM
- Full suite green except a pre-existing `test_stop_turn` failure present on `origin/main` (unrelated).

## Notes / caveats
- On a brand-new install's *first* boot the data dir may be empty, so DBs created during that boot become WAL on the next restart — acceptable per the issue's boot-time one-shot design.

- **CLI-scheduled jobs activate on the server's next restart.** The CLI persists the job to `jobs.db` but does not notify the already-running server's scheduler (which loads jobs only at boot) — same two-process split as the always-allow/config quirks. A cron job then fires normally; a one-shot whose time has passed by that restart is retired without firing. The `manage_jobs` confirmation and the docs say so, and steer time-sensitive one-shots to Telegram. Live cross-process job registration would need IPC/polling — deliberately out of scope per the issue's acceptance of cross-process quirks.