### PR TITLE
chore(www): bump version fallback to v0.17

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -102,7 +102,7 @@
       <div class="mb-4 inline-flex items-center gap-2 rounded-full border px-4 py-1 text-xs"
         style="border-color: var(--color-accent-dim); background: var(--color-accent-glow); color: var(--color-accent);">
         <span class="inline-block h-1.5 w-1.5 rounded-full" style="background: var(--color-accent);"></span>
-        <span id="version-tag">v0.15</span> &mdash; Self-hosted &bull; Open source
+        <span id="version-tag">v0.17</span> &mdash; Self-hosted &bull; Open source
       </div>
 
       <h1 class="mx-auto mb-6 max-w-3xl text-4xl font-bold leading-tight sm:text-5xl md:text-6xl" style="color: #eee;">


### PR DESCRIPTION
Updates the hardcoded version fallback in index.html from v0.15 to v0.17. The auto-fetch from GitHub API remains the primary source — this is just the fallback shown before the JS executes.