### PR TITLE
fix(www): remove clean-url redirects conflicting with Cloudflare zone rules

### DIFF
--- a/www/.cloudflareignore
+++ b/www/.cloudflareignore
@@ -1,1 +1,0 @@
-tailwindcss

--- a/www/_redirects
+++ b/www/_redirects
@@ -1,8 +1,3 @@
-# Clean URL rewrites (internal, no redirect)
-/features /features.html 200
-/use-cases /use-cases.html 200
-/comparison /comparison.html 200
-
 # External redirects
 /docs/*  https://docs.humux.dev/:splat  301
 /github  https://github.com/mattmezza/humux  301


### PR DESCRIPTION
The `_redirects` file had rules rewriting/redirecting `/features` → `/features.html` and vice versa. But Cloudflare zone already has a built-in rule that:
- strips `.html` extensions (308 redirect)
- serves the clean URL (`/features`) with 200 OK

The `_redirects` rules conflicted with this, creating a redirect loop.

**Fix:** Remove the clean-URL `_redirects` rules entirely. The zone handles them natively, and all internal links already use `/features.html` directly. External redirects (`/docs`, `/github`, etc.) are unaffected.
