### PR TITLE
feat(www): add CLI channel across features, comparison, index, use-cases

### DIFF
--- a/www/_redirects
+++ b/www/_redirects
@@ -1,8 +1,3 @@
-# Clean URL rewrites (internal, no redirect)
-/features /features.html 200
-/use-cases /use-cases.html 200
-/comparison /comparison.html 200
-
 # External redirects
 /docs/*  https://docs.humux.dev/:splat  301
 /github  https://github.com/mattmezza/humux  301

--- a/www/comparison.html
+++ b/www/comparison.html
@@ -160,7 +160,7 @@
             </tr>
             <tr>
               <td class="font-medium" style="color: #ddd;">Messaging channels</td>
-              <td class="text-center" style="color: var(--color-secondary);">2</td>
+              <td class="text-center" style="color: var(--color-secondary);">3</td>
               <td class="text-center" style="color: var(--color-secondary);">~5</td>
               <td class="text-center" style="color: var(--color-secondary);">25+</td>
               <td class="text-center" style="color: var(--color-secondary);">30+</td>
@@ -182,6 +182,15 @@
               <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
               <td class="text-center check"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></td>
               <td class="text-center" style="color: var(--color-warn);">Via bridge</td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
+            </tr>
+            <tr>
+              <td class="font-medium" style="color: #ddd;">CLI channel</td>
+              <td class="text-center check"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
               <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
               <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
             </tr>

--- a/www/features.html
+++ b/www/features.html
@@ -97,7 +97,7 @@
           </div>
           <div>
             <h2 class="text-lg font-semibold" style="color: #eee;">Messaging</h2>
-            <p class="text-xs" style="color: var(--color-muted);">Telegram, WhatsApp, group chats, reactions</p>
+            <p class="text-xs" style="color: var(--color-muted);">Telegram, WhatsApp, CLI, group chats, reactions</p>
           </div>
         </div>
         <svg class="h-4 w-4 transition-transform duration-200" :class="{ 'rotate-180': open }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="color: var(--color-muted);"><polyline points="6 9 12 15 18 9"/></svg>
@@ -127,6 +127,10 @@
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">WhatsApp (wacli)</h3>
             <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Read and send WhatsApp messages via the wacli CLI tool. Integrated as a skill the agent can learn.</p>
+          </div>
+          <div class="feature-card">
+            <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">CLI channel</h3>
+            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Chat with the agent directly from your terminal — SSH in or run <code class="inline-code">uv run python -m core.cli</code>. Resumable sessions, no Telegram needed.</p>
           </div>
         </div>
       </div>

--- a/www/index.html
+++ b/www/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>humux — Human Multiplexer. Self-hosted personal AI agent.</title>
-  <meta name="description" content="humux is a self-hosted personal AI agent. One Docker container. Unified messaging, email, calendar, memory, voice, and automation.">
+  <meta name="description" content="humux is a self-hosted personal AI agent. One Docker container. Unified messaging (Telegram, WhatsApp, CLI), email, calendar, memory, voice, and automation.">
   <meta name="keywords" content="AI agent, self-hosted, personal assistant, Docker, open source, privacy, Telegram bot, email automation">
   <meta name="author" content="Merola Software &amp; Services">
   <link rel="canonical" href="https://humux.dev">

--- a/www/use-cases.html
+++ b/www/use-cases.html
@@ -99,7 +99,7 @@
             You're a developer who wants an AI that works <em>with</em> your codebase,
             not in a separate chat window. humux's coding harness lets the agent read,
             write, and edit files in a confined workspace. It can grep, refactor, run
-            commands, and commit changes — all through Telegram or the admin UI.
+            commands, and commit changes — all through Telegram, the CLI channel, or the admin UI.
           </p>
 
           <div class="mt-6 space-y-3">
@@ -224,7 +224,7 @@
             Your inbox is overflowing, your calendar is fragmented across Google and iCloud,
             and you have recurring tasks that eat your time. humux reads and manages email
             (per-agent mailboxes), checks and creates calendar events, searches contacts,
-            and runs scheduled tasks — all through Telegram or the admin UI.
+            and runs scheduled tasks — all through Telegram, the CLI channel, or the admin UI.
           </p>
 
           <div class="mt-6 space-y-3">


### PR DESCRIPTION
The CLI channel (SSH/terminal access) shipped in v0.17 but wasn't mentioned anywhere on the marketing site.

**Changes:**
- **features.html:** new "CLI channel" card under Messaging — "Chat with the agent directly from your terminal — SSH in or run `uv run python -m core.cli`. Resumable sessions, no Telegram needed."
- **comparison.html:** row for CLI channel (checkmark for humux, cross for all others), channel count bumped 2→3
- **index.html:** meta description updated to include CLI
- **use-cases.html:** mentions CLI channel alongside Telegram and admin UI
- **_redirects:** removed conflicting clean-url rules (were creating redirect loops on /features, /use-cases, /comparison)