### PR TITLE
Fix false 'user skipped' when approval prompt is undeliverable

### DIFF
--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -201,6 +201,19 @@ def _truncate_approval(text: str) -> str:
     return text if len(text) <= _APPROVAL_TEXT_CAP else text[: _APPROVAL_TEXT_CAP - 1] + "…"
 
 
+# When the approval prompt can't be delivered we fail closed (skip the action),
+# but the user never saw it — so the model must NOT be told "user skipped", or
+# it wrongly concludes the owner is stepping in and replies to a phantom.
+_UNDELIVERABLE_ERROR = {
+    "error": (
+        "The approval prompt could not be delivered to the user (channel/delivery "
+        "error). The user did NOT see this request and did NOT skip or intervene. "
+        "Do not retry the same action; if it matters, say you couldn't reach the "
+        "user for approval."
+    )
+}
+
+
 def strip_voice_marker(text: str) -> str:
     """Remove the voice control marker (bare or with a ``:lang`` suffix) so it
     never leaks into a user-visible reply."""
@@ -2445,6 +2458,8 @@ class AgentCore:
             }
         if is_write_action and write_decisions.get(write_sig) == "denied":
             return {"error": "Action denied by user."}
+        if is_write_action and write_decisions.get(write_sig) == "undeliverable":
+            return _UNDELIVERABLE_ERROR
         if is_write_action and write_decisions.get(write_sig) == "skipped":
             return {
                 "error": (
@@ -2488,6 +2503,9 @@ class AgentCore:
                 elif isinstance(approvals, dict):
                     approvals[match_key] = decision
                     request_state["approvals"] = approvals
+            if decision == "undeliverable":
+                log.warning("Permission UNDELIVERABLE (fail-closed): %s", name)
+                return _UNDELIVERABLE_ERROR
             if decision == "skipped":
                 log.info("Permission SKIPPED by user: %s", name)
                 return {
@@ -4233,7 +4251,7 @@ class AgentCore:
                 # request and skip the action.
                 log.exception("Approval request undeliverable; skipping action (fail-closed)")
                 self.permissions._pending.pop(request_id, None)
-                return "skipped"
+                return "undeliverable"
 
         # Wait for the user's response (timeout after 2 minutes)
         try:

--- a/humux/tests/test_tools.py
+++ b/humux/tests/test_tools.py
@@ -996,7 +996,7 @@ async def test_undeliverable_approval_fails_closed(agent) -> None:
     ch = _FailingChannel()
     agent.channels = {"tg": ch}
     result = await agent._await_approval("Run command: " + "x" * 9000, "tg", "user1")
-    assert result == "skipped"
+    assert result == "undeliverable"  # distinct from a real user skip (#stepping-in bug)
     assert len(ch.calls) == 2  # original send + one truncated retry
     assert len(ch.calls[1]) <= 3500  # the retry was truncated to fit
     assert not agent.permissions._pending  # pending request dropped, no leak

--- a/humux/uv.lock
+++ b/humux/uv.lock
@@ -698,7 +698,7 @@ wheels = [
 
 [[package]]
 name = "humux"
-version = "0.16.0"
+version = "0.17.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Problem

When an approval prompt can't be delivered to the user (channel/delivery error, e.g. Telegram send raises), the gate fails closed and skips the action — correct. But it returned `"skipped"`, **identical to a genuine user skip**.

The model then received the error *"User skipped this action"*, concluded the owner was stepping in, and replied to a message the user never sent:

```
Approval request undeliverable; skipping action (fail-closed)
Permission SKIPPED by user: run_command
Response: Looks like you're stepping in. What did you want to do differently?
```

The user neither saw the approval prompt nor sent anything.

## Fix

Return a distinct `"undeliverable"` sentinel (separate from `"skipped"`) with an honest error telling the model the user **never saw the request and did NOT skip or intervene**. Handled at both the per-call and batch-write dispatch sites.

Timeout still maps to `"skipped"` (user genuinely didn't act). Out of scope: the underlying transport failure that made delivery fail in the first place — needs the send traceback.

## Test

`test_undeliverable_approval_fails_closed` updated to assert the new sentinel. Passing.