### PR TITLE
Fix: resolve DB/seed paths against script location, not CWD (#180)

### DIFF
--- a/humux/tools/calendar_auth.py
+++ b/humux/tools/calendar_auth.py
@@ -9,6 +9,7 @@ Non-Google CalDAV providers still use Basic Auth (username/password).
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import sqlite3
 import sys
 import time
@@ -17,7 +18,13 @@ import caldav
 import requests
 
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
-CONFIG_DB_PATH = "data/config.db"
+
+# Resolve relative to script location, not CWD (see issue #180).
+_ROOT = Path(__file__).resolve().parent.parent
+if Path("/app/data").exists():
+    CONFIG_DB_PATH = "/app/data/config.db"
+else:
+    CONFIG_DB_PATH = str(_ROOT / "data/config.db")
 TOKEN_DB_KEY = "calendar.google_oauth_token"
 
 # In-memory cache: (access_token, expiry_timestamp)

--- a/humux/tools/contacts.py
+++ b/humux/tools/contacts.py
@@ -20,13 +20,14 @@ import vobject
 import yaml
 from dotenv import load_dotenv
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Resolve relative to script location, not CWD (see issue #180).
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT))
 from core.config import _resolve_env_vars  # noqa: E402
 from tools.contacts_auth import get_google_access_token  # noqa: E402
 
-# Resolve relative to script location, not CWD (see issue #180).
-_ROOT = Path(__file__).resolve().parent.parent
 _DEFAULT_CONFIG_DB = str(_ROOT / "data/config.db")
+_DEFAULT_CONFIG = str(_ROOT / "config.yml")
 
 
 def _load_contacts_providers_from_db(db_path: str) -> dict[str, dict]:
@@ -50,7 +51,7 @@ def _load_contacts_providers_from_db(db_path: str) -> dict[str, dict]:
 
 
 def _load_contacts_providers(
-    config_path: str = "config.yml", db_path: str = _DEFAULT_CONFIG_DB
+    config_path: str = _DEFAULT_CONFIG, db_path: str = _DEFAULT_CONFIG_DB
 ) -> dict[str, dict]:
     providers = _load_contacts_providers_from_db(db_path)
     if providers:
@@ -334,7 +335,7 @@ def _is_google(provider: dict) -> bool:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Contacts CLI")
-    parser.add_argument("--config", default="config.yml", help="Path to config.yml")
+    parser.add_argument("--config", default=_DEFAULT_CONFIG, help="Path to config.yml")
     parser.add_argument("--db", default=_DEFAULT_CONFIG_DB, help="Path to config DB")
     sub = parser.add_subparsers(dest="cmd", required=True)
 

--- a/humux/tools/contacts.py
+++ b/humux/tools/contacts.py
@@ -24,6 +24,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from core.config import _resolve_env_vars  # noqa: E402
 from tools.contacts_auth import get_google_access_token  # noqa: E402
 
+# Resolve relative to script location, not CWD (see issue #180).
+_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_CONFIG_DB = str(_ROOT / "data/config.db")
+
 
 def _load_contacts_providers_from_db(db_path: str) -> dict[str, dict]:
     try:
@@ -46,7 +50,7 @@ def _load_contacts_providers_from_db(db_path: str) -> dict[str, dict]:
 
 
 def _load_contacts_providers(
-    config_path: str = "config.yml", db_path: str = "data/config.db"
+    config_path: str = "config.yml", db_path: str = _DEFAULT_CONFIG_DB
 ) -> dict[str, dict]:
     providers = _load_contacts_providers_from_db(db_path)
     if providers:
@@ -331,7 +335,7 @@ def _is_google(provider: dict) -> bool:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Contacts CLI")
     parser.add_argument("--config", default="config.yml", help="Path to config.yml")
-    parser.add_argument("--db", default="data/config.db", help="Path to config DB")
+    parser.add_argument("--db", default=_DEFAULT_CONFIG_DB, help="Path to config DB")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     list_cmd = sub.add_parser("list", help="List all contacts")

--- a/humux/tools/contacts_auth.py
+++ b/humux/tools/contacts_auth.py
@@ -6,11 +6,18 @@ import json
 import sqlite3
 import sys
 import time
+from pathlib import Path
 
 import requests
 
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
-CONFIG_DB_PATH = "data/config.db"
+
+# Resolve relative to script location, not CWD (see issue #180).
+_ROOT = Path(__file__).resolve().parent.parent
+if Path("/app/data").exists():
+    CONFIG_DB_PATH = "/app/data/config.db"
+else:
+    CONFIG_DB_PATH = str(_ROOT / "data/config.db")
 TOKEN_DB_KEY = "contacts.google_oauth_token"
 
 _token_cache: tuple[str, float] | None = None

--- a/humux/tools/google_oauth.py
+++ b/humux/tools/google_oauth.py
@@ -34,7 +34,12 @@ SCOPES = ["https://www.googleapis.com/auth/calendar"]
 REDIRECT_PORT = 8085
 REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}"
 
-CONFIG_DB_PATH = "data/config.db"
+# Resolve relative to script location, not CWD (see issue #180).
+_ROOT = Path(__file__).resolve().parent.parent
+if Path("/app/data").exists():
+    CONFIG_DB_PATH = "/app/data/config.db"
+else:
+    CONFIG_DB_PATH = str(_ROOT / "data/config.db")
 TOKEN_DB_KEY = "calendar.google_oauth_token"
 
 

--- a/humux/tools/jobs.py
+++ b/humux/tools/jobs.py
@@ -26,10 +26,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from core.job_store import VALID_STATUSES, VALID_TYPES, JobStore  # noqa: E402
 
-DB_PATH = "data/jobs.db"
-# Also check the Docker path
+# Resolve relative to script location, not CWD (see issue #180).
+_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_DB = str(_ROOT / "data/jobs.db")
 if Path("/app/data").exists():
     DB_PATH = "/app/data/jobs.db"
+else:
+    DB_PATH = _DEFAULT_DB
 
 
 def _get_store() -> JobStore:

--- a/humux/tools/skills.py
+++ b/humux/tools/skills.py
@@ -23,17 +23,22 @@ from core.skills import SkillsStore  # noqa: E402
 
 NAME_PATTERN = re.compile(r"^[a-z0-9-]+$")
 
+# Resolve paths relative to this script's location, not CWD (which is the
+# workspace when run via bash). This ensures the CLI always finds the correct
+# DB and seed dir regardless of the calling context.  See issue #180.
+_ROOT = Path(__file__).resolve().parent.parent
+
 
 def _default_db_path() -> str:
     if Path("/app/data").exists():
         return "/app/data/skills.db"
-    return "data/skills.db"
+    return str(_ROOT / "data/skills.db")
 
 
 def _default_seed_dir() -> str:
     if Path("/app/skills").exists():
         return "/app/skills"
-    return "skills"
+    return str(_ROOT / "skills")
 
 
 def _validate_name(name: str) -> str:


### PR DESCRIPTION
## Summary

Fixes #180 — CLI tools (`skills.py`, `jobs.py`, `contacts.py`) hardcoded relative paths like `data/skills.db` that resolved against the **current working directory**. When run via `bash` in the agent runtime, CWD is the workspace (e.g. `/tmp/mpa-workspace/`), so they'd create/look for DBs in the wrong place — a fresh empty DB instead of the real one, causing "Skill not found" errors.

## Fix

Compute `_ROOT` from `Path(__file__).resolve().parent.parent` (the project root) at module load time and join paths from there. Docker paths under `/app/` are checked first and take precedence, preserving container behaviour.

## Files changed

| File | What changed |
|------|-------------|
| `tools/skills.py` | `_default_db_path()`, `_default_seed_dir()` — now use `_ROOT / "data/skills.db"` and `_ROOT / "skills"` |
| `tools/jobs.py` | `DB_PATH` — now uses `_ROOT / "data/jobs.db"` |
| `tools/contacts.py` | Default `--db` arg and function signature — now use `_ROOT / "data/config.db"` |
| `tools/calendar_auth.py` | `CONFIG_DB_PATH` — now resolves via `_ROOT` + Docker fallback |
| `tools/contacts_auth.py` | `CONFIG_DB_PATH` — same fix, also added missing `from pathlib import Path` |
| `tools/google_oauth.py` | `CONFIG_DB_PATH` — same fix |

## Testing

- [x] Each path falls back to `/app/...` when inside Docker (`/app/data` exists)
- [x] Outside Docker, paths are anchored to the script's location, not CWD
- [x] `db_path` CLI flags (`--db`, `--seed-dir`) still override defaults explicitly
