### PR TITLE
fix(core): replace non-existent -o json with --json <fields> in gh tool prompt (#181)

### DIFF
--- a/humux/core/tools.py
+++ b/humux/core/tools.py
@@ -39,7 +39,7 @@ Examples:
   gh api repos/owner/name/commits
   gh search issues "is:open label:bug" --repo owner/name
 Always pass `--repo owner/name` unless the working directory is a checkout of the
-target repository. Use `-o json` / `gh api` and parse JSON when you need fields.
+target repository. Use `--json <fields>` (e.g. `gh issue list --json number,title,labels`) or `gh api` and parse JSON when you need fields.
 Single-quote issue/PR bodies that contain Markdown (`--body '…```code```…'`):
 single quotes make backticks and `$(…)` literal so the command guard keeps them
 and the shell doesn't run them; double quotes leave them live and get rejected.


### PR DESCRIPTION
## Problem

The gh tool advertisement taught the model to use `-o json`, which does not exist on `gh issue list` / `gh pr list` subcommands. Every JSON-shaped gh call wastes a round-trip: the model tries `-o json`, fails, then retries with `--json`.

## Solution

Replaced `-o json` with `--json <fields>` and added a concrete example (`gh issue list --json number,title,labels`) so the model gets it right first time.

## Acceptance criteria

- [x] `_GH_PROMPT` in `core/tools.py` no longer mentions `-o json`
- [x] `--json <fields>` syntax is documented with an example
- [x] Existing `gh api` reference is preserved

Closes #181