### PR TITLE
feat(#188): unify scheduled-job lifecycle into a single manage_jobs tool

### DIFF
--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -619,26 +619,27 @@ TOOLS = [
     {
         "name": "manage_jobs",
         "description": (
-            "Create, list, or cancel scheduled jobs. "
-            "Use action='create' to schedule a one-time or recurring task. "
-            "Use action='list' to see all active jobs. "
-            "Use action='cancel' to stop a job from running."
+            "Manage the full lifecycle of scheduled jobs. "
+            "action='create' schedules a one-time or recurring task. "
+            "action='list' shows jobs (active by default). "
+            "action='get' returns one job. "
+            "action='update' edits a job's fields; set status='paused' to pause "
+            "or status='active' to resume. "
+            "action='cancel' permanently stops a job."
         ),
         "input_schema": {
             "type": "object",
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["create", "list", "cancel"],
-                    "description": (
-                        "What to do: create a new job, list existing jobs, or cancel a job"
-                    ),
+                    "enum": ["create", "list", "get", "update", "cancel"],
+                    "description": ("create, list, get, update, or cancel a job"),
                 },
                 "job_id": {
                     "type": "string",
                     "description": (
                         "For create: a short unique identifier (lowercase, dashes ok). "
-                        "For cancel: the ID of the job to cancel."
+                        "For get/update/cancel: the ID of the target job."
                     ),
                 },
                 "task": {
@@ -670,6 +671,22 @@ TOOLS = [
                 "description": {
                     "type": "string",
                     "description": "Short human-readable description of this job",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["active", "paused"],
+                    "description": (
+                        "update only: 'paused' halts the job without deleting it; "
+                        "'active' resumes it."
+                    ),
+                },
+                "filter_status": {
+                    "type": "string",
+                    "description": "list only: only return jobs with this status.",
+                },
+                "include_done": {
+                    "type": "boolean",
+                    "description": "list only: also include done/cancelled jobs.",
                 },
             },
             "required": ["action"],
@@ -3178,26 +3195,93 @@ class AgentCore:
         """
         action = params.get("action", "")
 
-        if action == "list":
-            jobs = await self.job_store.list_jobs()
+        def _view(j: dict) -> dict:
             return {
-                "ok": True,
-                "jobs": [
-                    {
-                        "id": j["id"],
-                        "type": j["type"],
-                        "schedule": j["schedule"],
-                        "cron": j.get("cron"),
-                        "run_at": j.get("run_at"),
-                        "task": j["task"],
-                        "channel": j["channel"],
-                        "status": j["status"],
-                        "description": j.get("description", ""),
-                        "created_by": j.get("created_by", ""),
-                    }
-                    for j in jobs
-                ],
+                "id": j["id"],
+                "type": j["type"],
+                "schedule": j["schedule"],
+                "cron": j.get("cron"),
+                "run_at": j.get("run_at"),
+                "task": j["task"],
+                "channel": j["channel"],
+                "status": j["status"],
+                "description": j.get("description", ""),
+                "created_by": j.get("created_by", ""),
             }
+
+        if action == "list":
+            jobs = await self.job_store.list_jobs(
+                status=params.get("filter_status"),
+                include_done=bool(params.get("include_done")),
+            )
+            return {"ok": True, "jobs": [_view(j) for j in jobs]}
+
+        if action == "get":
+            job_id = params.get("job_id", "").strip()
+            if not job_id:
+                return {"error": "Missing job_id for get action."}
+            job = await self.job_store.get_job(job_id)
+            if not job:
+                return {"error": f"Job not found: {job_id}"}
+            return {"ok": True, "job": _view(job)}
+
+        if action == "update":
+            job_id = params.get("job_id", "").strip()
+            if not job_id:
+                return {"error": "Missing job_id for update action."}
+            existing = await self.job_store.get_job(job_id)
+            if not existing:
+                return {"error": f"Job not found: {job_id}"}
+
+            status = params.get("status")
+            if status is not None and status not in ("active", "paused"):
+                return {"error": "status must be 'active' or 'paused'."}
+
+            cron_expr = params.get("cron")
+            run_at_str = params.get("run_at")
+            if cron_expr and run_at_str:
+                return {"error": "Specify only one of 'cron' or 'run_at'."}
+
+            schedule = existing["schedule"]
+            new_cron = existing.get("cron")
+            new_run_at = existing.get("run_at")
+            if cron_expr:
+                from core.scheduler import _parse_cron
+
+                try:
+                    _parse_cron(cron_expr)
+                except ValueError as exc:
+                    return {"error": str(exc)}
+                schedule, new_cron, new_run_at = "cron", cron_expr, None
+            elif run_at_str:
+                try:
+                    run_at = datetime.fromisoformat(run_at_str)
+                except ValueError:
+                    return {"error": f"Invalid datetime format: {run_at_str!r}. Use ISO format."}
+                if run_at.tzinfo is None:
+                    run_at = run_at.replace(tzinfo=ZoneInfo(self.config.agent.timezone))
+                schedule, new_run_at, new_cron = "once", run_at.isoformat(), None
+
+            task = params.get("task")
+            channel = params.get("channel")
+            description = params.get("description")
+            # Omit agent/origin_* so upsert's COALESCE keeps the captured routing (#71).
+            await self.job_store.upsert_job(
+                job_id=job_id,
+                type="agent",
+                schedule=schedule,
+                cron=new_cron,
+                run_at=new_run_at,
+                task=task if task is not None else existing["task"],
+                channel=channel if channel is not None else existing["channel"],
+                status=status if status is not None else existing["status"],
+                description=(
+                    description if description is not None else existing.get("description", "")
+                ),
+            )
+            await self.scheduler.sync_job(job_id)
+            updated = await self.job_store.get_job(job_id)
+            return {"ok": True, "job": _view(updated)}
 
         if action == "cancel":
             job_id = params.get("job_id", "").strip()
@@ -3341,7 +3425,11 @@ class AgentCore:
             else:
                 return {"error": "Must specify 'cron' for recurring or 'run_at' for one-time jobs."}
 
-        return {"error": f"Unknown action: {action!r}. Use 'create', 'list', or 'cancel'."}
+        return {
+            "error": (
+                f"Unknown action: {action!r}. Use 'create', 'list', 'get', 'update', or 'cancel'."
+            )
+        }
 
     async def _tool_remember(self, params: dict, request_state: dict | None = None) -> dict:
         """Save a long-term memory via the structured store (#13).

--- a/humux/core/permissions.py
+++ b/humux/core/permissions.py
@@ -745,11 +745,18 @@ def format_approval_message(tool_name: str, params: dict) -> str:
             run_at = params.get("run_at")
             schedule = f"cron: {cron}" if cron else f"once at {run_at}" if run_at else "?"
             return f"Create scheduled job ({schedule})\n{task}"
+        if action == "update":
+            job_id = params.get("job_id", "?")
+            status = params.get("status")
+            verb = {"paused": "Pause", "active": "Resume"}.get(status, "Update")
+            return f"{verb} scheduled job: {job_id}"
         if action == "cancel":
             job_id = params.get("job_id", "?")
             return f"Cancel scheduled job: {job_id}"
+        if action == "get":
+            return f"Get scheduled job: {params.get('job_id', '?')}"
         if action == "list":
-            return "List all scheduled jobs"
+            return "List scheduled jobs"
         return f"Manage jobs: {action}"
     if tool_name == "bash":
         cmd = _preview(params.get("command", "?"))

--- a/humux/core/prompt_builder.py
+++ b/humux/core/prompt_builder.py
@@ -33,7 +33,7 @@ emails, messages, calendar events, scheduled jobs — ALWAYS use that tool (`sen
 those actions via `bash`.
 
 Use `bash` for everything else on the CLI: read/query operations, CLI writes with no
-structured tool (`gh`, `git`, `jobs.py`, `browser.py`), and file listing/searching/
+structured tool (`gh`, `git`, `browser.py`), and file listing/searching/
 builds/tests in the workspace. It is permission-gated: documented read commands run
 without asking; anything acting outwardly asks the owner first. If a command is blocked,
 read the error and adjust — don't retry it unchanged.

--- a/humux/tests/test_tools.py
+++ b/humux/tests/test_tools.py
@@ -619,6 +619,54 @@ async def test_reupsert_without_origin_keeps_it(agent, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_manage_jobs_lifecycle(agent, monkeypatch) -> None:
+    """Issue #188: the tool covers the whole lifecycle — create → update (retask
+    + pause) → get reflects the change and keeps origin → cancel — so the agent
+    never needs the origin-dropping jobs.py CLI."""
+    monkeypatch.setattr(agent.scheduler, "sync_job", _no_sync)
+    state = {
+        "origin": {"channel": "telegram:coach", "user_id": "u7", "chat_id": "-100200:5"},
+        "agent_name": "coach",
+    }
+    res = await agent._tool_manage_jobs(
+        {
+            "action": "create",
+            "job_id": "brief",
+            "task": "morning brief",
+            "cron": "0 7 * * *",
+        },
+        state,
+    )
+    assert res.get("ok") is True
+
+    upd = await agent._tool_manage_jobs(
+        {"action": "update", "job_id": "brief", "task": "evening brief", "status": "paused"}
+    )
+    assert upd["job"]["task"] == "evening brief"
+    assert upd["job"]["status"] == "paused"
+
+    got = await agent._tool_manage_jobs({"action": "get", "job_id": "brief"})
+    assert got["job"]["task"] == "evening brief"
+    assert got["job"]["status"] == "paused"
+    stored = await agent.job_store.get_job("brief")
+    assert stored["agent"] == "coach"  # origin survived the update (#71)
+    assert stored["origin_chat_id"] == "-100200:5"
+
+    # update with no origin re-passed must not wipe routing; resume works
+    await agent._tool_manage_jobs({"action": "update", "job_id": "brief", "status": "active"})
+    stored = await agent.job_store.get_job("brief")
+    assert stored["status"] == "active"
+    assert stored["agent"] == "coach"
+
+    # get/update on a missing id 404s
+    miss = await agent._tool_manage_jobs({"action": "get", "job_id": "nope"})
+    assert "not found" in miss.get("error", "").lower()
+
+    cancelled = await agent._tool_manage_jobs({"action": "cancel", "job_id": "brief"})
+    assert cancelled.get("ok") is True
+
+
+@pytest.mark.asyncio
 async def test_cancelled_job_id_can_be_recreated(agent, monkeypatch) -> None:
     """A done/cancelled id is free to recreate (only live ids block)."""
     monkeypatch.setattr(agent, "_request_approval", _approve)

--- a/humux/uv.lock
+++ b/humux/uv.lock
@@ -698,7 +698,7 @@ wheels = [
 
 [[package]]
 name = "humux"
-version = "0.18.0"
+version = "0.20.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Closes #188.

## What

`manage_jobs` now covers the full scheduled-job lifecycle, so the agent has **one** correctly-routed write path and no longer needs the origin-dropping `jobs.py` CLI. Five actions:

| action | behavior |
|--------|----------|
| `create` | unchanged (already captures origin per #71) |
| `list` | now threads `filter_status` + `include_done` |
| `get` | **new** — returns one job or not-found |
| `update` | **new** — apply only provided fields; `status=paused\|active` is pause/resume |
| `cancel` | unchanged (soft, keeps its tailored permission preview) |

## Why the routing bug is fixed

`update` re-upserts **omitting** `agent`/`origin_*`, so `upsert_job`'s `COALESCE(NULLIF(...))` (sticky since #71) preserves the captured agent + chat. Editing or pausing a chat-scheduled reminder no longer silently reroutes it to the owner's DM under the default identity.

`core/prompt_builder.py`: dropped `jobs.py` from the bash-writes list — the contradictory ¶1/¶2 instructions are resolved; the tool is the only documented agent write path. `jobs.py` stays on disk as a human ops CLI.

## Scope decisions (from the issue)

- **hard delete** — omitted; `cancel` already stops a job, purging history is an ops concern. Add later only if cancelled jobs pile up.
- **pause/resume** — folded into `update status`, no redundant actions.
- **reply-threading fold-in** — deferred to a follow-up: it needs a new sticky `message_id` column + schema migration + a scheduler send change (not cheap). "Same chat" already works; "quoted reply" is the follow-up.

## Tests

`tests/test_tools.py::test_manage_jobs_lifecycle`: create → update (retask + pause) → get reflects change and origin survives → resume keeps routing → get/update 404 on missing id → cancel. Full `test_tools.py` + `test_permissions.py` green (84 passed).