### PR TITLE
fix(#183): reply in the forum topic that triggered the agent

### DIFF
--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -90,6 +90,9 @@ group or supergroup each bot then:
 
 A few details worth knowing:
 
+- **Forum topics** — in a group with topics enabled, each topic is its own conversation:
+  the agent keeps separate context per topic and always replies in the topic that
+  triggered it (the General topic behaves like the plain group chat).
 - **Clearing context** — in a group, clear a specific bot with `/new@botname` (a bare
   `/new` is not addressed to any one bot, so it's recorded as context, not a clear).
 - **Stopping a turn** — press **⛔ Stop** on any approval prompt, or send `/stop`, to abort

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -184,19 +184,31 @@ class TelegramChannel:
 
     # -- Context id helpers --------------------------------------------------
 
-    def _fold(self, chat) -> int | str | None:
+    def _fold(self, chat, message=None) -> int | str | None:
         """The context id for a chat — its id, or ``None`` when there is no chat
-        (the caller falls back to the sender's user id)."""
-        return chat.id if chat else None
+        (the caller falls back to the sender's user id).
+
+        A message in a forum topic folds to ``"<chat>:<thread>"`` (#183) so each
+        topic is its own conversation and the reply routes back to that topic
+        (``_route`` splits the id into chat + ``message_thread_id``). The General
+        topic has ``is_topic_message`` unset, so it keeps the bare chat id —
+        same as before forums, and same as every non-forum chat.
+        """
+        if not chat:
+            return None
+        thread = getattr(message, "message_thread_id", None)
+        if thread and getattr(message, "is_topic_message", False):
+            return f"{chat.id}:{thread}"
+        return chat.id
 
     @staticmethod
     def _route(chat_id: int | str) -> tuple[int | str, dict]:
-        """Split a legacy folded ``"<chat>:<thread>"`` id for the Bot API.
+        """Split a folded ``"<chat>:<thread>"`` id for the Bot API.
 
-        Forum topics were dropped (#133), so new ids are never folded — but a chat
-        id stored while topics were on can still be ``"<chat>:<thread>"``, so this
-        stays to route it. Returns ``(chat_id, kwargs)`` where kwargs carries
-        ``message_thread_id`` when a thread is encoded, else empty (unchanged).
+        ``_fold`` encodes a forum-topic message as ``"<chat>:<thread>"`` (#183);
+        this splits it back so the reply lands in that topic. Returns
+        ``(chat_id, kwargs)`` where kwargs carries ``message_thread_id`` when a
+        thread is encoded, else empty (unchanged).
         """
         base, sep, thread = str(chat_id).partition(":")
         if sep and thread.isdigit() and base.lstrip("-").isdigit():
@@ -455,7 +467,7 @@ class TelegramChannel:
         if not user or not message:
             return
         sender_id = user.id
-        folded = self._fold(chat)
+        folded = self._fold(chat, message)
         routing = self._turn_routing(update, message, context)
         convo_user = routing["user_id"]
         self._remember_chat(convo_user, folded)
@@ -503,7 +515,10 @@ class TelegramChannel:
             ):
                 asyncio.create_task(
                     self._handle_skill_command(
-                        base.lower()[len("/zz_skill_") :], convo_user, str(chat_id), message.message_id
+                        base.lower()[len("/zz_skill_") :],
+                        convo_user,
+                        str(chat_id),
+                        message.message_id,
                     ),
                     name=f"tg-skill-{convo_user}",
                 )
@@ -539,7 +554,7 @@ class TelegramChannel:
         if not user or not message:
             return
         sender_id = user.id
-        folded = self._fold(chat)
+        folded = self._fold(chat, message)
         routing = self._turn_routing(update, message, context)
         convo_user = routing["user_id"]
         self._remember_chat(convo_user, folded)
@@ -596,7 +611,7 @@ class TelegramChannel:
         if not user or not message:
             return
         sender_id = user.id
-        folded = self._fold(chat)
+        folded = self._fold(chat, message)
         routing = self._turn_routing(update, message, context)
         convo_user = routing["user_id"]
         self._remember_chat(convo_user, folded)
@@ -650,7 +665,9 @@ class TelegramChannel:
             name=f"tg-photo-{convo_user}",
         )
 
-    async def _handle_skill_command(self, slug: str, convo_user: str, chat_id: str, message_id: int) -> None:
+    async def _handle_skill_command(
+        self, slug: str, convo_user: str, chat_id: str, message_id: int
+    ) -> None:
         """/zz_skill_<name>: load a skill from the store into the conversation (#178, #187).
 
         The body is recorded in history as a record-only inbound turn (so the
@@ -715,7 +732,9 @@ class TelegramChannel:
         await query.answer()  # Acknowledge the button press
 
         user_id = user.id
-        folded = self._fold(chat)
+        # The pressed button rides the approval message, which lives in the same
+        # topic as the turn — fold it so the resume routes back there (#183).
+        folded = self._fold(chat, getattr(query, "message", None))
         if folded is not None:
             self._last_chat_for_user[user_id] = folded
         # Same gate as an inbound turn (#129): a button press (approve/deny/cancel)

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -734,7 +734,15 @@ class TelegramChannel:
         user_id = user.id
         # The pressed button rides the approval message, which lives in the same
         # topic as the turn — fold it so the resume routes back there (#183).
-        folded = self._fold(chat, getattr(query, "message", None))
+        msg = getattr(query, "message", None)
+        folded = self._fold(chat, msg)
+        if msg is not None and not hasattr(msg, "is_topic_message"):
+            # An InaccessibleMessage (button older than ~48h) has lost its topic;
+            # fall back to the sender's last known chat when that is a topic of
+            # this same chat, so a Stop/Approve still reaches the topic's turn.
+            prev = self._last_chat_for_user.get(user_id)
+            if isinstance(prev, str) and prev.startswith(f"{folded}:"):
+                folded = prev
         if folded is not None:
             self._last_chat_for_user[user_id] = folded
         # Same gate as an inbound turn (#129): a button press (approve/deny/cancel)
@@ -831,15 +839,24 @@ class TelegramChannel:
             log.info("Reaction skipped on %s/%s: %s", cid, message_id, exc)
 
     async def send_approval_request(
-        self, user_id: str, request_id: str, description: str, image_path: str | None = None
+        self,
+        user_id: str,
+        request_id: str,
+        description: str,
+        image_path: str | None = None,
+        chat_id: str | None = None,
     ) -> None:
         """Send a permission approval prompt with Approve/Deny inline buttons.
 
         When ``image_path`` is given (e.g. a browser screenshot), send it as a
         photo with the buttons so the user can watch and approve from their phone.
+        ``chat_id`` is the asking turn's own chat (a folded topic id in a forum,
+        #183) so the prompt lands in the conversation that triggered it; without
+        it (older callers, subagent paths) fall back to the sender's last chat.
         """
         target_id = int(user_id)
-        chat_id = self._last_chat_for_user.get(target_id, target_id)
+        if not chat_id:
+            chat_id = self._last_chat_for_user.get(target_id, target_id)
         keyboard = InlineKeyboardMarkup(
             [
                 [
@@ -913,11 +930,15 @@ class TelegramChannel:
         # a permission prompt it is waiting, not thinking, so the placeholder label
         # must say so instead of a stale "Thinking…". send_approval_request /
         # _on_approval_callback flip ``waiting`` and poke ``changed`` to re-render.
-        # ponytail: one entry per routed chat, assumes turns in a chat don't overlap
-        # (approvals are interactive/serial anyway) — key by (chat, turn) if they do.
+        # Keyed by the FOLDED id, not the routed base chat: two topics of one
+        # forum group are separate conversations since #183 and can run turns
+        # concurrently — a base-chat key would make them share (and clobber)
+        # one placeholder state.
+        # ponytail: one entry per conversation, assumes turns in a conversation
+        # don't overlap (they're serialized by the per-chat lock anyway).
         state = {"waiting": False, "changed": asyncio.Event()}
         waits = self.__dict__.setdefault("_typing_waits", {})
-        waits[str(cid)] = state
+        waits[str(chat_id)] = state
 
         async def _placeholder():
             # Wait out the delay; a turn that finishes first never posts (no flash).
@@ -977,7 +998,7 @@ class TelegramChannel:
             yield
         finally:
             turn_over.set()
-            waits.pop(str(cid), None)
+            waits.pop(str(chat_id), None)
             typing_task.cancel()
             for t in (typing_task, placeholder_task):
                 try:
@@ -988,9 +1009,9 @@ class TelegramChannel:
     def _set_typing_waiting(self, chat_id: int | str, waiting: bool) -> None:
         """Flip the active turn's placeholder between "Thinking…" and "Waiting for
         your approval…" (#147). No-op when no turn is showing a placeholder for
-        this chat (e.g. a subagent or admin-API approval with no _typing wrapper)."""
-        cid, _ = self._route(chat_id)
-        state = self.__dict__.get("_typing_waits", {}).get(str(cid))
+        this chat (e.g. a subagent or admin-API approval with no _typing wrapper).
+        Keyed by the folded conversation id — same key ``_typing`` stores (#183)."""
+        state = self.__dict__.get("_typing_waits", {}).get(str(chat_id))
         if state is None:
             return
         state["waiting"] = waiting

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -20,7 +20,7 @@ from zoneinfo import ZoneInfo
 from tavily import TavilyClient
 
 from core import coding, imagegen
-from core.agents import Agent, AgentStore, default_agent_from_values
+from core.agents import Agent, AgentStore, default_agent_from_values, topic_base_id
 from core.compaction import compact_messages, should_compact
 from core.config import Config
 from core.embeddings import LOCAL_PROVIDERS, EmbeddingClient, LocalEmbeddingClient
@@ -1352,7 +1352,11 @@ class AgentCore:
             # in the same chat (each its own task) see the reservation and trip
             # the cap — closing the check-then-act race that would otherwise let
             # a burst sail past the cap. A SKIP releases its slot below.
-            reserved = self._reserve_reply(channel, chat_id, rd_cfg)
+            # The cap is per GROUP, not per topic (#183): a folded topic id would
+            # give a bot-loop one fresh budget per topic, reopening the storm the
+            # cap exists to close (#36/#53).
+            cap_chat = topic_base_id(chat_id) or chat_id
+            reserved = self._reserve_reply(channel, cap_chat, rd_cfg)
             if reserved is None:
                 log.warning(
                     "Reply suppressed: rate cap %d/%ds hit for chat=%s channel=%s",
@@ -1365,7 +1369,7 @@ class AgentCore:
             identity = agent.name if agent else "the assistant"
             llm = self._background_llm(rd_cfg.provider, rd_cfg.thinking_level)
             if not await should_reply(llm, rd_cfg.model, message, identity):
-                self._release_reply(channel, chat_id, reserved)
+                self._release_reply(channel, cap_chat, reserved)
                 return AgentResponse(text="")
 
         # Goal decomposition — classify and (if complex) decompose the request.
@@ -1475,8 +1479,8 @@ class AgentCore:
         # agent serves that agent in every topic; a topic binding still wins.
         bound = await self.history.get_chat_agent(channel, user_id, chat_id)
         if not bound:
-            base = str(chat_id).partition(":")[0]
-            if base != str(chat_id):
+            base = topic_base_id(chat_id)
+            if base is not None:
                 bound = await self.history.get_chat_agent(channel, user_id, base)
         if bound:
             agent = await self._load_agent(bound)
@@ -2429,7 +2433,12 @@ class AgentCore:
                 decision = approvals[match_key]
             else:
                 decision = await self._request_approval(
-                    name, params, channel, user_id, scope=agent_scope
+                    name,
+                    params,
+                    channel,
+                    user_id,
+                    scope=agent_scope,
+                    chat_id=str(request_state.get("origin", {}).get("chat_id") or ""),
                 )
                 if is_write_action:
                     write_decisions[write_sig] = decision
@@ -3980,7 +3989,13 @@ class AgentCore:
         return result
 
     async def _request_approval(
-        self, tool_name: str, params: dict, channel: str, user_id: str, scope: str = ""
+        self,
+        tool_name: str,
+        params: dict,
+        channel: str,
+        user_id: str,
+        scope: str = "",
+        chat_id: str = "",
     ) -> str:
         """Ask the user to approve a single tool call via their channel.
 
@@ -3993,6 +4008,7 @@ class AgentCore:
             tool_name,
             params,
             scope=scope,
+            chat_id=chat_id,
         )
 
     async def _batch_approve_writes(
@@ -4035,7 +4051,12 @@ class AgentCore:
             return
         lines = "\n\n".join(f"{i}. {desc}" for i, (_, desc) in enumerate(pending, 1))
         description = f"Approve these {len(pending)} actions?\n\n{lines}"
-        decision = await self._await_approval(description, channel, user_id)
+        decision = await self._await_approval(
+            description,
+            channel,
+            user_id,
+            chat_id=str(request_state.get("origin", {}).get("chat_id") or ""),
+        )
         for sig, _ in pending:
             write_decisions[sig] = decision
 
@@ -4070,6 +4091,7 @@ class AgentCore:
         tool_name: str | None = None,
         params: dict | None = None,
         scope: str = "",
+        chat_id: str = "",
     ) -> str:
         """Send an approval prompt to the channel and wait for the response.
 
@@ -4091,6 +4113,7 @@ class AgentCore:
                 request_id,
                 description,
                 image_path=self._approval_image(tool_name, params),
+                chat_id=chat_id,
             )
         except AttributeError:
             # Channel doesn't support approval requests — auto-approve
@@ -4105,7 +4128,9 @@ class AgentCore:
             # truncating the *display* text changes nothing that executes.
             log.warning("Approval send failed; retrying with truncated prompt", exc_info=True)
             try:
-                await ch.send_approval_request(user_id, request_id, _truncate_approval(description))
+                await ch.send_approval_request(
+                    user_id, request_id, _truncate_approval(description), chat_id=chat_id
+                )
             except Exception:
                 # Still undeliverable — fail CLOSED. A gate that cannot ask the
                 # user must never silently approve (#79). Drop the pending

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -1470,8 +1470,14 @@ class AgentCore:
                 return agent
             # Unknown/deleted agent — fall through to the ordinary ladder.
 
-        # 1. Per-chat binding.
+        # 1. Per-chat binding. A forum-topic id ("<chat>:<thread>", #183) with no
+        # binding of its own inherits the group's binding, so a group bound to an
+        # agent serves that agent in every topic; a topic binding still wins.
         bound = await self.history.get_chat_agent(channel, user_id, chat_id)
+        if not bound:
+            base = str(chat_id).partition(":")[0]
+            if base != str(chat_id):
+                bound = await self.history.get_chat_agent(channel, user_id, base)
         if bound:
             agent = await self._load_agent(bound)
             if agent:

--- a/humux/core/agents.py
+++ b/humux/core/agents.py
@@ -205,7 +205,9 @@ class Agent:
             return True
         setting = self.chat_settings.get(chat_id)
         if setting is None:
-            setting = self.chat_settings.get(str(chat_id).partition(":")[0])
+            base = topic_base_id(chat_id)
+            if base is not None:
+                setting = self.chat_settings.get(base)
         if not isinstance(setting, dict):
             return True
         mode = setting.get("mode", "everyone")
@@ -287,14 +289,28 @@ def _as_tool_config(value: object) -> dict:
     return {}
 
 
+def topic_base_id(chat_id: object) -> str | None:
+    """The group id behind a folded Telegram forum-topic id (#183), or ``None``.
+
+    A topic id is ``"<chat>:<thread>"`` with both halves numeric — the same
+    validation the Telegram channel's ``_route`` applies, so a colon in an
+    unrelated id (e.g. a ``"cli:<session>"`` chat) never reads as a topic.
+    """
+    base, sep, thread = str(chat_id).partition(":")
+    if sep and thread.isdigit() and base.lstrip("-").isdigit():
+        return base
+    return None
+
+
 def _as_chat_settings(value: object) -> dict:
     """Coerce a frontmatter / form / DB-column value into per-chat settings (#129).
 
     Shape: ``{chat_id: {"mode": everyone|nobody|users, "users": [int]}}``. Accepts
-    a parsed dict (frontmatter/form) or a JSON string (DB column). ``everyone``
-    entries are dropped (that is the default — an absent chat is unrestricted), so
-    the stored dict stays lean. Non-numeric user ids and malformed entries are
-    discarded so a broken value never breaks load.
+    a parsed dict (frontmatter/form) or a JSON string (DB column). An explicit
+    ``everyone`` entry is kept: since #183 an absent topic entry inherits the
+    group's setting, so "everyone" on a topic is how it relaxes a gated group —
+    dropping it would silently re-gate the topic. Non-numeric user ids and
+    malformed entries are discarded so a broken value never breaks load.
     """
     if isinstance(value, str) and value.strip():
         try:
@@ -310,8 +326,6 @@ def _as_chat_settings(value: object) -> dict:
         mode = str(spec.get("mode", "everyone") or "everyone").strip().lower()
         if mode not in ("everyone", "nobody", "users"):
             mode = "everyone"
-        if mode == "everyone":
-            continue  # the default — no need to store it
         users: list[int] = []
         for u in spec.get("users") or []:
             try:

--- a/humux/core/agents.py
+++ b/humux/core/agents.py
@@ -196,8 +196,16 @@ class Agent:
 
         No stored setting = everyone allowed (unchanged behaviour). ``nobody``
         blocks all; ``users`` allows only the listed Telegram ids (#129).
+
+        A forum-topic id (``"<chat>:<thread>"``, #183) with no setting of its own
+        falls back to the group's setting, so a gate on the group covers every
+        topic; a topic-specific setting still wins.
         """
-        setting = self.chat_settings.get(chat_id) if isinstance(self.chat_settings, dict) else None
+        if not isinstance(self.chat_settings, dict):
+            return True
+        setting = self.chat_settings.get(chat_id)
+        if setting is None:
+            setting = self.chat_settings.get(str(chat_id).partition(":")[0])
         if not isinstance(setting, dict):
             return True
         mode = setting.get("mode", "everyone")

--- a/humux/core/cli.py
+++ b/humux/core/cli.py
@@ -165,7 +165,12 @@ class CliChannel:
         print(f"\n{text}\n")
 
     async def send_approval_request(
-        self, user_id: str, request_id: str, description: str, image_path: str | None = None
+        self,
+        user_id: str,
+        request_id: str,
+        description: str,
+        image_path: str | None = None,
+        chat_id: str | None = None,  # unused: the CLI has one conversation on screen
     ) -> None:
         if self.yolo:  # --yolo: approve everything, no prompt (this call only, no rule)
             sys.stderr.write(f"\r\033[K\033[2m  · [yolo] auto-approved: {description}\033[0m\n")

--- a/humux/tests/test_chat_settings.py
+++ b/humux/tests/test_chat_settings.py
@@ -35,6 +35,23 @@ def test_chat_permits_users_allowlist() -> None:
     assert a.chat_permits("c", 8) is False
 
 
+def test_chat_permits_topic_inherits_group_setting() -> None:
+    # A forum-topic id "<chat>:<thread>" (#183) with no setting of its own falls
+    # back to the group's setting; a topic-specific setting still wins.
+    a = Agent(name="coach", chat_settings={"-100": {"mode": "users", "users": [7]}})
+    assert a.chat_permits("-100:5", 7) is True
+    assert a.chat_permits("-100:5", 8) is False
+    a = Agent(
+        name="coach",
+        chat_settings={
+            "-100": {"mode": "nobody", "users": []},
+            "-100:5": {"mode": "everyone", "users": []},
+        },
+    )
+    assert a.chat_permits("-100:5", 7) is True  # topic override wins
+    assert a.chat_permits("-100:6", 7) is False  # sibling topic inherits the group
+
+
 # ---- _as_chat_settings: coercion + normalisation ----------------------------
 
 

--- a/humux/tests/test_chat_settings.py
+++ b/humux/tests/test_chat_settings.py
@@ -41,15 +41,23 @@ def test_chat_permits_topic_inherits_group_setting() -> None:
     a = Agent(name="coach", chat_settings={"-100": {"mode": "users", "users": [7]}})
     assert a.chat_permits("-100:5", 7) is True
     assert a.chat_permits("-100:5", 8) is False
+    # Through the real load-path normalizer: the explicit everyone override must
+    # survive _as_chat_settings, or the topic could never relax the group gate.
     a = Agent(
         name="coach",
-        chat_settings={
-            "-100": {"mode": "nobody", "users": []},
-            "-100:5": {"mode": "everyone", "users": []},
-        },
+        chat_settings=_as_chat_settings(
+            {
+                "-100": {"mode": "nobody", "users": []},
+                "-100:5": {"mode": "everyone", "users": []},
+            }
+        ),
     )
     assert a.chat_permits("-100:5", 7) is True  # topic override wins
     assert a.chat_permits("-100:6", 7) is False  # sibling topic inherits the group
+    # A colon in a non-numeric id (e.g. "cli:<session>") is NOT a topic id — it
+    # must never fall back to another entry's setting.
+    a = Agent(name="coach", chat_settings={"cli": {"mode": "nobody", "users": []}})
+    assert a.chat_permits("cli:abc123", 7) is True
 
 
 # ---- _as_chat_settings: coercion + normalisation ----------------------------
@@ -60,9 +68,15 @@ def test_as_chat_settings_from_json_string_and_ids() -> None:
     assert got == {"c": {"mode": "users", "users": [5, 6]}}  # non-numeric dropped
 
 
-def test_as_chat_settings_drops_everyone_and_junk() -> None:
-    assert _as_chat_settings({"c": {"mode": "everyone", "users": [1]}}) == {}
-    assert _as_chat_settings({"c": {"mode": "bogus"}}) == {}  # bogus → everyone → dropped
+def test_as_chat_settings_keeps_explicit_everyone_drops_junk() -> None:
+    # An explicit "everyone" is KEPT (#183): a topic entry with everyone is how a
+    # topic relaxes a gated group — dropping it would silently re-gate the topic.
+    assert _as_chat_settings({"c": {"mode": "everyone", "users": [1]}}) == {
+        "c": {"mode": "everyone", "users": [1]}
+    }
+    assert _as_chat_settings({"c": {"mode": "bogus"}}) == {
+        "c": {"mode": "everyone", "users": []}  # bogus coerces to everyone
+    }
     assert _as_chat_settings("not json") == {}
     assert _as_chat_settings(42) == {}
     assert _as_chat_settings({"c": "not-a-dict"}) == {}

--- a/humux/tests/test_per_chat_agent.py
+++ b/humux/tests/test_per_chat_agent.py
@@ -197,17 +197,37 @@ async def test_bind_chat_agent_clears_session_system(tmp_path) -> None:
 # ---- Telegram chat id folding ----------------------------------------------
 
 
-def _fold(chat):
-    return TelegramChannel._fold(types.SimpleNamespace(), chat)
+def _fold(chat, message=None):
+    return TelegramChannel._fold(types.SimpleNamespace(), chat, message)
 
 
 def test_fold_uses_chat_id() -> None:
-    # Forum topics were dropped (#133): a message's context is just its chat id.
+    # No topic on the message → the context is just the chat id.
     assert _fold(types.SimpleNamespace(id=-100123)) == -100123
 
 
 def test_fold_no_chat_returns_none() -> None:
     assert _fold(None) is None
+
+
+def test_fold_topic_message_encodes_thread() -> None:
+    # A forum-topic message folds to "<chat>:<thread>" so each topic is its own
+    # conversation and the reply routes back to that topic (#183).
+    msg = types.SimpleNamespace(message_thread_id=45, is_topic_message=True)
+    assert _fold(types.SimpleNamespace(id=-100123), msg) == "-100123:45"
+
+
+def test_fold_ignores_thread_of_plain_reply() -> None:
+    # A reply in a non-forum group carries message_thread_id but is NOT a topic
+    # message — it must keep the bare chat id (same conversation, no re-route).
+    msg = types.SimpleNamespace(message_thread_id=45, is_topic_message=False)
+    assert _fold(types.SimpleNamespace(id=-100123), msg) == -100123
+
+
+def test_fold_general_topic_keeps_bare_id() -> None:
+    # The General topic has no thread id set — bare chat id, as before forums.
+    msg = types.SimpleNamespace(message_thread_id=None, is_topic_message=False)
+    assert _fold(types.SimpleNamespace(id=-100123), msg) == -100123
 
 
 def test_route_roundtrip() -> None:

--- a/humux/tests/test_per_chat_agent.py
+++ b/humux/tests/test_per_chat_agent.py
@@ -131,6 +131,21 @@ async def test_resolve_agent_ladder(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_agent_topic_inherits_group_binding(tmp_path) -> None:
+    # A forum-topic id "<chat>:<thread>" (#183) with no binding of its own
+    # inherits the group's binding; a topic-specific binding still wins.
+    h = ConversationHistory(db_path=str(tmp_path / "h.db"))
+    store = await _seed_agents(tmp_path)
+    fa = _fake_agent(h, store)
+    await h.set_chat_agent("telegram", "-100", "coach", "-100")
+    p = await fa._resolve_agent("telegram", "-100", "-100:45")
+    assert p is not None and p.name == "coach"  # inherited from the group
+    await h.set_chat_agent("telegram", "-100", "writer", "-100:45")
+    p = await fa._resolve_agent("telegram", "-100", "-100:45")
+    assert p is not None and p.name == "writer"  # topic binding wins
+
+
+@pytest.mark.asyncio
 async def test_resolve_agent_bot_per_agent_channel(tmp_path) -> None:
     # Rung 0 (#29): a "telegram:<name>" channel binds straight to that agent,
     # outranking the per-chat binding and the default.

--- a/humux/tests/test_telegram_channel.py
+++ b/humux/tests/test_telegram_channel.py
@@ -14,7 +14,7 @@ def _dedup_channel() -> TelegramChannel:
     ch.channel_name = "telegram"
     ch._bot_username = "coachbot"
     ch._last_inbound = {}
-    ch._fold = lambda chat: None
+    ch._fold = lambda chat, message=None: None
     ch._remember_chat = lambda *a: None
     ch._reply_context = lambda m: ""
     ch._may_act = AsyncMock(return_value=True)

--- a/humux/tests/test_telegram_channel.py
+++ b/humux/tests/test_telegram_channel.py
@@ -272,6 +272,30 @@ async def test_approval_request_chunks_and_keyboard_rides_last() -> None:
     assert calls[-1].kwargs.get("reply_markup") is not None
 
 
+@pytest.mark.asyncio
+async def test_approval_request_routes_to_turn_topic() -> None:
+    # The asking turn's own chat id (a folded topic id, #183) wins over the
+    # sender's last chat, so the prompt lands in the topic that triggered it —
+    # not wherever the user (or a sibling topic) last wrote.
+    ch = _channel_with_mock_bot()
+    ch._last_chat_for_user = {123: "-100:9"}  # stale: user last wrote in topic 9
+    await ch.send_approval_request("123", "req1", "do thing?", chat_id="-100:5")
+    args, kwargs = ch.app.bot.send_message.call_args
+    assert args[0] == -100
+    assert kwargs.get("message_thread_id") == 5
+
+
+@pytest.mark.asyncio
+async def test_approval_request_falls_back_to_last_chat() -> None:
+    # Without an explicit chat (subagent/older paths) the last-chat routing stays.
+    ch = _channel_with_mock_bot()
+    ch._last_chat_for_user = {123: "-100:9"}
+    await ch.send_approval_request("123", "req1", "do thing?")
+    args, kwargs = ch.app.bot.send_message.call_args
+    assert args[0] == -100
+    assert kwargs.get("message_thread_id") == 9
+
+
 # --- /zz_skill_* commands (#178) ---
 
 

--- a/humux/tests/test_tools.py
+++ b/humux/tests/test_tools.py
@@ -413,7 +413,7 @@ def _job_call(call_id: str, **params):
     return LLMToolCall(id=call_id, name="manage_jobs", arguments={"action": "create", **params})
 
 
-async def _approve(name, params, channel, user_id, scope=""):
+async def _approve(name, params, channel, user_id, scope="", chat_id=""):
     return "approved"
 
 
@@ -647,7 +647,7 @@ async def test_skipping_one_write_does_not_block_a_different_one(agent, monkeypa
     """Skipping a write blocks only that exact action, not other writes."""
     decisions = {"ping mum": "skipped", "ping dad": "approved"}
 
-    async def fake_approval(name, params, channel, user_id, scope=""):
+    async def fake_approval(name, params, channel, user_id, scope="", chat_id=""):
         return decisions.get(params.get("task"), "approved")
 
     monkeypatch.setattr(agent, "_request_approval", fake_approval)
@@ -681,7 +681,7 @@ async def test_batch_approval_asks_once_for_multiple_writes(agent, monkeypatch) 
     """Several writes in one turn must trigger exactly one approval prompt."""
     prompts = {"n": 0}
 
-    async def fake_await(description, channel, user_id, tool_name=None, params=None):
+    async def fake_await(description, channel, user_id, tool_name=None, params=None, chat_id=""):
         prompts["n"] += 1
         return "approved"
 
@@ -706,7 +706,7 @@ async def test_batch_approval_asks_once_for_multiple_writes(agent, monkeypatch) 
 async def test_batch_approval_denied_blocks_every_write(agent, monkeypatch) -> None:
     """Denying the batch blocks all of its writes, not just one."""
 
-    async def deny(description, channel, user_id, tool_name=None, params=None):
+    async def deny(description, channel, user_id, tool_name=None, params=None, chat_id=""):
         return "denied"
 
     monkeypatch.setattr(agent, "_await_approval", deny)
@@ -729,7 +729,7 @@ async def test_single_write_is_not_batched(agent, monkeypatch) -> None:
     """A lone write is left to the per-call path, not the batch prompt."""
     prompts = {"n": 0}
 
-    async def fake_await(description, channel, user_id, tool_name=None, params=None):
+    async def fake_await(description, channel, user_id, tool_name=None, params=None, chat_id=""):
         prompts["n"] += 1
         return "approved"
 
@@ -867,7 +867,9 @@ class _FailingChannel:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    async def send_approval_request(self, user_id, request_id, description, image_path=None):
+    async def send_approval_request(
+        self, user_id, request_id, description, image_path=None, chat_id=None
+    ):
         self.calls.append(description)
         raise RuntimeError("message too long")
 


### PR DESCRIPTION
Fixes #183.

## Problem

In a Telegram group with forum (topics) mode on, triggering the agent inside a topic made it reply in the **General** topic. The topic's `message_thread_id` was dropped when building the context id (`_fold` returned the bare chat id since #133 removed folding), so the reply — and the conversation context — never scoped to the topic.

## Fix

- `_fold` now encodes a forum-topic message as `"<chat>:<thread>"` (only when `is_topic_message` is set — a plain reply in a non-forum group also carries `message_thread_id` and must keep the bare chat id). The existing `_route` helper splits this id back into `chat_id` + `message_thread_id` for every outgoing call, so replies, typing indicators, and placeholders land in the right topic.
- Because the conversation key is `(channel, user_id, chat_id)`, each topic gets its own history/session — an independent conversation, per the issue's expected behaviour. The General topic keeps the bare chat id, unchanged.

## Per-group behaviour preserved (follow-up commits)

Splitting one group into N conversations touched things that must stay group-wide or turn-scoped:

- **Bindings & permissions inherit**: a topic with no agent binding (#14) or per-chat setting (#129) of its own falls back to the group's; a topic-specific one still wins. An explicit `everyone` setting now survives `_as_chat_settings` (it's how a topic relaxes a gated group). `topic_base_id()` validates both halves numerically, so ids like `cli:<session>` never read as topics.
- **Approval prompts route to the asking turn's chat**: `chat_id` is threaded from the agent core to `send_approval_request`, so a prompt lands in the topic that triggered it — not wherever the sender last wrote (also fixes the pre-existing cross-chat race). Approval-button callbacks fold the callback message the same way, with a fallback for inaccessible (>48h) messages.
- **Reply-decision rate cap stays per group** (#36/#53): keyed on the base group id so a bot-loop can't get a fresh budget per topic.
- **Typing/placeholder state keyed per conversation**, so concurrent turns in two topics don't clobber each other's "Thinking…/Waiting…" bubble.

## Tests

New tests for topic folding (topic vs plain reply vs General), binding/settings inheritance + topic overrides, non-topic colon ids, and approval routing. Full suite: 945 passed; ruff clean (two pre-existing >100-char lines wrapped — the commit hook rejects them).

## Docs

Added a note on per-topic conversations to the channels page.