### PR TITLE
feat(search): add SearXNG as a self-hosted search backend (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ humux follows a **Python orchestrator + CLI tools** design. Python handles the a
 | **Browser** | Playwright (Chromium) |
 | **Voice STT** | faster-whisper (CTranslate2) |
 | **Voice TTS** | edge-tts / Kokoro 82M |
-| **Web search** | Tavily |
+| **Web search** | Tavily or self-hosted SearXNG |
 | **Scheduler** | APScheduler |
 | **Storage** | SQLite (8 databases) |
 | **Admin UI** | FastAPI + Jinja2 + HTMX + Alpine.js + Tailwind CSS v4 |
@@ -380,7 +380,7 @@ humux uses a dual-layer config system:
 | **Voice** | faster-whisper (STT), edge-tts / Kokoro 82M (TTS) |
 | **Browser** | Playwright (Chromium), headless or CDP sidecar |
 | **Scheduler** | APScheduler |
-| **Search** | Tavily |
+| **Search** | Tavily or self-hosted SearXNG |
 | **Container** | Docker (single image, multi-stage) |
 | **CI/CD** | GitHub Actions (lint, test, build, publish to ghcr.io) |
 

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -104,8 +104,9 @@ admin:
 
 search:
   enabled: true
-  provider: "tavily"
-  api_key: "${TAVILY_API_KEY}"
+  provider: "tavily"           # "tavily" | "searxng"
+  api_key: "${TAVILY_API_KEY}" # Tavily only
+  searxng_url: ""              # SearXNG only, e.g. http://searxng:8080
   max_results: 5
 
 vision:
@@ -168,7 +169,26 @@ Admin UI settings. The API key is required for authentication.
 
 #### `search`
 
-Web search configuration via Tavily.
+Web search for the agent's `web_search` tool. Two interchangeable backends —
+the tool's contract to the model is identical either way, so switching is a
+single config change with no code modification.
+
+- **`tavily`** (default): hosted metasearch with cleaned, LLM-ready content.
+  Set `api_key` (a `${vault:TAVILY_API_KEY}` ref keeps it out of config). Free
+  tier of 1K queries/mo.
+- **`searxng`**: a self-hosted [SearXNG](https://docs.searxng.org) instance —
+  no API key, no per-query cost. Set `searxng_url` to the instance base URL
+  (e.g. `http://searxng:8080`). Results are snippet-only (title + URL +
+  ~200-char excerpt); fetch full pages with the browser / `w3m` / `curl` tools
+  when needed. Stand one up with the bundled override:
+
+  ```bash
+  docker compose -f docker-compose.yml -f docker-compose.searxng.yml up -d
+  ```
+
+  The override pre-enables the JSON API (no manual `settings.yml` editing) and
+  exposes it at `http://searxng:8080`. Pick the provider and test reachability
+  from the admin UI (Tools → Web search) or the setup wizard.
 
 #### `vision`
 

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -35,7 +35,7 @@ from pydantic import BaseModel, Field
 
 from core.artifacts import ARTIFACT_CSP, NOT_FOUND_HTML, resolve, serving_base, valid_id
 from core.compaction import effective_window
-from core.config import CompactionConfig
+from core.config import CompactionConfig, search_ready
 from core.config_store import ConfigStore
 from core.goal_decomposition import classify_complexity, decompose_goal
 from core.llm import LLMClient, get_sent_payload
@@ -262,6 +262,8 @@ async def _wizard_step_context(step: str, config_store: ConfigStore) -> dict[str
         val = await config_store.get("search.api_key")
         if val and not _is_vault_ref(val):
             ctx["tavily_key"] = val
+        ctx["searxng_url"] = await config_store.get("search.searxng_url") or ""
+        ctx["search_provider"] = await config_store.get("search.provider") or "tavily"
     elif step == "admin":
         val = await config_store.get("admin.password_hash")
         if val:
@@ -1416,6 +1418,7 @@ def create_admin_app(
         search_provider = await config_store.get("search.provider") or "tavily"
         search_api_key = await config_store.get("search.api_key") or ""
         search_vaulted = _is_vault_ref(search_api_key)
+        search_searxng_url = await config_store.get("search.searxng_url") or ""
         search_max_results = await config_store.get("search.max_results") or "5"
 
         # Web artifacts (issue #82) — only the public-serving toggle remains; the
@@ -1500,6 +1503,7 @@ def create_admin_app(
             search_provider=search_provider,
             search_api_key="" if search_vaulted else search_api_key,
             search_vaulted=search_vaulted,
+            search_searxng_url=search_searxng_url,
             search_max_results=search_max_results,
         )
 
@@ -2156,7 +2160,8 @@ def create_admin_app(
                 agent.memory.hygiene_enabled = mem_cfg.hygiene_enabled
                 agent.memory.hygiene_similarity_threshold = mem_cfg.hygiene_similarity_threshold
                 agent.reflections.max_reflections = new_config.task_reflection.max_reflections
-                if new_config.search.enabled and new_config.search.api_key:
+                agent.search_enabled = search_ready(new_config.search)
+                if agent.search_enabled and new_config.search.provider == "tavily":
                     from tavily import TavilyClient
 
                     agent.search_client = TavilyClient(api_key=new_config.search.api_key)
@@ -3665,6 +3670,8 @@ def create_admin_app(
             return await _test_telegram(payload.get("bot_token", ""))
         if service == "tavily":
             return await _test_tavily(payload.get("api_key", ""))
+        if service == "searxng":
+            return await _test_searxng(payload.get("url", ""))
         return {"ok": False, "error": f"Unknown service: {service}"}
 
     @app.post("/setup/list-models")
@@ -4294,3 +4301,23 @@ async def _test_tavily(api_key: str) -> dict:
         return {"ok": True, "results": len(result.get("results", []))}
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
+
+
+async def _test_searxng(url: str) -> dict:
+    if not url.strip():
+        return {"ok": False, "error": "Instance URL is empty"}
+    try:
+        import httpx
+
+        base = url.strip().rstrip("/")
+        async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
+            resp = await client.get(
+                f"{base}/search",
+                params={"q": "test", "format": "json"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        return {"ok": True, "results": len(data.get("results", []))}
+    except Exception as exc:
+        # A 403/JSON error usually means the instance hasn't enabled the JSON format.
+        return {"ok": False, "error": f"{exc} (is JSON format enabled in settings.yml?)"}

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -571,11 +571,12 @@
 
     // Web search tool (lives in the Tools tab). save() writes the search.*
     // config; test() checks the Tavily key via the shared test-connection route.
-    function searchTool(enabled, provider, apiKey, maxResults) {
+    function searchTool(enabled, provider, apiKey, searxngUrl, maxResults) {
       return {
         enabled: enabled ?? 'false',
         provider: provider || 'tavily',
         apiKey: apiKey || '',
+        searxngUrl: searxngUrl || '',
         maxResults: maxResults || '5',
         result: '',
         resultOk: false,
@@ -586,6 +587,7 @@
             'search.enabled': String(this.enabled === true || this.enabled === 'true'),
             'search.provider': this.provider,
             'search.api_key': this.apiKey,
+            'search.searxng_url': this.searxngUrl,
             'search.max_results': String(this.maxResults)
           };
           fetch('/config', {
@@ -611,7 +613,11 @@
               'Content-Type': 'application/json',
               'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
             },
-            body: JSON.stringify({service: 'tavily', api_key: this.apiKey})
+            body: JSON.stringify(
+              this.provider === 'searxng'
+                ? {service: 'searxng', url: this.searxngUrl}
+                : {service: 'tavily', api_key: this.apiKey}
+            )
           })
             .then(r => r.json())
             .then(d => { this.testResult = d.ok ? 'Connection OK' : ('Failed: ' + (d.error || 'unknown')); })

--- a/humux/api/templates/partials/tools.html
+++ b/humux/api/templates/partials/tools.html
@@ -279,6 +279,7 @@
     {{ search_enabled|default('false', true)|tojson|forceescape }},
     {{ search_provider|default('tavily', true)|tojson|forceescape }},
     {{ search_api_key|default('', true)|tojson|forceescape }},
+    {{ search_searxng_url|default('', true)|tojson|forceescape }},
     {{ search_max_results|default('5', true)|tojson|forceescape }}
   )">
     <div class="flex items-center justify-between gap-3 mb-1">
@@ -288,17 +289,18 @@
         Enabled
       </label>
     </div>
-    <p class="text-muted text-xs mb-3">Lets the agent look things up online via the <code>web_search</code> tool. Currently supports Tavily. When disabled the tool is hidden from the model.</p>
+    <p class="text-muted text-xs mb-3">Lets the agent look things up online via the <code>web_search</code> tool. Choose Tavily (hosted, needs an API key) or a self-hosted SearXNG instance (needs a URL, zero cost). When disabled the tool is hidden from the model.</p>
 
     <div class="space-y-3" x-show="enabled === 'true' || enabled === true">
       <div>
         <label class="label">Provider</label>
         <select class="input-sm" style="max-width:300px" x-model="provider">
           <option value="tavily">Tavily</option>
+          <option value="searxng">SearXNG (self-hosted)</option>
         </select>
       </div>
 
-      <div>
+      <div x-show="provider === 'tavily'">
         <label class="label">API Key</label>
         {% if search_vaulted %}
         <div class="text-xs text-muted py-1" style="max-width:500px">🔒 Stored in the vault as <code>${vault:TAVILY_API_KEY}</code> — manage it from the <button type="button" class="text-accent hover:underline" @click="$dispatch('switch-tab', 'secrets')">Vaults</button> tab.</div>
@@ -310,6 +312,13 @@
         {% endif %}
       </div>
 
+      <div x-show="provider === 'searxng'">
+        <label class="label">Instance URL</label>
+        <input type="text" class="input-sm" style="max-width:500px"
+               x-model="searxngUrl" placeholder="http://searxng:8080">
+        <p class="text-muted text-xs mt-1">Base URL of your SearXNG instance (JSON format must be enabled). The bundled <code>docker-compose.searxng.yml</code> exposes it at <code>http://searxng:8080</code>.</p>
+      </div>
+
       <div>
         <label class="label">Max results</label>
         <input type="number" class="input-sm" style="max-width:120px" x-model="maxResults" min="1" max="20">
@@ -319,7 +328,7 @@
 
     <div class="flex items-center gap-2 mt-4">
       <button class="btn-primary btn-sm" @click="save()">Save</button>
-      <button class="btn btn-sm" :disabled="testing || !apiKey" x-show="enabled === 'true' || enabled === true" @click="test()">
+      <button class="btn btn-sm" :disabled="testing || (provider === 'searxng' ? !searxngUrl : !apiKey)" x-show="enabled === 'true' || enabled === true" @click="test()">
         <span x-show="!testing">Test connection</span>
         <span x-show="testing">Testing…</span>
       </button>

--- a/humux/api/templates/wizard/search.html
+++ b/humux/api/templates/wizard/search.html
@@ -1,25 +1,62 @@
-<div class="card" x-data="{ testResult: '', testOk: false, testing: false }">
+<div class="card" x-data="{
+      provider: '{{ step_ctx.search_provider|default('tavily') }}',
+      testResult: '', testOk: false, testing: false,
+      test() {
+        this.testing = true; this.testResult = '';
+        const body = this.provider === 'searxng'
+          ? {service: 'searxng', url: document.getElementById('w-searxng-url').value}
+          : {service: 'tavily', api_key: document.getElementById('w-tavily-key').value};
+        fetch('/setup/test-connection', {
+          method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body)
+        })
+        .then(r => r.json())
+        .then(d => { this.testOk = d.ok; this.testResult = d.ok ? 'Search working (' + d.results + ' results)' : d.error; })
+        .catch(e => { this.testOk = false; this.testResult = e.message; })
+        .finally(() => { this.testing = false; });
+      },
+      next() {
+        const searxng = this.provider === 'searxng';
+        const key = document.getElementById('w-tavily-key').value;
+        const url = document.getElementById('w-searxng-url').value;
+        const enabled = searxng ? !!url : !!key;
+        htmx.ajax('POST', '/setup/step', {
+          target: '#wizard-step', swap: 'innerHTML',
+          values: {
+            step: 'browser',
+            'values[search.enabled]': enabled ? 'true' : 'false',
+            'values[search.provider]': this.provider,
+            'values[search.api_key]': key,
+            'values[search.searxng_url]': url
+          }
+        });
+      }
+    }">
   <h2 class="text-base mb-3">Web Search <span class="text-muted font-normal text-xs">(optional)</span></h2>
 
-  <label class="label" for="w-tavily-key">Tavily API Key</label>
-  <input type="password" class="input" id="w-tavily-key" name="tavily_key" placeholder="tvly-..."
-         value="{{ step_ctx.tavily_key|default('') }}">
-  <p class="hint">Free tier at <a href="https://app.tavily.com" target="_blank">app.tavily.com</a></p>
+  <label class="label">Provider</label>
+  <select class="input" style="max-width:320px" x-model="provider">
+    <option value="tavily">Tavily — hosted, needs an API key</option>
+    <option value="searxng">SearXNG — self-hosted, zero cost, needs a URL</option>
+  </select>
+  <p class="hint" x-show="provider === 'tavily'">Hosted metasearch with cleaned, LLM-ready content. Free tier of 1K queries/mo.</p>
+  <p class="hint" x-show="provider === 'searxng'">Self-hosted metasearch — no API key, no per-query cost. Ship it with the bundled <code>docker-compose.searxng.yml</code>.</p>
+
+  <div class="mt-3" x-show="provider === 'tavily'">
+    <label class="label" for="w-tavily-key">Tavily API Key</label>
+    <input type="password" class="input" id="w-tavily-key" name="tavily_key" placeholder="tvly-..."
+           value="{{ step_ctx.tavily_key|default('') }}">
+    <p class="hint">Free tier at <a href="https://app.tavily.com" target="_blank">app.tavily.com</a></p>
+  </div>
+
+  <div class="mt-3" x-show="provider === 'searxng'">
+    <label class="label" for="w-searxng-url">Instance URL</label>
+    <input type="text" class="input" id="w-searxng-url" name="searxng_url" placeholder="http://searxng:8080"
+           value="{{ step_ctx.searxng_url|default('') }}">
+    <p class="hint">Base URL of your SearXNG instance (JSON format must be enabled).</p>
+  </div>
 
   <div class="mt-3">
-    <button class="btn" :disabled="testing"
-            @click="
-              testing = true; testResult = '';
-              fetch('/setup/test-connection', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({service: 'tavily', api_key: document.getElementById('w-tavily-key').value})
-              })
-              .then(r => r.json())
-              .then(d => { testOk = d.ok; testResult = d.ok ? 'Search working (' + d.results + ' results)' : d.error; })
-              .catch(e => { testOk = false; testResult = e.message; })
-              .finally(() => { testing = false; })
-            ">
+    <button class="btn" :disabled="testing" @click="test()">
       <span x-show="testing" class="spinner mr-1"></span>
       Test connection
     </button>
@@ -40,21 +77,7 @@
               hx-vals='{"step": "browser", "values": {}}'>
         Skip
       </button>
-      <button class="btn-primary"
-              @click="
-                const key = document.getElementById('w-tavily-key').value;
-                htmx.ajax('POST', '/setup/step', {
-                  target: '#wizard-step', swap: 'innerHTML',
-                  values: {
-                    step: 'browser',
-                    'values[search.enabled]': key ? 'true' : 'false',
-                    'values[search.api_key]': key,
-                    'values[search.provider]': 'tavily'
-                  }
-                })
-              ">
-        Next
-      </button>
+      <button class="btn-primary" @click="next()">Next</button>
     </div>
   </div>
 </div>

--- a/humux/config.yml.example
+++ b/humux/config.yml.example
@@ -111,8 +111,10 @@ admin:
 
 search:
   enabled: true
-  provider: "tavily"
-  api_key: "${TAVILY_API_KEY}"
+  provider: "tavily"            # "tavily" (hosted, needs api_key) | "searxng" (self-hosted, needs searxng_url)
+  api_key: "${TAVILY_API_KEY}"  # Tavily only
+  searxng_url: ""               # SearXNG only — instance base URL, e.g. http://searxng:8080.
+                                # Stand one up: docker compose -f docker-compose.yml -f docker-compose.searxng.yml up -d
   max_results: 5
 
 # Vision fallback — when the active model can't read images, route image

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -22,7 +22,7 @@ from tavily import TavilyClient
 from core import coding, imagegen
 from core.agents import Agent, AgentStore, default_agent_from_values, topic_base_id
 from core.compaction import compact_messages, should_compact
-from core.config import Config
+from core.config import Config, search_ready
 from core.embeddings import LOCAL_PROVIDERS, EmbeddingClient, LocalEmbeddingClient
 from core.executor import ToolExecutor
 from core.goal_decomposition import DecomposedGoal, classify_complexity, decompose_goal
@@ -1036,15 +1036,20 @@ class AgentCore:
         # prune oldest keys if that ever shows up in memory.
         self._reply_times: dict[tuple[str, str], list[float]] = {}
 
-        # Web search (Tavily)
-        if config.search.enabled and config.search.api_key:
-            self.search_client: TavilyClient | None = TavilyClient(
-                api_key=config.search.api_key,
+        # Web search — Tavily needs an SDK client; SearXNG is just an async HTTP
+        # GET (no client). self.search_enabled gates the tool for both providers.
+        self.search_client: TavilyClient | None = None
+        self.search_enabled = search_ready(config.search)
+        if self.search_enabled and config.search.provider == "tavily":
+            self.search_client = TavilyClient(api_key=config.search.api_key)
+        if config.search.enabled:
+            log.info(
+                "Web search %s (provider: %s)",
+                "enabled" if self.search_enabled else "misconfigured",
+                config.search.provider,
             )
-            log.info("Web search enabled (provider: %s)", config.search.provider)
         else:
-            self.search_client = None
-            log.info("Web search disabled (no API key or not enabled)")
+            log.info("Web search disabled")
 
     async def process(
         self,
@@ -1581,7 +1586,7 @@ class AgentCore:
             imagegen_enabled=self.config.tools.imagegen.enabled,
             workspace_enabled=self.config.workspace.enabled
             and bool(self.config.workspace.directory.strip()),
-            search_enabled=self.search_client is not None,
+            search_enabled=self.search_enabled,
         )
 
     async def _turn_preamble(
@@ -3998,15 +4003,18 @@ class AgentCore:
         return int(usage.get("input_tokens", 0) or 0) + int(usage.get("output_tokens", 0) or 0)
 
     async def _tool_web_search(self, params: dict) -> dict:
-        """Search the web via Tavily API."""
-        if not self.search_client:
-            return {"error": "Web search is not configured. Set search.api_key in config."}
+        """Search the web via the configured provider (Tavily or SearXNG)."""
+        if not self.search_enabled:
+            return {"error": "Web search is not configured."}
 
         query = params.get("query", "").strip()
         if not query:
             return {"error": "Empty search query."}
 
         max_results = self.config.search.max_results
+
+        if self.config.search.provider == "searxng":
+            return await self._searxng_search(query, max_results)
 
         try:
             response = await asyncio.to_thread(
@@ -4033,6 +4041,38 @@ class AgentCore:
             "query": query,
             "results": results,
         }
+
+    async def _searxng_search(self, query: str, max_results: int) -> dict:
+        """Search via a self-hosted SearXNG instance's JSON API. Returns the same
+        {query, results:[{title,url,content}]} shape as the Tavily path."""
+        import httpx
+
+        base = self.config.search.searxng_url.rstrip("/")
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(20.0)) as client:
+                resp = await client.get(
+                    f"{base}/search",
+                    params={
+                        "q": query,
+                        "format": "json",
+                        "engines": "google,bing,duckduckgo",
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception as exc:
+            log.exception("SearXNG search failed for query: %s", query)
+            return {"error": f"Search failed: {exc}"}
+
+        results = [
+            {
+                "title": item.get("title", ""),
+                "url": item.get("url", ""),
+                "content": item.get("content", ""),
+            }
+            for item in data.get("results", [])[:max_results]
+        ]
+        return {"query": query, "results": results}
 
     async def _tool_generate_image(self, params: dict, request_state: dict) -> dict:
         """Generate an image and queue it for native-media delivery (issue #55).

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -318,9 +318,19 @@ class CompactionConfig(BaseModel):
 
 class SearchConfig(BaseModel):
     enabled: bool = False
-    provider: str = "tavily"
-    api_key: str = ""
+    provider: str = "tavily"  # "tavily" | "searxng"
+    api_key: str = ""  # Tavily only
+    searxng_url: str = ""  # SearXNG instance base URL, e.g. http://searxng:8080
     max_results: int = 5
+
+
+def search_ready(cfg: SearchConfig) -> bool:
+    """True when web search is enabled and the active provider is configured."""
+    if not cfg.enabled:
+        return False
+    if cfg.provider == "searxng":
+        return bool(cfg.searxng_url.strip())
+    return bool(cfg.api_key.strip())  # tavily
 
 
 class VisionConfig(BaseModel):

--- a/humux/docker-compose.searxng.yml
+++ b/humux/docker-compose.searxng.yml
@@ -1,0 +1,24 @@
+# SearXNG search backend (issue #64) — a self-hosted, zero-cost alternative to
+# Tavily. Layer this over the main compose file to run SearXNG alongside humux:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.searxng.yml up -d
+#
+# Then in the admin UI (Tools → Web search) or setup wizard, pick provider
+# "SearXNG" and set the instance URL to  http://searxng:8080  (the agent reaches
+# the sidecar by service name on the shared compose network). The JSON API is
+# pre-enabled via ./searxng/settings.yml — no manual configuration needed.
+services:
+  searxng:
+    image: searxng/searxng:latest
+    container_name: humux-searxng
+    restart: unless-stopped
+    ports:
+      # Optional: exposes the browsable UI on the host. Drop this line to keep
+      # SearXNG reachable only from the agent on the internal compose network.
+      - "8080:8080"
+    volumes:
+      - ./searxng:/etc/searxng:rw
+    environment:
+      # Public base URL of the instance (used for absolute links); harmless at
+      # personal scale even if you don't expose it.
+      - SEARXNG_BASE_URL=http://localhost:8080/

--- a/humux/searxng/settings.yml
+++ b/humux/searxng/settings.yml
@@ -1,0 +1,21 @@
+# SearXNG settings for the bundled humux sidecar (issue #64).
+# Inherits SearXNG's shipped defaults and overrides only what humux needs:
+# the JSON API (off by default upstream) and a couple of sane personal-scale knobs.
+# No manual editing required — `docker compose -f docker-compose.yml -f
+# docker-compose.searxng.yml up` gives a working JSON backend at http://searxng:8080.
+use_default_settings: true
+
+server:
+  # CHANGE THIS to any random string before exposing the instance publicly.
+  secret_key: "humux-searxng-change-me"
+  # ponytail: limiter off = no Redis sidecar needed at personal volumes. Turn it
+  # on (and add a redis service) only if the instance is public / high-traffic.
+  limiter: false
+  image_proxy: true
+
+search:
+  # The whole point of this override: expose the machine-readable JSON API the
+  # agent's web_search tool calls. html stays on for the browsable UI.
+  formats:
+    - html
+    - json


### PR DESCRIPTION
## What

Adds **SearXNG** as a self-hosted, zero-cost web-search backend alongside Tavily. Closes #64.

The `web_search` tool's contract to the model is unchanged — provider is a config choice:

```yaml
search:
  provider: "searxng"          # or "tavily"
  searxng_url: "http://searxng:8080"
```

## Changes

- **Config** (`core/config.py`): new `search.searxng_url`; shared `search_ready()` helper decides whether the active provider is configured.
- **Agent** (`core/agent.py`): `self.search_enabled` gates the tool for both providers; `_tool_web_search` branches to `_searxng_search` — one async `httpx` GET to `{url}/search?format=json`, mapped to the same `{query, results:[{title,url,content}]}` shape. Unreachable instance → graceful `{error}`, no crash.
- **Admin UI** (`partials/tools.html`, `base.html`): provider picker + conditional URL field + connection test (`_test_searxng`), usable at phone width.
- **Setup wizard** (`wizard/search.html`): provider step offering Tavily (key) or SearXNG (URL), each with a test button.
- **Compose** (`docker-compose.searxng.yml` + `searxng/settings.yml`): one-command SearXNG with the JSON API pre-enabled — no manual `settings.yml` editing.

```bash
docker compose -f docker-compose.yml -f docker-compose.searxng.yml up -d
```

- **Docs**: `configuration.mdx`, `config.yml.example`, README.

## Notes

- No migration; existing Tavily setups are untouched (`provider` defaulted to `tavily` already).
- `searxng_url` is a plaintext URL, not a vault secret.
- SearXNG returns snippet-only results; full-page content is fetched via the existing browser/`w3m`/`curl` tools — the same two-step pattern used elsewhere.
- Skipped a provider-strategy abstraction: two providers = one branch on `provider`. Add a class only if a third lands.

## Test

- `search_ready` truth table + `_searxng_search` parse/error paths verified against a live fake JSON endpoint.
- `test_tools.py`, `test_admin_ui.py`, `test_config_store.py`, `test_secrets_vault.py` green.
