### PR TITLE
feat: add header, footer, quick actions, and responsive padding to admin UI

### DIFF
--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -17,8 +17,47 @@
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
   {% block head %}{% endblock %}
 </head>
-<body class="py-8" style="padding-left: 32px; padding-right: 32px;">
-  {% block body %}{% endblock %}
+<body class="min-h-screen flex flex-col">
+
+  {# Header bar #}
+  <header class="sticky top-0 z-40 bg-[#0a0a0a]/95 backdrop-blur border-b border-border px-8 py-2.5">
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">
+      <div class="flex items-center gap-3">
+        <a href="/" class="flex items-center gap-2 no-underline">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="22" height="22">
+            <rect width="32" height="32" rx="6" fill="#060606"/>
+            <text x="16" y="22" font-family="'JetBrains Mono',monospace" font-size="18" font-weight="bold" fill="#6c9" text-anchor="middle">h</text>
+          </svg>
+          <span class="text-sm font-semibold tracking-wide">humux</span>
+        </a>
+        <span id="status-badge"
+              hx-get="/partials/status" hx-trigger="load, refresh-status from:body" hx-swap="innerHTML">
+          <span class="text-muted text-xs">Loading...</span>
+        </span>
+      </div>
+      <nav class="flex items-center gap-4 text-xs text-muted">
+        <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>
+        <a href="https://github.com/mattmezza/humux" target="_blank" class="hover:text-accent transition-colors">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  {# Main content #}
+  <main class="flex-1 px-8 py-6">
+    {% block body %}{% endblock %}
+  </main>
+
+  {# Footer #}
+  <footer class="border-t border-border px-8 py-3 text-xs text-muted">
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">
+      <span>humux v0.20.0</span>
+      <nav class="flex items-center gap-4">
+        <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>
+        <a href="https://github.com/mattmezza/humux" target="_blank" class="hover:text-accent transition-colors">GitHub</a>
+        <a href="https://humux.dev" target="_blank" class="hover:text-accent transition-colors">About</a>
+      </nav>
+    </div>
+  </footer>
 
   <div id="toast" style="position: fixed; right: 24px; bottom: 24px; display: none; z-index: 100; max-width: 360px;"></div>
 

--- a/humux/api/templates/dashboard.html
+++ b/humux/api/templates/dashboard.html
@@ -3,18 +3,25 @@
 
 {% block body %}
 <div>
-<!--
-  <div class="flex items-center justify-between gap-3 mb-2 flex-wrap">
-    <h1 class="text-xl text-accent">
-
-    </h1>
-  </div>
-    -->
-
-  {# Status bar — loaded via HTMX, refreshes on lifecycle events #}
-  <div id="status-bar" class="flex items-center gap-3 py-2 mb-4 flex-wrap"
-       hx-get="/partials/status" hx-trigger="load, refresh-status from:body" hx-swap="innerHTML">
-    <span class="text-muted text-xs">Loading...</span>
+  {# Quick-action cards #}
+  <div class="flex items-center gap-3 mb-5 flex-wrap">
+    <a href="/admin/skills/new" class="card px-4 py-2.5 text-xs hover:border-accent/40 transition-colors flex items-center gap-2 no-underline">
+      <span class="text-accent text-sm">+</span>
+      <span>New skill</span>
+    </a>
+    <a href="/admin?tab=jobs" class="card px-4 py-2.5 text-xs hover:border-accent/40 transition-colors flex items-center gap-2 no-underline">
+      <span class="text-muted text-sm">⚙</span>
+      <span>Jobs</span>
+    </a>
+    <a href="/admin?tab=inspect" class="card px-4 py-2.5 text-xs hover:border-accent/40 transition-colors flex items-center gap-2 no-underline">
+      <span class="text-muted text-sm">⬇</span>
+      <span>Inspect</span>
+    </a>
+    <button class="card px-4 py-2.5 text-xs hover:border-accent/40 transition-colors flex items-center gap-2 cursor-pointer"
+            onclick="openAgentModal()">
+      <span class="text-muted text-sm">▶</span>
+      <span>Agent control</span>
+    </button>
   </div>
 
   {# Restart-required banner — shown after saving a setting the agent only reads at

--- a/humux/api/templates/login.html
+++ b/humux/api/templates/login.html
@@ -4,7 +4,7 @@
 {% block body %}
 <div class="min-h-[80vh] flex items-center justify-center">
   <div class="w-full max-w-sm">
-    <h1 class="text-xl text-accent mb-6">Agent Admin</h1>
+    <h1 class="text-xl text-accent mb-6">humux</h1>
     <div class="card" x-data="{ error: '' }">
       <h2 class="text-base mb-4">Authentication</h2>
       <form @submit.prevent="


### PR DESCRIPTION
## What changed

### 1. Branded header bar (sticky)
Replaced the plain status-bar line with a proper dark header:
```
[ h humux ]  [ RUNNING ]   Docs  GitHub
```
- Inline SVG logo (lowercase-h from the favicon) + "humux" wordmark
- Agent status badge loaded via HTMX — clickable, opens the agent modal
- Docs and GitHub links on the right

### 2. Footer
A minimal sticky footer with version and links:
```
humux v0.20.0     Docs · GitHub · About
```

### 3. Quick-action cards
A row of 4 action cards sits below the tabs, above the tab content:
- **New skill** — shortcut to the skill editor
- **Jobs** — view active subagent runs
- **Inspect** — inspect payloads
- **Agent control** — opens the Start/Stop/Restart modal

### 4. Responsive padding
Inline `style="padding-left: 32px; padding-right: 32px"` replaced with Tailwind classes. Layout uses flex column for a proper sticky header + footer.

### 5. Login page consistency
Page title updated from "Agent Admin" to "humux".