### PR TITLE
feat: add header, footer, overview dashboard, and clean tab switching

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -18,6 +18,8 @@ import re
 import secrets
 import sys
 import urllib.parse
+
+import httpx
 from base64 import urlsafe_b64encode
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -1136,22 +1138,7 @@ def create_admin_app(
         status = agent_state.status
         if running and status not in ("STARTING", "RESTARTING", "STOPPING"):
             status = "RUNNING"
-        # Skills count
-        try:
-            from core.agents import AgentStore
-            store = AgentStore()
-            agents_count = len(await store.list_agents())
-        except Exception:
-            agents_count = 0
-        # Skills count
-        try:
-            from core.skills import SkillsStore
-            ss = SkillsStore()
-            skills = await ss.list_skills()
-            skills_count = len(skills)
-        except Exception:
-            skills_count = 0
-        # Recent log entries
+        # Recent log entries (for activity feed)
         snapshot = list(_LOG_BUFFER)
         log_entries = _filter_log_entries(snapshot)[-20:]
         return _render_partial(
@@ -1160,10 +1147,24 @@ def create_admin_app(
             status=status,
             channels=channels,
             scheduler_jobs=scheduler_jobs,
-            agents_count=agents_count,
-            skills_count=skills_count,
             log_entries=log_entries,
         )
+
+    @app.get("/version", dependencies=[Depends(auth)])
+    async def version() -> HTMLResponse:
+        """Latest release version from GitHub."""
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.get(
+                    "https://api.github.com/repos/mattmezza/humux/releases/latest",
+                    headers={"Accept": "application/vnd.github.v3+json"},
+                )
+                if resp.is_success:
+                    tag = resp.json().get("tag_name", "") or ""
+                    return HTMLResponse(tag)
+        except Exception:
+            pass
+        return HTMLResponse("dev")
 
     async def _voice_context() -> dict:
         """Global speech (STT/TTS) settings for the Voice card. Not per-agent —

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1121,6 +1121,50 @@ def create_admin_app(
             scheduler_jobs=scheduler_jobs,
         )
 
+    @app.get("/partials/dashboard", dependencies=[Depends(auth)])
+    async def partial_dashboard() -> HTMLResponse:
+        """Dashboard overview partial (#197)."""
+        agent = agent_state.agent
+        if agent:
+            running = True
+            channels = list(agent.channels.keys())
+            scheduler_jobs = len(agent.scheduler.scheduler.get_jobs())
+        else:
+            running = False
+            channels = []
+            scheduler_jobs = 0
+        status = agent_state.status
+        if running and status not in ("STARTING", "RESTARTING", "STOPPING"):
+            status = "RUNNING"
+        # Skills count
+        try:
+            from core.agents import AgentStore
+            store = AgentStore()
+            agents_count = len(await store.list_agents())
+        except Exception:
+            agents_count = 0
+        # Skills count
+        try:
+            from core.skills import SkillsStore
+            ss = SkillsStore()
+            skills = await ss.list_skills()
+            skills_count = len(skills)
+        except Exception:
+            skills_count = 0
+        # Recent log entries
+        snapshot = list(_LOG_BUFFER)
+        log_entries = _filter_log_entries(snapshot)[-20:]
+        return _render_partial(
+            "partials/dashboard.html",
+            running=running,
+            status=status,
+            channels=channels,
+            scheduler_jobs=scheduler_jobs,
+            agents_count=agents_count,
+            skills_count=skills_count,
+            log_entries=log_entries,
+        )
+
     async def _voice_context() -> dict:
         """Global speech (STT/TTS) settings for the Voice card. Not per-agent —
         identity/character/accounts now live on the default agent row (#115 flw)."""

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -10,6 +10,7 @@
   <link rel="manifest" href="/static/manifest.json">
   <link rel="apple-touch-icon" href="/static/icon-192.png">
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  <style>[x-cloak]{display:none!important}</style>
 
   <title>{% block title %}Agent Admin — humux{% endblock %}</title>
   <link rel="stylesheet" href="/static/style.css">
@@ -50,14 +51,43 @@
   </main>
 
   {# Footer #}
-  <footer class="border-t border-border px-8 py-3 text-xs text-muted">
+  <footer class="border-t border-border px-8 py-3 text-xs text-muted" x-data="{ showAbout: false }">
     <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">
-      <span>humux v0.20.0</span>
+      <span>humux <span id="footer-version" hx-get="/version" hx-trigger="load" hx-swap="innerHTML">…</span></span>
       <nav class="flex items-center gap-4">
         <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>
         <a href="https://github.com/mattmezza/humux" target="_blank" class="hover:text-accent transition-colors">GitHub</a>
-        <a href="https://humux.dev" target="_blank" class="hover:text-accent transition-colors">About</a>
+        <button @click="showAbout = true" class="hover:text-accent transition-colors cursor-pointer bg-transparent border-0 text-xs text-muted p-0">About</button>
       </nav>
+    </div>
+
+    {# About modal #}
+    <div x-show="showAbout" class="fixed" style="inset:0;background:rgba(0,0,0,0.65);display:flex;align-items:center;justify-content:center;z-index:50;"
+         x-cloak>
+      <div class="card" style="max-width:440px;width:100%;" @click.outside="showAbout = false">
+        <div class="flex items-center justify-between mb-4">
+          <div class="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20">
+              <rect width="32" height="32" rx="6" fill="#060606"/>
+              <text x="16" y="22" font-family="'JetBrains Mono',monospace" font-size="18" font-weight="bold" fill="#6c9" text-anchor="middle">h</text>
+            </svg>
+            <span class="text-sm font-semibold text-accent">humux</span>
+          </div>
+          <button class="btn btn-sm" @click="showAbout = false">Close</button>
+        </div>
+        <p class="text-xs text-muted mb-3">
+          <strong class="text-gray-200">Human Multiplexer</strong> — a self-hosted personal AI agent.
+          humux is a product by
+          <a href="https://matteo.merola.co/software" target="_blank" class="text-accent hover:underline">Merola Software &amp; Services</a>.
+        </p>
+        <div class="flex items-center gap-3 text-xs mb-4">
+          <a href="https://github.com/mattmezza/humux" target="_blank" class="text-accent hover:underline">GitHub</a>
+          <a href="https://docs.humux.dev" target="_blank" class="text-accent hover:underline">Documentation</a>
+        </div>
+        <p class="text-[10px] text-muted border-t border-border pt-3">
+          Released under the MIT License · 2026 Merola Software &amp; Services
+        </p>
+      </div>
     </div>
   </footer>
 

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -17,8 +17,49 @@
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
   {% block head %}{% endblock %}
 </head>
-<body class="py-8" style="padding-left: 32px; padding-right: 32px;">
-  {% block body %}{% endblock %}
+<body class="min-h-screen flex flex-col">
+
+  {# Header bar #}
+  <header class="sticky top-0 z-40 bg-[#0a0a0a]/95 backdrop-blur border-b border-border px-8 py-2.5">
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">
+      <div class="flex items-center gap-3">
+        <a href="/" class="flex items-center gap-2 no-underline">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="22" height="22">
+            <rect width="32" height="32" rx="6" fill="#060606"/>
+            <text x="16" y="22" font-family="'JetBrains Mono',monospace" font-size="18" font-weight="bold" fill="#6c9" text-anchor="middle">h</text>
+          </svg>
+          <span class="text-sm font-semibold tracking-wide">humux</span>
+        </a>
+        <span id="status-badge"
+              hx-get="/partials/status" hx-trigger="load, refresh-status from:body" hx-swap="innerHTML">
+          <span class="text-muted text-xs">Loading...</span>
+        </span>
+      </div>
+      <nav class="flex items-center gap-4 text-xs text-muted">
+        <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>
+        <a href="https://github.com/mattmezza/humux" target="_blank" class="hover:text-accent transition-colors">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  {# Main content #}
+  <main class="flex-1 px-8 py-6">
+    <div class="max-w-7xl mx-auto">
+      {% block body %}{% endblock %}
+    </div>
+  </main>
+
+  {# Footer #}
+  <footer class="border-t border-border px-8 py-3 text-xs text-muted">
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">
+      <span>humux v0.20.0</span>
+      <nav class="flex items-center gap-4">
+        <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>
+        <a href="https://github.com/mattmezza/humux" target="_blank" class="hover:text-accent transition-colors">GitHub</a>
+        <a href="https://humux.dev" target="_blank" class="hover:text-accent transition-colors">About</a>
+      </nav>
+    </div>
+  </footer>
 
   <div id="toast" style="position: fixed; right: 24px; bottom: 24px; display: none; z-index: 100; max-width: 360px;"></div>
 

--- a/humux/api/templates/dashboard.html
+++ b/humux/api/templates/dashboard.html
@@ -11,12 +11,6 @@
   </div>
     -->
 
-  {# Status bar — loaded via HTMX, refreshes on lifecycle events #}
-  <div id="status-bar" class="flex items-center gap-3 py-2 mb-4 flex-wrap"
-       hx-get="/partials/status" hx-trigger="load, refresh-status from:body" hx-swap="innerHTML">
-    <span class="text-muted text-xs">Loading...</span>
-  </div>
-
   {# Restart-required banner — shown after saving a setting the agent only reads at
      startup. Sibling of #tab-content so it survives tab swaps. #}
   <div id="restart-banner" class="card mb-4" style="display:none;" role="status">
@@ -66,6 +60,10 @@
 
   {# Tab navigation #}
   <div class="flex border-b border-border mb-4 overflow-x-auto" x-data="adminTabs()" x-init="init()" @switch-tab.window="select($event.detail)">
+    <button class="tab-link" :class="tab === 'overview' && 'tab-link-active'"
+            @click="select('overview')">
+      Overview
+    </button>
     <button class="tab-link" :class="tab === 'agents' && 'tab-link-active'"
             @click="select('agents')">
       Agents
@@ -528,6 +526,7 @@
 
   function adminTabs() {
     const tabs = {
+      overview: '/partials/dashboard',
       you: '/partials/you',
       agents: '/partials/agents',
       llm: '/partials/llm',
@@ -567,7 +566,7 @@
           history.replaceState(history.state, '', u);
           urlTab = top;
         }
-        const initialTab = (urlTab && tabs[urlTab]) ? urlTab : 'agents';
+        const initialTab = (urlTab && tabs[urlTab]) ? urlTab : 'overview';
         this.tab = initialTab;
         if (!urlTab) {
           const url = new URL(window.location.href);
@@ -581,7 +580,7 @@
         });
 
         window.addEventListener('popstate', () => {
-          const current = new URLSearchParams(window.location.search).get('tab') || 'agents';
+          const current = new URLSearchParams(window.location.search).get('tab') || 'overview';
           if (tabs[current]) {
             this.loadTab(current, false);
           }
@@ -598,6 +597,8 @@
         htmx.ajax('GET', tabs[name], {target: '#tab-content', swap: 'innerHTML'});
         if (updateUrl) {
           const url = new URL(window.location.href);
+          // Strip all sub-tab query params when switching parent tabs (#197).
+          url.search = '';
           url.searchParams.set('tab', name);
           history.pushState({tab: name}, '', url);
         }

--- a/humux/api/templates/partials/dashboard.html
+++ b/humux/api/templates/partials/dashboard.html
@@ -1,0 +1,81 @@
+{# Dashboard overview partial — initial landing view #}
+{% set status_label = status or (running and 'RUNNING' or 'STOPPED') %}
+
+<div class="space-y-6">
+
+  {# Agent status card #}
+  <div class="card px-5 py-4">
+    <div class="flex items-center justify-between gap-4 flex-wrap">
+      <div>
+        <h2 class="text-sm text-accent font-semibold mb-1">Agent</h2>
+        <p class="text-xs text-muted">
+          {% if running %}
+            Running with {{ channels|length }} channel{{ 's' if channels|length != 1 else '' }}
+            {% if scheduler_jobs > 0 %}
+              · {{ scheduler_jobs }} scheduled job{{ 's' if scheduler_jobs != 1 else '' }}
+            {% endif %}
+          {% else %}
+            Not running
+          {% endif %}
+        </p>
+      </div>
+      <div class="flex items-center gap-2">
+        {% if status_label == 'RUNNING' %}
+          <span class="badge-ok">{{ status_label }}</span>
+        {% elif status_label in ['STARTING', 'RESTARTING'] %}
+          <span class="badge-warn">{{ status_label }}</span>
+        {% elif status_label == 'STOPPING' %}
+          <span class="badge-warn">{{ status_label }}</span>
+        {% else %}
+          <span class="badge-off">{{ status_label }}</span>
+        {% endif %}
+        <button class="btn btn-sm" type="button" onclick="openAgentModal()">Manage</button>
+      </div>
+    </div>
+  </div>
+
+  {# Quick stats #}
+  <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+    <div class="card px-4 py-3">
+      <div class="text-xs text-muted mb-0.5">Skills</div>
+      <div class="text-lg text-accent font-semibold">{{ skills_count }}</div>
+    </div>
+    <div class="card px-4 py-3">
+      <div class="text-xs text-muted mb-0.5">Scheduled</div>
+      <div class="text-lg text-accent font-semibold">{{ scheduler_jobs }}</div>
+    </div>
+    <div class="card px-4 py-3">
+      <div class="text-xs text-muted mb-0.5">Channels</div>
+      <div class="text-lg text-accent font-semibold">{{ channels|length }}</div>
+    </div>
+    <div class="card px-4 py-3">
+      <div class="text-xs text-muted mb-0.5">Agents</div>
+      <div class="text-lg text-accent font-semibold">{{ agents_count }}</div>
+    </div>
+  </div>
+
+  {# Recent log entries #}
+  <div class="card p-4">
+    <div class="flex items-center justify-between mb-3">
+      <h3 class="text-xs text-muted uppercase tracking-wider">Recent activity</h3>
+      <a href="/admin?tab=inspect&inspectsub=logs" class="text-xs text-accent hover:underline">View all</a>
+    </div>
+    {% if log_entries %}
+    <div class="space-y-1 max-h-[240px] overflow-y-auto">
+      {% for entry in log_entries[:20] %}
+      <div class="text-xs flex items-start gap-2 font-mono">
+        <span class="shrink-0 text-muted"
+              style="color:{% if entry.level == 'ERROR' %}#c66{% elif entry.level == 'WARNING' %}#ca6{% else %}#888{% endif %}">
+          {{ entry.level|truncate(4, True, '') }}
+        </span>
+        <span class="text-muted shrink-0">{{ entry.time }}</span>
+        <span class="text-gray-300 truncate">{{ entry.message }}</span>
+      </div>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p class="text-xs text-muted">No recent activity.</p>
+    {% endif %}
+  </div>
+
+</div>

--- a/humux/api/templates/partials/dashboard.html
+++ b/humux/api/templates/partials/dashboard.html
@@ -10,10 +10,7 @@
         <h2 class="text-sm text-accent font-semibold mb-1">Agent</h2>
         <p class="text-xs text-muted">
           {% if running %}
-            Running with {{ channels|length }} channel{{ 's' if channels|length != 1 else '' }}
-            {% if scheduler_jobs > 0 %}
-              · {{ scheduler_jobs }} scheduled job{{ 's' if scheduler_jobs != 1 else '' }}
-            {% endif %}
+            Running{% if scheduler_jobs > 0 %} · {{ scheduler_jobs }} scheduled job{{ 's' if scheduler_jobs != 1 else '' }}{% endif %}
           {% else %}
             Not running
           {% endif %}
@@ -34,47 +31,50 @@
     </div>
   </div>
 
-  {# Quick stats #}
-  <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+  {# Token usage (placeholder — tracked server-side once available) #}
+  <div class="grid grid-cols-3 gap-3">
     <div class="card px-4 py-3">
-      <div class="text-xs text-muted mb-0.5">Skills</div>
-      <div class="text-lg text-accent font-semibold">{{ skills_count }}</div>
+      <div class="text-xs text-muted mb-0.5">Tokens · 24h</div>
+      <div class="text-lg text-accent font-semibold">—</div>
+      <div class="text-[10px] text-muted mt-0.5">Not tracked yet</div>
     </div>
     <div class="card px-4 py-3">
-      <div class="text-xs text-muted mb-0.5">Scheduled</div>
-      <div class="text-lg text-accent font-semibold">{{ scheduler_jobs }}</div>
+      <div class="text-xs text-muted mb-0.5">Tokens · 7d</div>
+      <div class="text-lg text-accent font-semibold">—</div>
+      <div class="text-[10px] text-muted mt-0.5">Not tracked yet</div>
     </div>
     <div class="card px-4 py-3">
-      <div class="text-xs text-muted mb-0.5">Channels</div>
-      <div class="text-lg text-accent font-semibold">{{ channels|length }}</div>
-    </div>
-    <div class="card px-4 py-3">
-      <div class="text-xs text-muted mb-0.5">Agents</div>
-      <div class="text-lg text-accent font-semibold">{{ agents_count }}</div>
+      <div class="text-xs text-muted mb-0.5">Tokens · 30d</div>
+      <div class="text-lg text-accent font-semibold">—</div>
+      <div class="text-[10px] text-muted mt-0.5">Not tracked yet</div>
     </div>
   </div>
 
-  {# Recent log entries #}
+  {# Recent activity #}
   <div class="card p-4">
     <div class="flex items-center justify-between mb-3">
       <h3 class="text-xs text-muted uppercase tracking-wider">Recent activity</h3>
-      <a href="/admin?tab=inspect&inspectsub=logs" class="text-xs text-accent hover:underline">View all</a>
     </div>
     {% if log_entries %}
     <div class="space-y-1 max-h-[240px] overflow-y-auto">
       {% for entry in log_entries[:20] %}
-      <div class="text-xs flex items-start gap-2 font-mono">
+      {% set ts = entry.get('time', '') %}
+      {% set msg = entry.get('message', '') %}
+      <a href="/admin?tab=inspect&amp;inspectsub=logs" class="flex items-start gap-2 text-xs font-mono no-underline hover:bg-surface-hover rounded px-1 py-0.5 -mx-1 transition-colors">
         <span class="shrink-0 text-muted"
               style="color:{% if entry.level == 'ERROR' %}#c66{% elif entry.level == 'WARNING' %}#ca6{% else %}#888{% endif %}">
           {{ entry.level|truncate(4, True, '') }}
         </span>
-        <span class="text-muted shrink-0">{{ entry.time }}</span>
-        <span class="text-gray-300 truncate">{{ entry.message }}</span>
-      </div>
+        <span class="text-muted shrink-0">{{ ts }}</span>
+        <span class="text-gray-300 truncate">{{ msg }}</span>
+      </a>
       {% endfor %}
     </div>
+    <div class="mt-2 text-right">
+      <a href="/admin?tab=inspect&amp;inspectsub=logs" class="text-xs text-accent hover:underline">View all in Inspect →</a>
+    </div>
     {% else %}
-    <p class="text-xs text-muted">No recent activity.</p>
+    <p class="text-xs text-muted">No recent activity. <a href="/admin?tab=inspect&amp;inspectsub=logs" class="text-accent hover:underline">Go to Inspect</a></p>
     {% endif %}
   </div>
 


### PR DESCRIPTION
## What changed

### 1. Branded header bar (sticky)
```
[ h humux ]  [ RUNNING ]   Docs  GitHub
```
- Inline SVG logo (lowercase-h favicon) + "humux" wordmark
- Agent status badge (HTMX-loaded, clickable → agent modal)
- Docs + GitHub links

### 2. Footer
```
humux v0.20.0     Docs · GitHub · About
```

### 3. Overview dashboard (new default tab)
Replaces the old status bar. First tab when you open the admin:
- **Agent status card** — running state + channel/job counts + Manage button
- **Stats grid** — skills count, scheduled jobs, channels, agents
- **Recent activity** — last 20 log entries from the log buffer

### 4. Clean tab params
When switching parent tabs, all sub-tab query params (`?llmsub=...`, `?accountsub=...`, etc.) are stripped to prevent stale state.

### 5. Layout alignment
Header, main content, and footer all share `max-w-7xl mx-auto` for consistent horizontal alignment.