### PR TITLE
feat: header, footer, overview tab with real token stats, about modal (#199)

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1162,6 +1162,22 @@ def create_admin_app(
             log_entries=log_entries,
         )
 
+    @app.get("/version", dependencies=[Depends(auth)])
+    async def version() -> HTMLResponse:
+        """Latest release version from GitHub."""
+        try:
+            async with httpx.AsyncClient(timeout=5) as client:
+                resp = await client.get(
+                    "https://api.github.com/repos/mattmezza/humux/releases/latest",
+                    headers={"Accept": "application/vnd.github.v3+json"},
+                )
+                if resp.is_success:
+                    tag = resp.json().get("tag_name", "") or ""
+                    return HTMLResponse(tag)
+        except Exception:
+            pass
+        return HTMLResponse("dev")
+
     async def _voice_context() -> dict:
         """Global speech (STT/TTS) settings for the Voice card. Not per-agent —
         identity/character/accounts now live on the default agent row (#115 flw)."""

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -91,9 +91,19 @@ _jinja_env = Environment(
     autoescape=True,
     auto_reload=True,
 )
+def _fmt_tokens(n: int) -> str:
+    """Format a token count with k/M/G suffix (#199)."""
+    if n >= 1_000_000_000:
+        return f"{n / 1_000_000_000:.2f}".rstrip("0").rstrip(".") + "G"
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.2f}".rstrip("0").rstrip(".") + "M"
+    if n >= 1_000:
+        return f"{n / 1_000:.2f}".rstrip("0").rstrip(".") + "k"
+    return str(n)
+
+
 _jinja_env.globals["step_ctx"] = {}  # default empty dict for wizard templates
-
-
+_jinja_env.globals["fmt_tokens"] = _fmt_tokens
 def _render(template_name: str, **ctx: object) -> HTMLResponse:
     """Render a Jinja2 template and return an HTMLResponse."""
     tmpl = _jinja_env.get_template(template_name)

--- a/humux/api/templates/agent_editor.html
+++ b/humux/api/templates/agent_editor.html
@@ -52,6 +52,9 @@
         <label class="label">Character &amp; tone <span class="text-muted">— who the agent is + tone & behaviour</span></label>
         <textarea class="textarea" x-model="character" style="min-height:260px; font-size:0.8rem; line-height:1.5"
                   placeholder="You are a strength &amp; conditioning coach…&#10;&#10;## Tone&#10;- Direct and motivating…"></textarea>
+        <div class="hint flex justify-between"><span></span>
+          <span class="text-[10px] text-muted" x-text="'~' + window.estimateTokens(character) + ' tokens'"></span>
+        </div>
       </div>
 
       {# Per-agent voice override — only the voices valid for the active global

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -62,27 +62,27 @@
     </div>
 
     {# About modal #}
-    <div x-show="showAbout" class="fixed" style="inset:0;background:rgba(0,0,0,0.65);display:flex;align-items:center;justify-content:center;z-index:50;"
+    <div x-show="showAbout"
+         class="fixed inset-0 z-50 flex items-center justify-center"
+         style="background:rgba(0,0,0,0.65);"
          x-cloak
          @keydown.window.escape="showAbout = false">
-      <div class="card" style="max-width:440px;width:100%;" @click.outside="showAbout = false">
-        <div class="flex items-center justify-between mb-4">
-          <a :href="'https://humux.dev?ref=' + window.location.hostname" target="_blank" class="flex items-center gap-2 no-underline hover:opacity-80 transition-opacity">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20">
+      <div class="card mx-4" style="max-width:440px;width:100%;" @click.outside="showAbout = false">
+        <div class="flex items-start justify-between mb-4 gap-3">
+          <a :href="'https://humux.dev?ref=' + window.location.hostname" target="_blank" class="flex items-center gap-2 no-underline hover:opacity-80 transition-opacity group">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="22" height="22">
               <rect width="32" height="32" rx="6" fill="#060606"/>
               <text x="16" y="22" font-family="'JetBrains Mono',monospace" font-size="18" font-weight="bold" fill="#6c9" text-anchor="middle">h</text>
             </svg>
-            <span class="text-sm font-semibold text-accent">humux</span>
+            <div>
+              <span class="text-sm font-semibold text-accent group-hover:underline">humux</span>
+              <span class="font-mono text-[10px] text-muted block leading-tight">/ˈhjuːmʌks/</span>
+            </div>
           </a>
-          <button class="btn btn-sm" @click="showAbout = false">Close</button>
+          <button class="btn btn-sm shrink-0" @click="showAbout = false">Close</button>
         </div>
-        <p class="text-xs text-muted mb-2">
-          <strong class="text-gray-200">Human Multiplexer</strong> — a self-hosted personal AI agent.
-        </p>
-        <p class="text-xs text-muted mb-1">
-          <span class="font-mono text-gray-300">/ˈhjuːmʌks/</span>
-        </p>
         <p class="text-xs text-muted mb-3">
+          <strong class="text-gray-200">Human Multiplexer</strong> — a self-hosted personal AI agent.
           humux is a product by
           <a href="https://matteo.merola.co/software" target="_blank" class="text-accent hover:underline">Merola Software &amp; Services</a>.
         </p>

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -89,7 +89,7 @@
         <div class="flex items-center gap-3 text-xs mb-4">
           <a href="https://github.com/mattmezza/humux" target="_blank" class="text-accent hover:underline">GitHub</a>
           <a href="https://docs.humux.dev" target="_blank" class="text-accent hover:underline">Documentation</a>
-          <a href="https://humux.dev" target="_blank" class="text-accent hover:underline">humux.dev</a>
+          <a :href="'https://humux.dev?ref=' + window.location.hostname" target="_blank" class="text-accent hover:underline">humux.dev</a>
         </div>
         <p class="text-[10px] text-muted border-t border-border pt-3">
           Released under the MIT License · 2026 Merola Software &amp; Services

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -10,6 +10,7 @@
   <link rel="manifest" href="/static/manifest.json">
   <link rel="apple-touch-icon" href="/static/icon-192.png">
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+  <style>[x-cloak]{display:none!important}</style>
 
   <title>{% block title %}Agent Admin — humux{% endblock %}</title>
   <link rel="stylesheet" href="/static/style.css">
@@ -50,14 +51,43 @@
   </main>
 
   {# Footer #}
-  <footer class="border-t border-border px-8 py-3 text-xs text-muted">
+  <footer class="border-t border-border px-8 py-3 text-xs text-muted" x-data="{ showAbout: false }">
     <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">
-      <span>humux v0.20.0</span>
+      <span>humux <span id="footer-version" hx-get="/version" hx-trigger="load" hx-swap="innerHTML">…</span></span>
       <nav class="flex items-center gap-4">
         <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>
         <a href="https://github.com/mattmezza/humux" target="_blank" class="hover:text-accent transition-colors">GitHub</a>
-        <a href="https://humux.dev" target="_blank" class="hover:text-accent transition-colors">About</a>
+        <button @click="showAbout = true" class="hover:text-accent transition-colors cursor-pointer bg-transparent border-0 text-xs text-muted p-0">About</button>
       </nav>
+    </div>
+
+    {# About modal #}
+    <div x-show="showAbout" class="fixed" style="inset:0;background:rgba(0,0,0,0.65);display:flex;align-items:center;justify-content:center;z-index:50;"
+         x-cloak>
+      <div class="card" style="max-width:440px;width:100%;" @click.outside="showAbout = false">
+        <div class="flex items-center justify-between mb-4">
+          <div class="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20">
+              <rect width="32" height="32" rx="6" fill="#060606"/>
+              <text x="16" y="22" font-family="'JetBrains Mono',monospace" font-size="18" font-weight="bold" fill="#6c9" text-anchor="middle">h</text>
+            </svg>
+            <span class="text-sm font-semibold text-accent">humux</span>
+          </div>
+          <button class="btn btn-sm" @click="showAbout = false">Close</button>
+        </div>
+        <p class="text-xs text-muted mb-3">
+          <strong class="text-gray-200">Human Multiplexer</strong> — a self-hosted personal AI agent.
+          humux is a product by
+          <a href="https://matteo.merola.co/software" target="_blank" class="text-accent hover:underline">Merola Software &amp; Services</a>.
+        </p>
+        <div class="flex items-center gap-3 text-xs mb-4">
+          <a href="https://github.com/mattmezza/humux" target="_blank" class="text-accent hover:underline">GitHub</a>
+          <a href="https://docs.humux.dev" target="_blank" class="text-accent hover:underline">Documentation</a>
+        </div>
+        <p class="text-[10px] text-muted border-t border-border pt-3">
+          Released under the MIT License · 2026 Merola Software &amp; Services
+        </p>
+      </div>
     </div>
   </footer>
 

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -63,26 +63,33 @@
 
     {# About modal #}
     <div x-show="showAbout" class="fixed" style="inset:0;background:rgba(0,0,0,0.65);display:flex;align-items:center;justify-content:center;z-index:50;"
-         x-cloak>
+         x-cloak
+         @keydown.window.escape="showAbout = false">
       <div class="card" style="max-width:440px;width:100%;" @click.outside="showAbout = false">
         <div class="flex items-center justify-between mb-4">
-          <div class="flex items-center gap-2">
+          <a :href="'https://humux.dev?ref=' + window.location.hostname" target="_blank" class="flex items-center gap-2 no-underline hover:opacity-80 transition-opacity">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20">
               <rect width="32" height="32" rx="6" fill="#060606"/>
               <text x="16" y="22" font-family="'JetBrains Mono',monospace" font-size="18" font-weight="bold" fill="#6c9" text-anchor="middle">h</text>
             </svg>
             <span class="text-sm font-semibold text-accent">humux</span>
-          </div>
+          </a>
           <button class="btn btn-sm" @click="showAbout = false">Close</button>
         </div>
-        <p class="text-xs text-muted mb-3">
+        <p class="text-xs text-muted mb-2">
           <strong class="text-gray-200">Human Multiplexer</strong> — a self-hosted personal AI agent.
+        </p>
+        <p class="text-xs text-muted mb-1">
+          <span class="font-mono text-gray-300">/ˈhjuːmʌks/</span>
+        </p>
+        <p class="text-xs text-muted mb-3">
           humux is a product by
           <a href="https://matteo.merola.co/software" target="_blank" class="text-accent hover:underline">Merola Software &amp; Services</a>.
         </p>
         <div class="flex items-center gap-3 text-xs mb-4">
           <a href="https://github.com/mattmezza/humux" target="_blank" class="text-accent hover:underline">GitHub</a>
           <a href="https://docs.humux.dev" target="_blank" class="text-accent hover:underline">Documentation</a>
+          <a href="https://humux.dev" target="_blank" class="text-accent hover:underline">humux.dev</a>
         </div>
         <p class="text-[10px] text-muted border-t border-border pt-3">
           Released under the MIT License · 2026 Merola Software &amp; Services

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -1354,6 +1354,21 @@
       }
     });
 
+    // Global: format a token count with k/M/G suffix (#199).
+    // 12530 → "12.53k", 1.23M → "1230000", 100.4M → "100400000", 1.34G → "1340000000"
+    function formatTokens(n) {
+      if (n >= 1e9) return (n / 1e9).toFixed(2).replace(/\.?0+$/, '') + 'G';
+      if (n >= 1e6) return (n / 1e6).toFixed(2).replace(/\.?0+$/, '') + 'M';
+      if (n >= 1e3) return (n / 1e3).toFixed(2).replace(/\.?0+$/, '') + 'k';
+      return String(n);
+    }
+    // Estimate tokens from character count (chars / 3.5).
+    function estimateTokens(text) {
+      return formatTokens(Math.round((text || '').length / 3.5));
+    }
+    window.formatTokens = formatTokens;
+    window.estimateTokens = estimateTokens;
+
     // Global: listen for HX-Trigger showToast events from the server
     document.body.addEventListener('showToast', function(e) {
       if (window.showToast && e.detail && e.detail.value) {

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -17,8 +17,49 @@
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.8/dist/cdn.min.js"></script>
   {% block head %}{% endblock %}
 </head>
-<body class="py-8" style="padding-left: 32px; padding-right: 32px;">
-  {% block body %}{% endblock %}
+<body class="min-h-screen flex flex-col">
+
+  {# Header bar #}
+  <header class="sticky top-0 z-40 bg-[#0a0a0a]/95 backdrop-blur border-b border-border px-8 py-2.5">
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">
+      <div class="flex items-center gap-3">
+        <a href="/" class="flex items-center gap-2 no-underline">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="22" height="22">
+            <rect width="32" height="32" rx="6" fill="#060606"/>
+            <text x="16" y="22" font-family="'JetBrains Mono',monospace" font-size="18" font-weight="bold" fill="#6c9" text-anchor="middle">h</text>
+          </svg>
+          <span class="text-sm font-semibold tracking-wide">humux</span>
+        </a>
+        <span id="status-badge"
+              hx-get="/partials/status" hx-trigger="load, refresh-status from:body" hx-swap="innerHTML">
+          <span class="text-muted text-xs">Loading...</span>
+        </span>
+      </div>
+      <nav class="flex items-center gap-4 text-xs text-muted">
+        <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>
+        <a href="https://github.com/mattmezza/humux" target="_blank" class="hover:text-accent transition-colors">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  {# Main content #}
+  <main class="flex-1 px-8 py-6">
+    <div class="max-w-7xl mx-auto">
+      {% block body %}{% endblock %}
+    </div>
+  </main>
+
+  {# Footer #}
+  <footer class="border-t border-border px-8 py-3 text-xs text-muted">
+    <div class="max-w-7xl mx-auto flex items-center justify-between gap-4">
+      <span>humux v0.20.0</span>
+      <nav class="flex items-center gap-4">
+        <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>
+        <a href="https://github.com/mattmezza/humux" target="_blank" class="hover:text-accent transition-colors">GitHub</a>
+        <a href="https://humux.dev" target="_blank" class="hover:text-accent transition-colors">About</a>
+      </nav>
+    </div>
+  </footer>
 
   <div id="toast" style="position: fixed; right: 24px; bottom: 24px; display: none; z-index: 100; max-width: 360px;"></div>
 

--- a/humux/api/templates/dashboard.html
+++ b/humux/api/templates/dashboard.html
@@ -11,12 +11,6 @@
   </div>
     -->
 
-  {# Status bar — loaded via HTMX, refreshes on lifecycle events #}
-  <div id="status-bar" class="flex items-center gap-3 py-2 mb-4 flex-wrap"
-       hx-get="/partials/status" hx-trigger="load, refresh-status from:body" hx-swap="innerHTML">
-    <span class="text-muted text-xs">Loading...</span>
-  </div>
-
   {# Restart-required banner — shown after saving a setting the agent only reads at
      startup. Sibling of #tab-content so it survives tab swaps. #}
   <div id="restart-banner" class="card mb-4" style="display:none;" role="status">
@@ -66,6 +60,10 @@
 
   {# Tab navigation #}
   <div class="flex border-b border-border mb-4 overflow-x-auto" x-data="adminTabs()" x-init="init()" @switch-tab.window="select($event.detail)">
+    <button class="tab-link" :class="tab === 'overview' && 'tab-link-active'"
+            @click="select('overview')">
+      Overview
+    </button>
     <button class="tab-link" :class="tab === 'agents' && 'tab-link-active'"
             @click="select('agents')">
       Agents
@@ -528,6 +526,7 @@
 
   function adminTabs() {
     const tabs = {
+      overview: '/partials/dashboard',
       you: '/partials/you',
       agents: '/partials/agents',
       llm: '/partials/llm',
@@ -567,7 +566,7 @@
           history.replaceState(history.state, '', u);
           urlTab = top;
         }
-        const initialTab = (urlTab && tabs[urlTab]) ? urlTab : 'agents';
+        const initialTab = (urlTab && tabs[urlTab]) ? urlTab : 'overview';
         this.tab = initialTab;
         if (!urlTab) {
           const url = new URL(window.location.href);
@@ -581,7 +580,7 @@
         });
 
         window.addEventListener('popstate', () => {
-          const current = new URLSearchParams(window.location.search).get('tab') || 'agents';
+          const current = new URLSearchParams(window.location.search).get('tab') || 'overview';
           if (tabs[current]) {
             this.loadTab(current, false);
           }
@@ -598,6 +597,8 @@
         htmx.ajax('GET', tabs[name], {target: '#tab-content', swap: 'innerHTML'});
         if (updateUrl) {
           const url = new URL(window.location.href);
+          // Strip all sub-tab query params when switching parent tabs (#197).
+          url.search = '';
           url.searchParams.set('tab', name);
           history.pushState({tab: name}, '', url);
         }

--- a/humux/api/templates/partials/dashboard.html
+++ b/humux/api/templates/partials/dashboard.html
@@ -35,18 +35,18 @@
   <div class="grid grid-cols-3 gap-3">
     <div class="card px-4 py-3">
       <div class="text-xs text-muted mb-0.5">Tokens · 24h</div>
-      <div class="text-lg text-accent font-semibold">{{ tok_24h.total_input + tok_24h.total_output }}</div>
-      <div class="text-[10px] text-muted mt-0.5">{{ tok_24h.total_input }} in / {{ tok_24h.total_output }} out</div>
+      <div class="text-lg text-accent font-semibold">{{ fmt_tokens(tok_24h.total_input + tok_24h.total_output) }}</div>
+      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_24h.total_input) }} in / {{ fmt_tokens(tok_24h.total_output) }} out</div>
     </div>
     <div class="card px-4 py-3">
       <div class="text-xs text-muted mb-0.5">Tokens · 7d</div>
-      <div class="text-lg text-accent font-semibold">{{ tok_7d.total_input + tok_7d.total_output }}</div>
-      <div class="text-[10px] text-muted mt-0.5">{{ tok_7d.total_input }} in / {{ tok_7d.total_output }} out</div>
+      <div class="text-lg text-accent font-semibold">{{ fmt_tokens(tok_7d.total_input + tok_7d.total_output) }}</div>
+      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_7d.total_input) }} in / {{ fmt_tokens(tok_7d.total_output) }} out</div>
     </div>
     <div class="card px-4 py-3">
       <div class="text-xs text-muted mb-0.5">Tokens · 30d</div>
-      <div class="text-lg text-accent font-semibold">{{ tok_30d.total_input + tok_30d.total_output }}</div>
-      <div class="text-[10px] text-muted mt-0.5">{{ tok_30d.total_input }} in / {{ tok_30d.total_output }} out</div>
+      <div class="text-lg text-accent font-semibold">{{ fmt_tokens(tok_30d.total_input + tok_30d.total_output) }}</div>
+      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_30d.total_input) }} in / {{ fmt_tokens(tok_30d.total_output) }} out</div>
     </div>
   </div>
 

--- a/humux/api/templates/partials/dashboard.html
+++ b/humux/api/templates/partials/dashboard.html
@@ -33,20 +33,23 @@
 
   {# Token usage — real data from TokenUsageStore #}
   <div class="grid grid-cols-3 gap-3">
+    {% set cr_24h = (tok_24h.total_cache_read / (tok_24h.total_cache_read + tok_24h.total_cache_creation) * 100)|round(1) if (tok_24h.total_cache_read + tok_24h.total_cache_creation) > 0 else 0 %}
+    {% set cr_7d = (tok_7d.total_cache_read / (tok_7d.total_cache_read + tok_7d.total_cache_creation) * 100)|round(1) if (tok_7d.total_cache_read + tok_7d.total_cache_creation) > 0 else 0 %}
+    {% set cr_30d = (tok_30d.total_cache_read / (tok_30d.total_cache_read + tok_30d.total_cache_creation) * 100)|round(1) if (tok_30d.total_cache_read + tok_30d.total_cache_creation) > 0 else 0 %}
     <div class="card px-4 py-3">
       <div class="text-xs text-muted mb-0.5">Tokens · 24h</div>
       <div class="text-lg text-accent font-semibold">{{ fmt_tokens(tok_24h.total_input + tok_24h.total_output) }}</div>
-      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_24h.total_input) }} in / {{ fmt_tokens(tok_24h.total_output) }} out</div>
+      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_24h.total_input) }} in / {{ fmt_tokens(tok_24h.total_output) }} out{% if cr_24h > 0 %} / {{ cr_24h }}% cached{% endif %}</div>
     </div>
     <div class="card px-4 py-3">
       <div class="text-xs text-muted mb-0.5">Tokens · 7d</div>
       <div class="text-lg text-accent font-semibold">{{ fmt_tokens(tok_7d.total_input + tok_7d.total_output) }}</div>
-      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_7d.total_input) }} in / {{ fmt_tokens(tok_7d.total_output) }} out</div>
+      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_7d.total_input) }} in / {{ fmt_tokens(tok_7d.total_output) }} out{% if cr_7d > 0 %} / {{ cr_7d }}% cached{% endif %}</div>
     </div>
     <div class="card px-4 py-3">
       <div class="text-xs text-muted mb-0.5">Tokens · 30d</div>
       <div class="text-lg text-accent font-semibold">{{ fmt_tokens(tok_30d.total_input + tok_30d.total_output) }}</div>
-      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_30d.total_input) }} in / {{ fmt_tokens(tok_30d.total_output) }} out</div>
+      <div class="text-[10px] text-muted mt-0.5">{{ fmt_tokens(tok_30d.total_input) }} in / {{ fmt_tokens(tok_30d.total_output) }} out{% if cr_30d > 0 %} / {{ cr_30d }}% cached{% endif %}</div>
     </div>
   </div>
 
@@ -56,9 +59,10 @@
     <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Provider breakdown (24h)</h3>
     <div class="space-y-1">
       {% for provider, counts in tok_24h.breakdown.items() %}
+      {% set pcr = (counts.cache_read / (counts.cache_read + counts.cache_creation) * 100)|round(1) if (counts.cache_read + counts.cache_creation) > 0 else 0 %}
       <div class="flex items-center justify-between text-xs">
         <span class="text-gray-300">{{ provider }}</span>
-        <span class="text-muted">{{ counts.input }} in / {{ counts.output }} out</span>
+        <span class="text-muted">{{ fmt_tokens(counts.input) }} in / {{ fmt_tokens(counts.output) }} out{% if pcr > 0 %} / {{ pcr }}% cached{% endif %}</span>
       </div>
       {% endfor %}
     </div>

--- a/humux/api/templates/partials/dashboard.html
+++ b/humux/api/templates/partials/dashboard.html
@@ -10,7 +10,7 @@
         <h2 class="text-sm text-accent font-semibold mb-1">Agent</h2>
         <p class="text-xs text-muted">
           {% if running %}
-            Running{% if scheduler_jobs > 0 %} · {{ scheduler_jobs }} scheduled job{{ 's' if scheduler_jobs != 1 else '' }}{% endif %}
+            Running{% if scheduler_jobs > 0 %} · <a href="/admin?tab=jobs" class="text-accent hover:underline">{{ scheduler_jobs }} scheduled job{{ 's' if scheduler_jobs != 1 else '' }}</a>{% endif %}
           {% else %}
             Not running
           {% endif %}

--- a/humux/api/templates/partials/dashboard.html
+++ b/humux/api/templates/partials/dashboard.html
@@ -66,7 +66,7 @@
   {% endif %}
 
   {# Recent activity #}
-  <div class="card p-4">
+  <div class="card p-4 overflow-hidden">
     <div class="flex items-center justify-between mb-3">
       <h3 class="text-xs text-muted uppercase tracking-wider">Recent activity</h3>
     </div>
@@ -75,13 +75,13 @@
       {% for entry in log_entries[:20] %}
       {% set ts = entry.get('time', '') %}
       {% set msg = entry.get('message', '') %}
-      <a href="/admin?tab=inspect&amp;inspectsub=logs" class="flex items-start gap-2 text-xs font-mono no-underline hover:bg-surface-hover rounded px-1 py-0.5 -mx-1 transition-colors">
+      <a href="/admin?tab=inspect&amp;inspectsub=logs" class="flex items-start gap-2 text-xs font-mono no-underline hover:bg-surface-hover rounded px-1 py-0.5 -mx-1 transition-colors min-w-0">
         <span class="shrink-0 text-muted"
               style="color:{% if entry.level == 'ERROR' %}#c66{% elif entry.level == 'WARNING' %}#ca6{% else %}#888{% endif %}">
           {{ entry.level|truncate(4, True, '') }}
         </span>
         <span class="text-muted shrink-0">{{ ts }}</span>
-        <span class="text-gray-300 truncate">{{ msg }}</span>
+        <span class="text-gray-300 truncate min-w-0">{{ msg }}</span>
       </a>
       {% endfor %}
     </div>

--- a/humux/api/templates/partials/you.html
+++ b/humux/api/templates/partials/you.html
@@ -52,10 +52,11 @@
   </div>
 
   {# Your personalia #}
-  <div class="card" x-data="{ persResult: '', persOk: false }">
+  <div class="card" x-data="{ personal: '', persResult: '', persOk: false }" x-init="personal = $refs.persEditor.value">
     <h2 class="text-base mb-1">Your personalia</h2>
     <p class="text-muted text-xs mb-3">Facts about you that the agent should know — preferences, routines, contacts, anything that helps it assist you better. Markdown format.</p>
-    <textarea class="textarea" id="you-pers-editor"
+    <textarea class="textarea" id="you-pers-editor" x-ref="persEditor"
+              x-model="personal"
               style="min-height:300px; font-size:0.8rem; line-height:1.5; tab-size:2"
               @keydown.tab.prevent="
                 const start = $el.selectionStart;
@@ -63,6 +64,10 @@
                 $el.value = $el.value.substring(0, start) + '  ' + $el.value.substring(end);
                 $el.selectionStart = $el.selectionEnd = start + 2;
               ">{{ you_personalia }}</textarea>
+    <div class="flex justify-between items-center mt-1">
+      <span></span>
+      <span class="text-[10px] text-muted" x-text="'~' + window.estimateTokens(personal) + ' tokens'"></span>
+    </div>
     <div class="flex justify-end mt-3">
       <button class="btn-primary btn-sm"
               @click="

--- a/humux/api/templates/skill_editor.html
+++ b/humux/api/templates/skill_editor.html
@@ -33,7 +33,10 @@ Include executable CLI examples.
 Edge cases, pitfalls, safety constraints."
                     x-on:input.debounce.500ms="validate($el.value)"
                     x-model.fill="content">{{ skill_content }}</textarea>
-          <div class="hint">First non-empty line becomes the summary shown in the list.</div>
+          <div class="flex items-center justify-between">
+            <div class="hint">First non-empty line becomes the summary shown in the list.</div>
+            <span class="text-[10px] text-muted" x-text="'~' + window.estimateTokens(content) + ' tokens'"></span>
+          </div>
           <template x-if="validationErrors.length > 0">
             <div class="mt-2 space-y-0.5">
               <template x-for="err in validationErrors" :key="err.line + err.message">

--- a/humux/core/llm.py
+++ b/humux/core/llm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import importlib
 import json
@@ -159,11 +160,14 @@ def _openai_usage(response: Any) -> dict[str, int] | None:
         return None
     prompt = getattr(u, "prompt_tokens", 0) or 0
     completion = getattr(u, "completion_tokens", 0) or 0
+    # DeepSeek ships prompt_cache_hit/miss_tokens (#199 review).
+    cache_hit = getattr(u, "prompt_cache_hit_tokens", 0) or 0
+    cache_miss = getattr(u, "prompt_cache_miss_tokens", 0) or 0
     return {
         "input_tokens": prompt,
         "output_tokens": completion,
-        "cache_read_input_tokens": 0,
-        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": cache_hit,
+        "cache_creation_input_tokens": cache_miss,
         "context_tokens": prompt,
     }
 
@@ -411,8 +415,8 @@ class LLMClient:
                         cache_read_input_tokens=usage.get("cache_read_input_tokens", 0),
                         cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
                     ))
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logging.getLogger(__name__).warning("Failed to record token usage (anthropic): %s", exc)
             return LLMResponse(
                 text="\n".join(text_parts).strip(),
                 tool_calls=tool_calls,
@@ -460,8 +464,8 @@ class LLMClient:
                     cache_read_input_tokens=usage.get("cache_read_input_tokens", 0),
                     cache_creation_input_tokens=usage.get("cache_creation_input_tokens", 0),
                 ))
-            except Exception:
-                pass
+            except Exception as exc:
+                logging.getLogger(__name__).warning("Failed to record token usage (openai): %s", exc)
         return LLMResponse(
             text=(message.content or "").strip(),
             tool_calls=tool_calls,

--- a/humux/core/metrics.py
+++ b/humux/core/metrics.py
@@ -68,15 +68,19 @@ class TokenUsageStore:
         """Aggregate token usage for the last *hours*.
 
         Returns:
-            total_input, total_output, and per-provider breakdown.
+            total_input, total_output, total_cache_read, total_cache_creation,
+            and per-provider breakdown.
         """
         await self._ensure_schema()
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             # Grand totals
             cursor = await db.execute(
-                "SELECT COALESCE(SUM(input_tokens), 0) AS total_input, "
-                "COALESCE(SUM(output_tokens), 0) AS total_output "
+                "SELECT "
+                "COALESCE(SUM(input_tokens), 0) AS total_input, "
+                "COALESCE(SUM(output_tokens), 0) AS total_output, "
+                "COALESCE(SUM(cache_read_input_tokens), 0) AS total_cache_read, "
+                "COALESCE(SUM(cache_creation_input_tokens), 0) AS total_cache_creation "
                 "FROM token_usage "
                 "WHERE recorded_at >= datetime('now', ?)",
                 (f"-{hours} hours",),
@@ -84,21 +88,38 @@ class TokenUsageStore:
             row = await cursor.fetchone()
             total_input = row["total_input"] if row else 0
             total_output = row["total_output"] if row else 0
+            total_cache_read = row["total_cache_read"] if row else 0
+            total_cache_creation = row["total_cache_creation"] if row else 0
 
             # Per-provider breakdown
             cursor = await db.execute(
                 "SELECT provider, "
                 "COALESCE(SUM(input_tokens), 0) AS total_input, "
-                "COALESCE(SUM(output_tokens), 0) AS total_output "
+                "COALESCE(SUM(output_tokens), 0) AS total_output, "
+                "COALESCE(SUM(cache_read_input_tokens), 0) AS total_cache_read, "
+                "COALESCE(SUM(cache_creation_input_tokens), 0) AS total_cache_creation "
                 "FROM token_usage "
                 "WHERE recorded_at >= datetime('now', ?) "
                 "GROUP BY provider ORDER BY total_input DESC",
                 (f"-{hours} hours",),
             )
-            breakdown = {r["provider"]: {"input": r["total_input"], "output": r["total_output"]}
-                         for r in await cursor.fetchall()}
+            rows = await cursor.fetchall()
+            breakdown = {}
+            for r in rows:
+                breakdown[r["provider"]] = {
+                    "input": r["total_input"],
+                    "output": r["total_output"],
+                    "cache_read": r["total_cache_read"],
+                    "cache_creation": r["total_cache_creation"],
+                }
 
-        return {"total_input": total_input, "total_output": total_output, "breakdown": breakdown}
+        return {
+            "total_input": total_input,
+            "total_output": total_output,
+            "total_cache_read": total_cache_read,
+            "total_cache_creation": total_cache_creation,
+            "breakdown": breakdown,
+        }
 
 
 # Module-level convenience: one store instance shared across the process.


### PR DESCRIPTION
## Stacked on #200 (token tracking)

This PR builds on the token tracking infrastructure from #200 and adds the UI polish.

### Changes
- **Sticky header** with humux logo, status badge, Docs + GitHub links
- **Footer** with dynamic version (fetched from GitHub release), Docs, GitHub, About
- **About modal** (Alpine.js) with company info, MIT license
- **Overview tab** as the default landing page with agent status, token usage (24h/7d/30d with real data from #200), provider breakdown, recent activity
- **Tab param cleanup** — switching parent tabs strips all sub-tab query params
- **Layout alignment** — header, content, footer share max-w-7xl mx-auto