### PR TITLE
Multi-message replies: one turn, several heterogeneous messages (#202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ No cloud dependency. No data leaving your server. One `docker compose up` and yo
 - **Telegram** — full bot with text, voice messages, reactions, inline approvals
 - **WhatsApp** — read and send via [wacli](https://github.com/openclaw/wacli) CLI, link once and it stays authenticated
 - **Multi-agent groups** — several agent-bots share one Telegram group, each replies only when addressed, never loops with other bots
+- **Multi-message replies** — the agent can answer with several messages in one turn, like a person texting: multiple bubbles, or a mix of text, voice notes, reactions and images
 - **Reply decision** — in group chats the agent decides per message whether to reply, with a hard rate cap that guarantees runaway loops end
 - **Steerable mid-turn** — redirect a long-running turn by just sending a follow-up; it's folded in before the agent's next step (reacts 👀 to confirm) instead of making you wait for it to finish on the wrong track
 - **Per-chat settings** — gate per Telegram chat who can trigger an agent and who may DM it

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -35,7 +35,8 @@ agent's row, after which every bot is configured per-agent. See
 ### Features
 
 - **Text messages** — standard chat with the agent
-- **Voice messages** — automatically transcribed via Whisper, agent can respond with synthesized voice
+- **Multi-message replies** — one turn can send several messages, like a person texting: multiple text bubbles, or a mix of text, voice notes, reactions and images. The model separates parts with a `[[split]]` marker; a single reply (no marker) is delivered as one message, exactly as before
+- **Voice messages** — automatically transcribed via Whisper, agent can respond with synthesized voice (per part, so text and voice can be mixed in one turn)
 - **Inline keyboards** — used for permission approval flow (Approve / Deny / Always allow / Stop)
 - **User ID whitelist** — only allowed users can interact with the bot
 - **Bot-per-agent** — every agent has its own bot token, so it's a separate Telegram contact, all running in one process; see below

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -1252,13 +1252,22 @@ class TelegramChannel:
         """
         cid, kw = self._route(chat_id)
         images = [a for a in (getattr(response, "attachments", None) or []) if a.is_image]
+        # Prefer the ordered messages list; tolerate a partial/old response object
+        # (some callers/tests pass a bare text/voice pair) as the surrounding
+        # getattr() style already does.
+        delivery = getattr(response, "delivery_messages", None)
+        if delivery is not None:
+            pairs = [(m.text, m.voice) for m in delivery]
+        else:
+            text, voice = getattr(response, "text", "") or "", getattr(response, "voice", None)
+            pairs = [(text, voice)] if (text or voice) else []
         sent = False
-        for msg in response.delivery_messages:
-            if msg.voice:
-                await self.app.bot.send_voice(cid, msg.voice, **kw)
+        for text, voice in pairs:
+            if voice:
+                await self.app.bot.send_voice(cid, voice, **kw)
                 sent = True
-            elif msg.text:
-                await self.send(chat_id, msg.text)
+            elif text:
+                await self.send(chat_id, text)
                 sent = True
         if not sent and not images:
             log.warning("Skipping empty response for chat_id=%s", chat_id)

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -1263,12 +1263,18 @@ class TelegramChannel:
             pairs = [(text, voice)] if (text or voice) else []
         sent = False
         for text, voice in pairs:
-            if voice:
-                await self.app.bot.send_voice(cid, voice, **kw)
-                sent = True
-            elif text:
-                await self.send(chat_id, text)
-                sent = True
+            # Isolate each bubble: a failure on a later message must not swallow the
+            # ones already delivered (#202) — log and move on so the turn is at worst
+            # partial, never aborted mid-way.
+            try:
+                if voice:
+                    await self.app.bot.send_voice(cid, voice, **kw)
+                    sent = True
+                elif text:
+                    await self.send(chat_id, text)
+                    sent = True
+            except Exception:
+                log.exception("Failed to deliver a message bubble to chat_id=%s", chat_id)
         if not sent and not images:
             log.warning("Skipping empty response for chat_id=%s", chat_id)
         for att in images:

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -1242,18 +1242,25 @@ class TelegramChannel:
         await self._send_response(chat_id, response)
 
     async def _send_response(self, chat_id: int | str, response) -> None:
-        """Send an AgentResponse back — voice or text, then any generated images.
+        """Send an AgentResponse back — each message (voice or text) in order,
+        then any generated images (#202).
 
-        Text goes through ``send()`` so Markdown is rendered (HTML), and photos are
-        sent bare afterwards — simpler and correct, vs. a raw-Markdown caption.
+        A turn may deliver several messages (multiple text bubbles, text + voice,
+        etc.); ``delivery_messages`` yields them in order, falling back to the flat
+        text/voice fields for old-style responses. Text goes through ``send()`` so
+        Markdown is rendered (HTML); photos are sent bare afterwards.
         """
         cid, kw = self._route(chat_id)
         images = [a for a in (getattr(response, "attachments", None) or []) if a.is_image]
-        if response.voice:
-            await self.app.bot.send_voice(cid, response.voice, **kw)
-        elif response.text:
-            await self.send(chat_id, response.text)
-        elif not images:
+        sent = False
+        for msg in response.delivery_messages:
+            if msg.voice:
+                await self.app.bot.send_voice(cid, msg.voice, **kw)
+                sent = True
+            elif msg.text:
+                await self.send(chat_id, msg.text)
+                sent = True
+        if not sent and not images:
             log.warning("Skipping empty response for chat_id=%s", chat_id)
         for att in images:
             await self.app.bot.send_photo(cid, att.data, **kw)

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -38,7 +38,7 @@ from core.llm import (
 )
 from core.log_streams import set_stream, subagent_stream
 from core.memory import MemoryStore
-from core.models import IMAGE_MIME_TYPES, AgentResponse, Attachment
+from core.models import IMAGE_MIME_TYPES, AgentResponse, Attachment, OutputMessage
 from core.permissions import PermissionEngine, PermissionLevel, format_approval_message
 from core.prompt_builder import build_prompt_sections
 from core.reply_decision import should_reply
@@ -188,6 +188,14 @@ VOICE_MARKER = "[respond_with_voice]"
 # suffix pattern would fail to match those and leak the raw marker to the user;
 # voice_request_lang validates the code separately.
 _VOICE_MARKER_RE = re.compile(r"\[respond_with_voice(?::([^\]]*))?\]")
+
+# Multi-message replies (#202): the model separates sequential messages with this
+# marker; each part becomes its own delivered message and may carry its own voice
+# marker, so a turn can mix text and voice bubbles. Absent = one message
+# (unchanged behaviour). Split swallows surrounding whitespace so blank lines
+# around the marker don't leak into a bubble.
+SPLIT_MARKER = "[[split]]"
+_SPLIT_MARKER_RE = re.compile(r"\s*\[\[split\]\]\s*", re.IGNORECASE)
 
 # Cap an approval prompt's text on the fail-closed retry so an over-long
 # description (e.g. a huge bash command) fits a channel's message limit. Well
@@ -2076,22 +2084,20 @@ class AgentCore:
                 final_text = _LOOP_ABORT_MESSAGE
         log.info("Response: %s", final_text[:200])
 
-        # Check if the LLM wants to respond with voice
-        voice_bytes = await self._maybe_synthesize_voice(
-            final_text, voice=(agent.voice or None) if agent else None
-        )
-        # Strip the control marker unconditionally — it must never reach the user,
-        # even when synthesis was skipped or failed (voice_bytes is None).
-        final_text = strip_voice_marker(final_text)
+        # Split into one or more delivery messages (#202); each part may be voice.
+        # ``final_text`` becomes the combined marker-free text used for history,
+        # memory extraction, and the backward-compat AgentResponse.text.
+        messages, final_text = await self._split_reply(final_text, agent)
 
-        # Persist the turn (user message + final assistant text only). A react-only
-        # turn (or any reply that sends nothing) leaves final_text empty — don't
-        # store an empty assistant turn: some providers reject empty content on the
-        # next replay, and the coalescer folds the resulting adjacent user turns (#70).
+        # Persist the turn (user message + one assistant turn per delivered message).
+        # A react-only turn (or any reply that sends nothing) yields no messages —
+        # don't store an empty assistant turn: some providers reject empty content on
+        # the next replay, and the coalescer folds the resulting adjacent user turns (#70).
         history_message = self._history_message_text(message, attachments)
         await self.history.add_turn(channel, user_id, "user", history_message, chat_id)
-        if final_text:
-            await self.history.add_turn(channel, user_id, "assistant", final_text, chat_id)
+        for msg in messages:
+            if msg.text:
+                await self.history.add_turn(channel, user_id, "assistant", msg.text, chat_id)
 
         # Automatic memory extraction
         if channel != "system":
@@ -2109,8 +2115,9 @@ class AgentCore:
 
         return AgentResponse(
             text=final_text,
-            voice=voice_bytes,
+            voice=messages[0].voice if messages else None,
             attachments=request_state.get("pending_attachments", []),
+            messages=messages,
         )
 
     async def _process_session(
@@ -2260,6 +2267,12 @@ class AgentCore:
             elif response.tool_calls and not final_text:
                 final_text = _LOOP_ABORT_MESSAGE
 
+        # Split into one or more delivery messages (#202); each part may be voice.
+        # ``final_text`` becomes the combined marker-free text — one assistant turn
+        # in the session (multiple assistant messages would break user/assistant
+        # alternation), and the backward-compat AgentResponse.text.
+        messages, final_text = await self._split_reply(final_text, agent)
+
         # Append the final assistant response to the session. Skip an empty final
         # (a react-only turn sends nothing): the reaction is already recorded as the
         # assistant tool_use turn above, and an empty assistant message is dead weight
@@ -2277,14 +2290,6 @@ class AgentCore:
         # session that was just sent, so it's the authoritative context size.
         system_notice = await self._maybe_compact(channel, user_id, chat_id, response)
 
-        # Check if the LLM wants to respond with voice
-        voice_bytes = await self._maybe_synthesize_voice(
-            final_text, voice=(agent.voice or None) if agent else None
-        )
-        # Strip the control marker unconditionally — it must never reach the user,
-        # even when synthesis was skipped or failed (voice_bytes is None).
-        final_text = strip_voice_marker(final_text)
-
         # Automatic memory extraction
         if channel != "system":
             asyncio.create_task(
@@ -2301,9 +2306,10 @@ class AgentCore:
 
         return AgentResponse(
             text=final_text,
-            voice=voice_bytes,
+            voice=messages[0].voice if messages else None,
             attachments=request_state.get("pending_attachments", []),
             system_notice=system_notice,
+            messages=messages,
         )
 
     @staticmethod
@@ -2316,6 +2322,26 @@ class AgentCore:
             suffix = f" [{label} attached]"
             return (message + suffix) if message else suffix.strip()
         return message
+
+    async def _split_reply(
+        self, final_text: str, agent: Agent | None
+    ) -> tuple[list[OutputMessage], str]:
+        """Split the model's final reply into ordered delivery messages (#202).
+
+        Parts are separated by SPLIT_MARKER; each part is independently checked
+        for the voice marker, so one turn can send several text bubbles, a voice
+        note, or a mix. No marker → a single message (unchanged behaviour).
+        Returns the message list and the combined marker-free text (for history,
+        logging, and the backward-compat ``AgentResponse.text``).
+        """
+        voice_name = (agent.voice or None) if agent else None
+        parts = [p for p in (seg.strip() for seg in _SPLIT_MARKER_RE.split(final_text)) if p]
+        messages: list[OutputMessage] = []
+        for part in parts:
+            voice_bytes = await self._maybe_synthesize_voice(part, voice=voice_name)
+            messages.append(OutputMessage(text=strip_voice_marker(part), voice=voice_bytes))
+        combined = "\n".join(m.text for m in messages if m.text)
+        return messages, combined
 
     async def _maybe_synthesize_voice(self, text: str, voice: str | None = None) -> bytes | None:
         """Synthesize voice if requested by the LLM, using the agent's voice

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -2115,7 +2115,7 @@ class AgentCore:
 
         return AgentResponse(
             text=final_text,
-            voice=messages[0].voice if messages else None,
+            voice=next((m.voice for m in messages if m.voice), None),
             attachments=request_state.get("pending_attachments", []),
             messages=messages,
         )
@@ -2306,7 +2306,7 @@ class AgentCore:
 
         return AgentResponse(
             text=final_text,
-            voice=messages[0].voice if messages else None,
+            voice=next((m.voice for m in messages if m.voice), None),
             attachments=request_state.get("pending_attachments", []),
             system_notice=system_notice,
             messages=messages,

--- a/humux/core/cli.py
+++ b/humux/core/cli.py
@@ -484,8 +484,11 @@ async def main() -> None:
         if response is None:
             print("\n[interrupted]\n")
             continue
-        if response.text:
-            print(f"\n{response.text}\n")
+        # Each message is printed as its own bubble (#202); voice notes have no
+        # terminal rendering, so their text stands in.
+        for msg in response.delivery_messages:
+            if msg.text:
+                print(f"\n{msg.text}\n")
         if getattr(response, "system_notice", None):
             print(f"[system] {response.system_notice}\n")
 

--- a/humux/core/llm.py
+++ b/humux/core/llm.py
@@ -196,27 +196,40 @@ def _as_content_blocks(content: Any) -> list[dict[str, Any]]:
 
 
 def _coalesce_user_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Merge consecutive ``user`` messages into one, so a run of user turns is
-    sent as a single turn.
+    """Merge consecutive same-role messages so the array alternates user/assistant.
 
     Group multi-agent rooms (#30) record every message they see — including ones
     the bot stays silent on — so the replayed history can hold several user turns
-    in a row before the bot's reply. Anthropic requires strict user/assistant
-    alternation, so this normalises the array right before the API call instead of
-    making every caller track it. String contents join with a blank line; anything
-    multimodal falls back to concatenated content-part blocks (valid for both
-    Anthropic and the OpenAI-compatible providers). Assistant/tool messages are
-    left untouched — only plain user turns are ever produced back-to-back.
+    in a row before the bot's reply. Multi-message replies (#202) likewise store
+    one assistant row per delivered bubble, so a turn can leave several plain-text
+    assistant rows in a row. Anthropic requires strict user/assistant alternation,
+    so this normalises the array right before the API call instead of making every
+    caller track it.
+
+    User runs merge whether string or multimodal (string → blank-line join, else
+    concatenated content-part blocks). Assistant runs merge only when BOTH sides
+    are plain strings (the shape multi-message history produces); an assistant turn
+    carrying content blocks (tool_use) is left untouched — those never appear
+    back-to-back, and merging them would corrupt the tool_use/tool_result pairing.
     """
     out: list[dict[str, Any]] = []
     for msg in messages:
-        if out and out[-1].get("role") == "user" and msg.get("role") == "user":
-            prev, cur = out[-1].get("content"), msg.get("content")
-            if isinstance(prev, str) and isinstance(cur, str):
-                merged: Any = f"{prev}\n\n{cur}"
+        prev = out[-1] if out else None
+        role = msg.get("role")
+        if prev and prev.get("role") == role == "user":
+            pc, cc = prev.get("content"), msg.get("content")
+            if isinstance(pc, str) and isinstance(cc, str):
+                merged: Any = f"{pc}\n\n{cc}"
             else:
-                merged = _as_content_blocks(prev) + _as_content_blocks(cur)
-            out[-1] = {**out[-1], "content": merged}
+                merged = _as_content_blocks(pc) + _as_content_blocks(cc)
+            out[-1] = {**prev, "content": merged}
+        elif (
+            prev
+            and prev.get("role") == role == "assistant"
+            and isinstance(prev.get("content"), str)
+            and isinstance(msg.get("content"), str)
+        ):
+            out[-1] = {**prev, "content": f"{prev['content']}\n\n{msg['content']}"}
         else:
             out.append(dict(msg))
     return out

--- a/humux/core/models.py
+++ b/humux/core/models.py
@@ -54,6 +54,20 @@ class Attachment:
 
 
 @dataclass
+class OutputMessage:
+    """One delivered message in a turn (#202).
+
+    A turn may send several of these in order — multiple text bubbles, or a mix
+    of text and voice. ``text`` is always the words (kept even for a voice
+    message, so history records what was said); ``voice`` carries synthesized
+    audio when the segment was voice-marked.
+    """
+
+    text: str = ""
+    voice: bytes | None = None
+
+
+@dataclass
 class AgentResponse:
     text: str
     voice: bytes | None = None
@@ -61,3 +75,20 @@ class AgentResponse:
     # Optional out-of-band system message (e.g. "context was compacted"),
     # delivered by the channel as a separate follow-up message.
     system_notice: str | None = None
+    # Ordered messages to deliver this turn (#202). Empty for turns built the
+    # old way (control commands, scheduler); ``delivery_messages`` falls back to
+    # the flat text/voice fields so every existing caller keeps working.
+    messages: list[OutputMessage] = field(default_factory=list)
+
+    @property
+    def delivery_messages(self) -> list[OutputMessage]:
+        """The messages a channel should send, in order.
+
+        Prefers the explicit ``messages`` list; otherwise derives a single
+        message from the flat ``text``/``voice`` fields (backward compatible).
+        """
+        if self.messages:
+            return self.messages
+        if self.text or self.voice:
+            return [OutputMessage(text=self.text, voice=self.voice)]
+        return []

--- a/humux/core/prompt_builder.py
+++ b/humux/core/prompt_builder.py
@@ -189,6 +189,22 @@ def build_prompt_sections(
         "</security>"
     )
 
+    # Multi-message replies (#202): a base capability, always documented so an
+    # agent or tool_usage override can't drop it. Lives in the intro next to the
+    # security rail rather than a toggleable section.
+    intro += (
+        "\n\n<messages>\n"
+        "You can send several messages in one turn, like a person texting: put "
+        "[[split]] between them and each part is delivered as its own message. Use it "
+        "to break a long reply into a few short bubbles, or to send a quick line and "
+        "then a detailed one — but don't overdo it; one message is usually right. "
+        "Each part can independently be a voice note (put its [respond_with_voice] "
+        "marker in that part), so you can mix text and voice. Reactions "
+        "(set_reaction) and images (generate_image) are separate and combine freely "
+        "with these.\n"
+        "</messages>"
+    )
+
     character = f"<character>\n{character_text}\n</character>"
     about_user = f"<about_user>\n{about_user_block}\n</about_user>" if about_user_block else ""
     tool_usage = f"<tool_usage>\n{tool_usage_text}\n</tool_usage>"

--- a/humux/core/prompt_builder.py
+++ b/humux/core/prompt_builder.py
@@ -198,10 +198,9 @@ def build_prompt_sections(
         "[[split]] between them and each part is delivered as its own message. Use it "
         "to break a long reply into a few short bubbles, or to send a quick line and "
         "then a detailed one — but don't overdo it; one message is usually right. "
-        "Each part can independently be a voice note (put its [respond_with_voice] "
-        "marker in that part), so you can mix text and voice. Reactions "
-        "(set_reaction) and images (generate_image) are separate and combine freely "
-        "with these.\n"
+        "When voice is available, a part carrying the voice marker is sent as a voice "
+        "note, so you can mix text and voice bubbles. Reactions (set_reaction) and "
+        "images (generate_image) are separate and combine freely with these.\n"
         "</messages>"
     )
 

--- a/humux/tests/test_group_chat.py
+++ b/humux/tests/test_group_chat.py
@@ -43,14 +43,20 @@ def test_coalesce_leaves_alternating_untouched() -> None:
     assert _coalesce_user_messages(msgs) == msgs
 
 
-def test_coalesce_does_not_merge_assistant_or_tool() -> None:
+def test_coalesce_merges_assistant_strings_not_tool() -> None:
+    # Multi-message replies (#202) store one assistant row per bubble, so plain
+    # string assistant turns now merge to keep alternation; tool turns don't.
     msgs = [
         {"role": "assistant", "content": "x"},
-        {"role": "assistant", "content": "y"},  # would never happen, must stay split
+        {"role": "assistant", "content": "y"},
         {"role": "user", "content": "a"},
         {"role": "tool", "content": "t"},
     ]
-    assert _coalesce_user_messages(msgs) == msgs
+    assert _coalesce_user_messages(msgs) == [
+        {"role": "assistant", "content": "x\n\ny"},
+        {"role": "user", "content": "a"},
+        {"role": "tool", "content": "t"},
+    ]
 
 
 def test_coalesce_runs_of_three() -> None:

--- a/humux/tests/test_multi_message.py
+++ b/humux/tests/test_multi_message.py
@@ -72,6 +72,37 @@ async def test_react_only_turn_yields_no_messages(agent):
     assert combined == ""
 
 
+# --- coalescer keeps alternation when a turn stored multiple assistant rows ----
+
+
+def test_consecutive_assistant_strings_merge():
+    from core.llm import _coalesce_user_messages
+
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "next"},
+    ]
+    out = _coalesce_user_messages(msgs)
+    assert [m["role"] for m in out] == ["user", "assistant", "user"]
+    assert out[1]["content"] == "one\n\ntwo"
+
+
+def test_assistant_tool_use_blocks_not_merged():
+    from core.llm import _coalesce_user_messages
+
+    # An assistant turn carrying content blocks (tool_use) must never be merged
+    # into an adjacent plain-text assistant turn — it would corrupt the pairing.
+    blocks = [{"type": "tool_use", "id": "t1", "name": "x", "input": {}}]
+    msgs = [
+        {"role": "assistant", "content": "text"},
+        {"role": "assistant", "content": blocks},
+    ]
+    out = _coalesce_user_messages(msgs)
+    assert len(out) == 2
+
+
 @pytest.mark.asyncio
 async def test_voice_marker_stripped_per_part(agent):
     # No TTS pipeline configured → voice is None, but the marker must never leak.

--- a/humux/tests/test_multi_message.py
+++ b/humux/tests/test_multi_message.py
@@ -1,0 +1,82 @@
+"""Multi-message replies (#202): split marker, per-part voice, delivery list."""
+
+import pytest
+
+from core.config import Config
+from core.models import AgentResponse, OutputMessage
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    from core.agent import AgentCore
+
+    cfg = Config()
+    cfg.agent.llm_provider = "deepseek"
+    cfg.agent.model = "deepseek-v4-flash"
+    cfg.memory.embedding.enabled = False
+    return AgentCore(cfg)  # voice pipeline unset → no TTS, split only
+
+
+# --- AgentResponse.delivery_messages ---------------------------------------
+
+
+def test_delivery_falls_back_to_flat_text():
+    r = AgentResponse(text="hello")
+    assert [m.text for m in r.delivery_messages] == ["hello"]
+
+
+def test_delivery_prefers_messages_list():
+    r = AgentResponse(text="a\nb", messages=[OutputMessage(text="a"), OutputMessage(text="b")])
+    assert [m.text for m in r.delivery_messages] == ["a", "b"]
+
+
+def test_delivery_empty_when_nothing_to_send():
+    assert AgentResponse(text="").delivery_messages == []
+
+
+# --- _split_reply -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_message_backward_compatible(agent):
+    messages, combined = await agent._split_reply("just one message", None)
+    assert [m.text for m in messages] == ["just one message"]
+    assert combined == "just one message"
+
+
+@pytest.mark.asyncio
+async def test_split_marker_yields_multiple_messages(agent):
+    messages, combined = await agent._split_reply("first[[split]]second[[split]]third", None)
+    assert [m.text for m in messages] == ["first", "second", "third"]
+    assert combined == "first\nsecond\nthird"
+
+
+@pytest.mark.asyncio
+async def test_split_swallows_surrounding_whitespace(agent):
+    messages, _ = await agent._split_reply("one\n\n[[split]]\n\ntwo", None)
+    assert [m.text for m in messages] == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_empty_parts_dropped(agent):
+    messages, combined = await agent._split_reply("[[split]]  [[split]]only", None)
+    assert [m.text for m in messages] == ["only"]
+    assert combined == "only"
+
+
+@pytest.mark.asyncio
+async def test_react_only_turn_yields_no_messages(agent):
+    messages, combined = await agent._split_reply("", None)
+    assert messages == []
+    assert combined == ""
+
+
+@pytest.mark.asyncio
+async def test_voice_marker_stripped_per_part(agent):
+    # No TTS pipeline configured → voice is None, but the marker must never leak.
+    messages, combined = await agent._split_reply(
+        "spoken bit [respond_with_voice:en][[split]]typed bit", None
+    )
+    assert [m.text for m in messages] == ["spoken bit", "typed bit"]
+    assert "[respond_with_voice" not in combined


### PR DESCRIPTION
Closes #202.

## What

Lets the agent answer with **several messages in one turn** — like a person texting — instead of a single blob. Multiple text bubbles, text + a voice note, a quick line then a detailed one, in any mix. A single reply (the common case) is unchanged and fully backward compatible.

## How

Reuses the existing marker convention rather than reworking the agentic loop:

- The model separates messages with a `[[split]]` marker in its final reply. Each part becomes its own delivered message and can independently carry the existing `[respond_with_voice]` marker — so text and voice mix per part. No marker → one message (unchanged).
- `AgentResponse` gains an ordered `messages: list[OutputMessage]`; `delivery_messages` falls back to the flat `text`/`voice` fields, so every existing caller (control commands, scheduler) keeps working untouched.
- Channels deliver each message in order: Telegram `_send_response` and the CLI iterate the list; reactions (`set_reaction`) and images (`generate_image`) already fire independently and combine freely.
- Injection-mode history records one assistant turn per delivered message. Session mode keeps one combined assistant message (multiple would break user/assistant alternation) while still delivering multiple bubbles.
- Always-on prompt block teaches the convention (kept out of the TTS-gated section so it can't leak the voice marker when TTS is off).

## Acceptance criteria

- [x] Agent can send multiple messages of different types per turn
- [x] Agent can send just one message (backward compatible)
- [x] Reactions + text, text + voice, multiple texts — all work
- [x] History captures multiple entries per turn (injection mode; session mode keeps alternation-safe combined turn + multi delivery)

## Tests

`tests/test_multi_message.py` covers the split, empty/react-only turns, whitespace handling, per-part voice-marker stripping, and `delivery_messages` fallback. Full suite: 980 passed, lint clean.