### PR TITLE
Agent Skills ecosystem support: SKILL.md format, git installs, community skills (#65)

### DIFF
--- a/docs/content/docs/skills.mdx
+++ b/docs/content/docs/skills.mdx
@@ -116,6 +116,39 @@ The admin UI includes a skill editor where you can create, edit, and delete skil
 python3 /app/tools/skills.py upsert --name my-skill --stdin
 ```
 
+### 4. Install from the Agent Skills ecosystem
+
+humux understands the [Agent Skills](https://agentskills.io) format: a directory
+holding a `SKILL.md` with YAML frontmatter (`name`, `description`) plus optional
+bundled files (`scripts/`, `references/`, ...). That means skills from community
+repos like [`anthropics/skills`](https://github.com/anthropics/skills) install
+as-is:
+
+```bash
+python3 /app/tools/skills.py install https://github.com/anthropics/skills \
+    --path document-skills/docx
+```
+
+or via the **Install from a git repo** form on the admin Skills tab. Installed
+skills land in `data/skills/<name>/` (the writable volume — the `skills/` seed
+dir is mounted read-only in Docker) and are **read-only**: update them by
+re-running install (or the ⟳ button in the admin UI), which re-fetches from the
+recorded origin; customize them by deleting and creating your own copy.
+
+Spec-format skills can also live directly in `skills/<name>/SKILL.md` as seeds,
+next to the flat `.md` files — both formats coexist.
+
+Bundled files stay on disk; the skill body the model loads starts with a pointer
+to the skill's base directory, and files are read with:
+
+```bash
+python3 /app/tools/skills.py cat docx scripts/example.py
+```
+
+Community skills may reference commands outside humux's executor allowlist —
+the validator surfaces those as warnings at install time, and the executor
+still blocks them at runtime.
+
 ## How skills are loaded
 
 ```python

--- a/docs/content/docs/skills.mdx
+++ b/docs/content/docs/skills.mdx
@@ -126,7 +126,7 @@ as-is:
 
 ```bash
 python3 /app/tools/skills.py install https://github.com/anthropics/skills \
-    --path document-skills/docx
+    --path skills/docx
 ```
 
 or via the **Install from a git repo** form on the admin Skills tab. Installed

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -944,6 +944,7 @@ def create_admin_app(
             "skill_editor.html",
             skill_name="",
             skill_content="",
+            skill_origin="",
             is_new=True,
         )
 
@@ -961,6 +962,7 @@ def create_admin_app(
             "skill_editor.html",
             skill_name=skill.get("name", ""),
             skill_content=skill.get("content", ""),
+            skill_origin=skill.get("origin") or "",
             is_new=False,
         )
 
@@ -2881,9 +2883,43 @@ def create_admin_app(
             raise HTTPException(400, "Skill name is required")
         if not content:
             raise HTTPException(400, "Skill content is required")
-        await store.upsert_skill(name, content)
+        try:
+            await store.upsert_skill(name, content)
+        except ValueError as exc:  # installed skill — read-only (#65)
+            raise HTTPException(400, str(exc)) from exc
         skills = await store.list_skills()
         return _render_partial("partials/skills.html", skills=skills)
+
+    @app.post("/skills/install", dependencies=[Depends(auth)])
+    async def install_skill(request: Request) -> HTMLResponse:
+        """Install an Agent Skills skill from a git repo (#65)."""
+        content_type = request.headers.get("content-type", "")
+        if "application/x-www-form-urlencoded" in content_type:
+            body = await request.form()
+        else:
+            body = await request.json()
+        url = str(body.get("url", "")).strip()
+        path = str(body.get("path", "")).strip()
+        if not url:
+            raise HTTPException(400, "Missing 'url' in request body")
+        store = await _skills_store_from_config(config_store)
+        try:
+            result = await store.install_from_git(url, path)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        skills = await store.list_skills()
+        return _render_partial("partials/skills.html", skills=skills, install_result=result)
+
+    @app.post("/skills/{name}/update", dependencies=[Depends(auth)])
+    async def update_skill(name: str) -> HTMLResponse:
+        """Re-install an installed skill from its recorded origin (#65)."""
+        store = await _skills_store_from_config(config_store)
+        try:
+            result = await store.update_installed_skill(name)
+        except ValueError as exc:
+            raise HTTPException(400, str(exc)) from exc
+        skills = await store.list_skills()
+        return _render_partial("partials/skills.html", skills=skills, install_result=result)
 
     @app.post("/skills/delete", dependencies=[Depends(auth)])
     async def delete_skill(request: Request) -> HTMLResponse:

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -4118,7 +4118,8 @@ async def _skills_store_from_config(config_store: ConfigStore) -> SkillsStore:
 
     skills_db_path = await config_store.get("agent.skills_db_path") or "data/skills.db"
     skills_dir = await config_store.get("agent.skills_dir") or "skills/"
-    return SkillsStore(db_path=skills_db_path, seed_dir=skills_dir)
+    installed_dir = await config_store.get("agent.skills_installed_dir") or "data/skills"
+    return SkillsStore(db_path=skills_db_path, seed_dir=skills_dir, installed_dir=installed_dir)
 
 
 async def _agent_store_from_config(config_store: ConfigStore):

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -31,10 +31,10 @@
           </svg>
           <span class="text-sm font-semibold tracking-wide">humux</span>
         </a>
-        <span id="status-badge"
+        <div id="status-badge" class="hidden md:block"
               hx-get="/partials/status" hx-trigger="load, refresh-status from:body" hx-swap="innerHTML">
           <span class="text-muted text-xs">Loading...</span>
-        </span>
+        </div>
       </div>
       <nav class="flex items-center gap-4 text-xs text-muted">
         <a href="https://docs.humux.dev" target="_blank" class="hover:text-accent transition-colors">Docs</a>

--- a/humux/api/templates/partials/skills.html
+++ b/humux/api/templates/partials/skills.html
@@ -90,7 +90,7 @@
       <input type="text" name="url" class="input-sm flex-1" style="min-width:220px"
              placeholder="Repo URL (https://github.com/anthropics/skills)" required>
       <input type="text" name="path" class="input-sm flex-1" style="min-width:180px"
-             placeholder="Path in repo (document-skills/docx)">
+             placeholder="Path in repo (skills/docx)">
       <button class="btn btn-sm" type="submit">Install</button>
     </form>
   </div>

--- a/humux/api/templates/partials/skills.html
+++ b/humux/api/templates/partials/skills.html
@@ -21,10 +21,24 @@
       <tbody>
         {% for skill in skills %}
         <tr x-show="!filter || {{ skill.name|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase()) || {{ (skill.summary or '')|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())">
-          <td class="text-xs break-all">{{ skill.name }}</td>
+          <td class="text-xs break-all">
+            {{ skill.name }}
+            {% if skill.origin %}
+            <span class="text-[10px] text-muted border border-current rounded px-1 ml-1"
+                  title="Installed from {{ skill.origin }}">installed</span>
+            {% endif %}
+          </td>
           <td class="text-xs">{{ skill.summary }}</td>
           <td class="whitespace-nowrap">
-            <a class="btn btn-sm" href="/admin/skills/{{ skill.name }}">edit</a>
+            <a class="btn btn-sm" href="/admin/skills/{{ skill.name }}">{% if skill.origin %}view{% else %}edit{% endif %}</a>
+            {% if skill.origin %}
+            <button class="btn-outline btn-sm ml-0.5"
+                    hx-post="/skills/{{ skill.name }}/update" hx-target="#tab-content" hx-swap="innerHTML"
+                    title="Re-install from {{ skill.origin }}"
+                    hx-confirm="Update &quot;{{ skill.name }}&quot; from its origin repo?">
+              ⟳
+            </button>
+            {% endif %}
             {% if skill.stale_seed %}
             <button class="btn-outline btn-sm ml-0.5"
                     hx-post="/skills/{{ skill.name }}/reset" hx-target="#tab-content" hx-swap="innerHTML"
@@ -51,5 +65,33 @@
 
   <div class="mt-5 flex items-center gap-2">
     <a class="btn btn-sm" href="/admin/skills/new">Create new skill</a>
+  </div>
+
+  {% if install_result %}
+  <div class="mt-3 text-xs text-green-500">
+    Installed <b>{{ install_result.name }}</b> from {{ install_result.origin }}.
+    {% for w in install_result.warnings %}
+    <div class="text-yellow-500">{{ w }}</div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="mt-5 card">
+    <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Install from a git repo</h3>
+    <p class="text-muted text-xs mb-2">
+      Installs an <a class="text-accent" href="https://agentskills.io" target="_blank">Agent Skills</a>
+      skill (a directory with a SKILL.md), e.g. from
+      <code>https://github.com/anthropics/skills</code>. Installed skills are read-only;
+      update re-fetches from the same repo.
+    </p>
+    <form class="flex items-center gap-2 flex-wrap"
+          hx-post="/skills/install"
+          hx-target="#tab-content" hx-swap="innerHTML">
+      <input type="text" name="url" class="input-sm flex-1" style="min-width:220px"
+             placeholder="Repo URL (https://github.com/anthropics/skills)" required>
+      <input type="text" name="path" class="input-sm flex-1" style="min-width:180px"
+             placeholder="Path in repo (document-skills/docx)">
+      <button class="btn btn-sm" type="submit">Install</button>
+    </form>
   </div>
 </div>

--- a/humux/api/templates/skill_editor.html
+++ b/humux/api/templates/skill_editor.html
@@ -6,10 +6,17 @@
   <a class="text-xs text-muted hover:text-accent inline-flex items-center gap-1 mb-2" href="/admin?tab=skills">← Back to Skills</a>
   <div class="flex items-center justify-between gap-2 mb-4 flex-wrap">
     <div>
-      <h1 class="text-xl text-accent">{% if is_new %}New Skill{% else %}Edit Skill{% endif %}</h1>
+      <h1 class="text-xl text-accent">{% if is_new %}New Skill{% elif skill_origin %}View Skill{% else %}Edit Skill{% endif %}</h1>
       <p class="text-muted text-xs mt-1">Skills teach the agent how to use tools safely and correctly.</p>
     </div>
   </div>
+
+  {% if skill_origin %}
+  <div class="alert-info text-xs mb-4">
+    Installed from <code>{{ skill_origin }}</code> — editing is disabled.
+    Use Update on the Skills tab to re-fetch it, or delete it and create your own copy to customize.
+  </div>
+  {% endif %}
 
   <div class="flex gap-4 flex-wrap">
     <div class="flex-[2] min-w-[260px]">
@@ -31,6 +38,7 @@ Include executable CLI examples.
 
 ## Notes
 Edge cases, pitfalls, safety constraints."
+                    {% if skill_origin %}readonly{% endif %}
                     x-on:input.debounce.500ms="validate($el.value)"
                     x-model.fill="content">{{ skill_content }}</textarea>
           <div class="flex items-center justify-between">
@@ -53,7 +61,9 @@ Edge cases, pitfalls, safety constraints."
           </template>
         </div>
         <div class="flex items-center gap-2">
+          {% if not skill_origin %}
           <button class="btn btn-sm" type="button" onclick="saveSkill()">Save</button>
+          {% endif %}
         </div>
         <div id="save-result" class="mt-2 text-xs"></div>
       </div>

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -973,6 +973,7 @@ class AgentCore:
         self.skills = SkillsEngine(
             db_path=config.agent.skills_db_path,
             seed_dir=config.agent.skills_dir,
+            installed_dir=config.agent.skills_installed_dir,
         )
         self.agents = AgentStore(
             db_path=config.agent.agents_db_path,

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -91,6 +91,9 @@ class AgentConfig(BaseModel):
     timezone: str = "Europe/Zurich"
     skills_dir: str = "skills/"
     skills_db_path: str = "data/skills.db"
+    # Where git-installed skills live (#65). Under data/ because the seed
+    # skills dir is mounted read-only in Docker; data/ is the writable volume.
+    skills_installed_dir: str = "data/skills"
     agents_dir: str = "agents/"
     agents_db_path: str = "data/agents.db"
     character: str = ""  # identity + tone (legacy `personalia` was merged in — #98)

--- a/humux/core/skills.py
+++ b/humux/core/skills.py
@@ -286,7 +286,7 @@ class SkillsStore:
                 " content = excluded.content, summary = excluded.summary,"
                 " seed_hash = excluded.seed_hash, origin = excluded.origin,"
                 " updated_at = datetime('now')",
-                (content, summary, file_hash, origin),
+                (name, content, summary, file_hash, origin),
             )
             await db.commit()
             return True

--- a/humux/core/skills.py
+++ b/humux/core/skills.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import re
 import shutil
@@ -382,7 +383,10 @@ class SkillsStore:
         if ".." in skill_path.split("/"):
             raise ValueError("Skill path cannot contain '..'")
         with tempfile.TemporaryDirectory(prefix="skill-install-") as tmp:
-            proc = subprocess.run(
+            # to_thread: keep the event loop free during the clone (called from
+            # the admin API).
+            proc = await asyncio.to_thread(
+                subprocess.run,
                 ["git", "clone", "--depth", "1", repo_url, tmp],
                 capture_output=True,
                 text=True,

--- a/humux/core/skills.py
+++ b/humux/core/skills.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import re
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 import aiosqlite
+import yaml
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS skills (
@@ -13,13 +18,24 @@ CREATE TABLE IF NOT EXISTS skills (
     content TEXT NOT NULL,
     summary TEXT DEFAULT '',
     seed_hash TEXT DEFAULT NULL,
+    origin TEXT DEFAULT NULL,
     created_at DATETIME DEFAULT (datetime('now')),
     updated_at DATETIME DEFAULT (datetime('now'))
 );
 """
 
-# Migration: add seed_hash to existing tables (safe no-op if already present).
+# Migrations: add columns to existing tables (safe no-op if already present).
 _MIGRATE_SEED_HASH = "ALTER TABLE skills ADD COLUMN seed_hash TEXT DEFAULT NULL;"
+# origin = "<repo-url>#<path-in-repo>" for skills installed from a git repo
+# (#65). Origin-tagged skills are read-only: update = re-install from origin.
+_MIGRATE_ORIGIN = "ALTER TABLE skills ADD COLUMN origin TEXT DEFAULT NULL;"
+
+# Marker file inside an installed skill directory recording where it came from,
+# so a rebuilt DB re-seeds with provenance intact (#65). One line: "url#path".
+ORIGIN_MARKER = ".origin"
+
+# Skill name rules (mirrors tools/skills.py): safe as a directory name.
+_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
 
 # One-line instruction prepended to the skills index (#178), telling the model
@@ -54,12 +70,79 @@ def _extract_summary(content: str) -> str:
     return ""
 
 
+def split_frontmatter(raw: str) -> tuple[dict, str]:
+    """Split Agent Skills YAML frontmatter from the body (#65).
+
+    Returns ``(meta, body)``; ``meta`` is ``{}`` when there is no frontmatter
+    or it fails to parse (the whole text is then the body).
+    """
+    if not raw.startswith("---"):
+        return {}, raw
+    parts = raw.split("\n---", 2)
+    if len(parts) < 2:
+        return {}, raw
+    try:
+        meta = yaml.safe_load(parts[0][3:])
+    except yaml.YAMLError:
+        return {}, raw
+    if not isinstance(meta, dict):
+        return {}, raw
+    body = parts[1]
+    if len(parts) == 3:
+        body += "\n---" + parts[2]
+    return meta, body.lstrip("\n")
+
+
+def _seed_summary(raw: str) -> str:
+    """Summary for a seed file: frontmatter ``description`` beats the
+    first-line heuristic. Agent Skills caps descriptions at 1024 chars; the
+    index wants one line, so trim harder."""
+    meta, body = split_frontmatter(raw)
+    desc = str(meta.get("description") or "").strip()
+    return " ".join(desc.split())[:300] if desc else _extract_summary(body)
+
+
+def _bundled_files_header(name: str, base_dir: Path) -> str:
+    """One-line pointer prepended to a directory skill's content so the model
+    can reach the files bundled next to SKILL.md (#65). Relative paths inside
+    the skill body resolve against this directory."""
+    return (
+        f"> Bundled files for this skill live in `{base_dir}/`. Relative paths in "
+        f"this document resolve there. Read one with: "
+        f"`python3 /app/tools/skills.py cat {name} <relative-path>`\n\n"
+    )
+
+
+def _load_seed(name: str, path: Path) -> tuple[str, str] | None:
+    """Load a seed file into ``(stored_content, summary)``; None if empty.
+
+    Directory skills (``<dir>/SKILL.md``) get the bundled-files header
+    prepended; the seed hash is computed over this final stored content so
+    drift detection keeps working for both formats.
+    """
+    raw = path.read_text().strip()
+    if not raw:
+        return None
+    summary = _seed_summary(raw)
+    if path.name == "SKILL.md":
+        raw = _bundled_files_header(name, path.parent.resolve()) + raw
+    return raw, summary
+
+
 class SkillsStore:
     """SQLite-backed store for skill documents."""
 
-    def __init__(self, db_path: str = "data/skills.db", seed_dir: str | Path = "skills/"):
+    def __init__(
+        self,
+        db_path: str = "data/skills.db",
+        seed_dir: str | Path = "skills/",
+        installed_dir: str | Path = "data/skills",
+    ):
         self.db_path = db_path
         self.seed_dir = Path(seed_dir) if seed_dir else None
+        # Skills installed from git repos land here (#65) — a writable dir
+        # (the seed dir is mounted read-only in Docker).
+        self.installed_dir = Path(installed_dir) if installed_dir else None
         self._ready = False
 
     async def _ensure_schema(self) -> None:
@@ -68,6 +151,13 @@ class SkillsStore:
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
         async with aiosqlite.connect(self.db_path) as db:
             await db.executescript(_SCHEMA)
+            # Migrations for pre-existing tables (safe no-op when current).
+            for migration in (_MIGRATE_SEED_HASH, _MIGRATE_ORIGIN):
+                try:
+                    await db.execute(migration)
+                except aiosqlite.OperationalError:  # already present
+                    pass
+            await db.commit()
         self._ready = True
 
     async def _count(self) -> int:
@@ -77,6 +167,31 @@ class SkillsStore:
             row = await cursor.fetchone()
             return int(row[0]) if row else 0
 
+    def _iter_seed_files(self) -> list[tuple[str, Path]]:
+        """All seed files as ``(name, path)`` — flat ``<seed_dir>/<name>.md``,
+        spec dirs ``<seed_dir>/<name>/SKILL.md`` (#65), and installed dirs
+        ``<installed_dir>/<name>/SKILL.md``. First occurrence of a name wins."""
+        out: list[tuple[str, Path]] = []
+        seen: set[str] = set()
+        roots = [d for d in (self.seed_dir, self.installed_dir) if d and d.exists()]
+        for root in roots:
+            for path in sorted(root.glob("*.md")) + sorted(root.glob("*/SKILL.md")):
+                name = path.stem if path.name != "SKILL.md" else path.parent.name
+                if name in seen:
+                    continue
+                seen.add(name)
+                out.append((name, path))
+        return out
+
+    def _origin_for(self, path: Path) -> str | None:
+        """The install origin ("url#path") recorded next to SKILL.md, if any."""
+        if path.name != "SKILL.md":
+            return None
+        marker = path.parent / ORIGIN_MARKER
+        if not marker.exists():
+            return None
+        return marker.read_text().strip() or None
+
     async def ensure_seeded(self) -> bool:
         """Seed missing skills from markdown files and adopt hashes for pre-migration rows.
 
@@ -84,15 +199,8 @@ class SkillsStore:
         ``reset_skill_to_seed()`` for that (triggered by a UI button).
         """
         await self._ensure_schema()
-        # Run migration (safe no-op if column already exists).
-        async with aiosqlite.connect(self.db_path) as db:
-            try:
-                await db.execute(_MIGRATE_SEED_HASH)
-            except aiosqlite.OperationalError:  # already present
-                pass
-            await db.commit()
-
-        if not self.seed_dir or not self.seed_dir.exists():
+        seeds = self._iter_seed_files()
+        if not seeds:
             return False
 
         inserted = 0
@@ -102,20 +210,19 @@ class SkillsStore:
                 row[0]: {"content": row[1], "seed_hash": row[2]} for row in await cursor.fetchall()
             }
 
-            for skill_file in sorted(self.seed_dir.glob("*.md")):
-                content = skill_file.read_text().strip()
-                if not content:
+            for name, skill_file in seeds:
+                loaded = _load_seed(name, skill_file)
+                if loaded is None:
                     continue
-                name = skill_file.stem
+                content, summary = loaded
                 file_hash = hashlib.sha256(content.encode()).hexdigest()
-                summary = _extract_summary(content)
 
                 if name not in existing:
-                    # New skill — insert with hash.
+                    # New skill — insert with hash (+ origin for installed ones).
                     await db.execute(
                         "INSERT INTO skills"
-                        " (name, content, summary, seed_hash) VALUES (?, ?, ?, ?)",
-                        (name, content, summary, file_hash),
+                        " (name, content, summary, seed_hash, origin) VALUES (?, ?, ?, ?, ?)",
+                        (name, content, summary, file_hash, self._origin_for(skill_file)),
                     )
                     inserted += 1
                 elif existing[name]["seed_hash"] is None and existing[name]["content"] == content:
@@ -128,50 +235,69 @@ class SkillsStore:
         return inserted > 0
 
     def _seed_path(self, name: str) -> Path | None:
-        """Return the seed file path for a skill name, or None."""
-        if not self.seed_dir:
+        """Return the seed file path for a skill name, or None. Checks the flat
+        seed file, the spec-format seed dir, and the installed dir (#65)."""
+        candidates = []
+        if self.seed_dir:
+            candidates += [self.seed_dir / f"{name}.md", self.seed_dir / name / "SKILL.md"]
+        if self.installed_dir:
+            candidates.append(self.installed_dir / name / "SKILL.md")
+        for path in candidates:
+            if path.exists():
+                return path
+        return None
+
+    def skill_base_dir(self, name: str) -> Path | None:
+        """Directory holding a skill's bundled files, or None for flat skills."""
+        path = self._seed_path(name)
+        if path is None or path.name != "SKILL.md":
             return None
-        path = self.seed_dir / f"{name}.md"
-        return path if path.exists() else None
+        return path.parent
 
     def _seed_hash_for(self, name: str) -> str | None:
-        """Compute sha256 of the seed file for this skill, or None."""
+        """Compute sha256 of the seeded content for this skill, or None."""
         path = self._seed_path(name)
         if path is None:
             return None
-        content = path.read_text().strip()
-        if not content:
+        loaded = _load_seed(name, path)
+        if loaded is None:
             return None
-        return hashlib.sha256(content.encode()).hexdigest()
+        return hashlib.sha256(loaded[0].encode()).hexdigest()
 
     async def reset_skill_to_seed(self, name: str) -> bool:
-        """Re-seed a single skill from its markdown file. No-op if the skill
-        has no seed file or the seed file hasn't changed. Returns True if the
-        skill was updated, False otherwise."""
+        """(Re-)seed a single skill from its file on disk. Upserts, so it also
+        covers a freshly installed skill not yet in the DB (#65). Returns True
+        if a row was written."""
         path = self._seed_path(name)
         if path is None:
             return False
-        content = path.read_text().strip()
-        if not content:
+        loaded = _load_seed(name, path)
+        if loaded is None:
             return False
+        content, summary = loaded
         file_hash = hashlib.sha256(content.encode()).hexdigest()
-        summary = _extract_summary(content)
+        origin = self._origin_for(path)
         await self._ensure_schema()
         async with aiosqlite.connect(self.db_path) as db:
-            cursor = await db.execute(
-                "UPDATE skills SET content = ?, summary = ?, seed_hash = ?, "
-                "updated_at = datetime('now') WHERE name = ?",
-                (content, summary, file_hash, name),
+            await db.execute(
+                "INSERT INTO skills (name, content, summary, seed_hash, origin)"
+                " VALUES (?, ?, ?, ?, ?)"
+                " ON CONFLICT(name) DO UPDATE SET"
+                " content = excluded.content, summary = excluded.summary,"
+                " seed_hash = excluded.seed_hash, origin = excluded.origin,"
+                " updated_at = datetime('now')",
+                (content, summary, file_hash, origin),
             )
             await db.commit()
-            return cursor.rowcount > 0
+            return True
 
     async def list_skills(self) -> list[dict]:
         await self.ensure_seeded()
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
-                "SELECT name, summary, content, seed_hash, updated_at FROM skills ORDER BY name"
+                "SELECT name, summary, content, seed_hash, origin, updated_at"
+                " FROM skills ORDER BY name"
             )
             rows = [dict(row) for row in await cursor.fetchall()]
         # Annotate each row with whether the seed has drifted.
@@ -188,7 +314,8 @@ class SkillsStore:
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
-                "SELECT name, content, summary, seed_hash, updated_at FROM skills WHERE name = ?",
+                "SELECT name, content, summary, seed_hash, origin, updated_at"
+                " FROM skills WHERE name = ?",
                 (name,),
             )
             row = await cursor.fetchone()
@@ -203,9 +330,19 @@ class SkillsStore:
             return skill
 
     async def upsert_skill(self, name: str, content: str) -> None:
-        """Upsert a skill, clearing its seed_hash (user edit = no longer pristine)."""
+        """Upsert a skill, clearing its seed_hash (user edit = no longer pristine).
+
+        Raises ``ValueError`` for installed (origin-tagged) skills — they are
+        read-only; update by re-installing, customize by copying (#65).
+        """
         await self._ensure_schema()
-        summary = _extract_summary(content)
+        existing = await self.get_skill(name)
+        if existing and existing.get("origin"):
+            raise ValueError(
+                f"Skill '{name}' was installed from {existing['origin']} and is "
+                "read-only. Delete it and create your own copy to customize."
+            )
+        summary = _seed_summary(content)
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
                 "INSERT INTO skills (name, content, summary) VALUES (?, ?, ?) "
@@ -221,14 +358,91 @@ class SkillsStore:
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute("DELETE FROM skills WHERE name = ?", (name,))
             await db.commit()
-            return cursor.rowcount > 0
+            deleted = cursor.rowcount > 0
+        # Installed skills also own a directory under installed_dir — remove it
+        # so ensure_seeded can't resurrect the row (#65). Never touches seed_dir.
+        if self.installed_dir:
+            skill_dir = self.installed_dir / name
+            if (skill_dir / "SKILL.md").exists():
+                shutil.rmtree(skill_dir)
+                deleted = True
+        return deleted
+
+    async def install_from_git(self, repo_url: str, skill_path: str = "") -> dict:
+        """Install (or update) a skill from a git repo into ``installed_dir`` (#65).
+
+        ``skill_path`` is the directory inside the repo holding SKILL.md
+        ("" = repo root is the skill). Clones shallow, copies the dir, records
+        the origin marker, and (re-)seeds the DB row. Returns
+        ``{name, origin, warnings}``; raises ``ValueError`` on anything wrong.
+        """
+        if not self.installed_dir:
+            raise ValueError("No installed-skills directory configured")
+        skill_path = skill_path.strip().strip("/")
+        if ".." in skill_path.split("/"):
+            raise ValueError("Skill path cannot contain '..'")
+        with tempfile.TemporaryDirectory(prefix="skill-install-") as tmp:
+            proc = subprocess.run(
+                ["git", "clone", "--depth", "1", repo_url, tmp],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if proc.returncode != 0:
+                raise ValueError(f"git clone failed: {proc.stderr.strip()[-500:]}")
+            src = Path(tmp) / skill_path if skill_path else Path(tmp)
+            skill_md = src / "SKILL.md"
+            if not skill_md.exists():
+                raise ValueError(f"No SKILL.md at '{skill_path or '.'}' in {repo_url}")
+            meta, _ = split_frontmatter(skill_md.read_text())
+            name = str(meta.get("name") or src.name).strip()
+            # Same name rules as tools/skills.py — the name becomes a directory
+            # under installed_dir, so this is also the path-safety check.
+            if not _NAME_PATTERN.match(name) or "--" in name:
+                raise ValueError(
+                    f"Invalid skill name {name!r} (lowercase letters, digits, hyphens)"
+                )
+            findings = validate_skill_file(skill_md)
+            errors = [str(f) for f in findings if f.severity == "error"]
+            if errors:
+                raise ValueError("Skill failed validation: " + "; ".join(errors))
+            dest = self.installed_dir / name
+            if dest.exists():
+                shutil.rmtree(dest)
+            self.installed_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(src, dest)
+            shutil.rmtree(dest / ".git", ignore_errors=True)
+            origin = f"{repo_url}#{skill_path}"
+            (dest / ORIGIN_MARKER).write_text(origin + "\n")
+        await self.reset_skill_to_seed(name)
+        return {
+            "name": name,
+            "origin": origin,
+            "warnings": [str(f) for f in findings if f.severity == "warning"],
+        }
+
+    async def update_installed_skill(self, name: str) -> dict:
+        """Re-install a skill from its recorded origin (#65)."""
+        skill = await self.get_skill(name)
+        if not skill:
+            raise ValueError(f"Skill not found: {name}")
+        origin = skill.get("origin") or ""
+        if "#" not in origin:
+            raise ValueError(f"Skill '{name}' has no install origin — nothing to update")
+        repo_url, _, skill_path = origin.partition("#")
+        return await self.install_from_git(repo_url, skill_path)
 
 
 class SkillsEngine:
     """Skill index + lazy loader for LLM usage."""
 
-    def __init__(self, db_path: str = "data/skills.db", seed_dir: str | Path = "skills/"):
-        self.store = SkillsStore(db_path=db_path, seed_dir=seed_dir)
+    def __init__(
+        self,
+        db_path: str = "data/skills.db",
+        seed_dir: str | Path = "skills/",
+        installed_dir: str | Path = "data/skills",
+    ):
+        self.store = SkillsStore(db_path=db_path, seed_dir=seed_dir, installed_dir=installed_dir)
 
     async def index_entries(self, allow: list[str] | None = None) -> list[dict]:
         """The skills index as ``{name, summary}`` rows, scoped to ``allow``
@@ -363,6 +577,43 @@ def _validate_h1_title(path: Path, content: str) -> list[ValidationError]:
                 1,
                 "Missing H1 title (first line should be '# Title')",
             )
+        )
+    return errors
+
+
+def _validate_frontmatter(path: Path, content: str) -> list[ValidationError]:
+    """Agent Skills frontmatter checks for SKILL.md files (#65): ``name`` and
+    ``description`` required, spec length caps, name matches the directory."""
+    errors: list[ValidationError] = []
+    meta, _ = split_frontmatter(content)
+    if not meta:
+        errors.append(
+            ValidationError(str(path), 1, "SKILL.md requires YAML frontmatter (name, description)")
+        )
+        return errors
+    name = str(meta.get("name") or "").strip()
+    desc = str(meta.get("description") or "").strip()
+    if not name:
+        errors.append(ValidationError(str(path), 1, "Frontmatter is missing 'name'"))
+    elif len(name) > 64:
+        errors.append(ValidationError(str(path), 1, "Frontmatter 'name' exceeds 64 characters"))
+    elif not _NAME_PATTERN.match(name):
+        errors.append(
+            ValidationError(str(path), 1, f"Frontmatter name {name!r} must be lowercase [a-z0-9-]")
+        )
+    elif path.name == "SKILL.md" and path.parent.name and name != path.parent.name:
+        errors.append(
+            ValidationError(
+                str(path),
+                1,
+                f"Frontmatter name {name!r} does not match directory '{path.parent.name}'",
+            )
+        )
+    if not desc:
+        errors.append(ValidationError(str(path), 1, "Frontmatter is missing 'description'"))
+    elif len(desc) > 1024:
+        errors.append(
+            ValidationError(str(path), 1, "Frontmatter 'description' exceeds 1024 characters")
         )
     return errors
 
@@ -547,9 +798,19 @@ def validate_skill_file(path: Path, strict: bool = False) -> list[ValidationErro
         return [ValidationError(str(path), 1, "File not found")]
     content = path.read_text()
     errors: list[ValidationError] = []
-    errors.extend(_validate_h1_title(path, content))
+    is_spec = path.name == "SKILL.md"
+    if is_spec:
+        errors.extend(_validate_frontmatter(path, content))
+        # Spec skills carry frontmatter, not an H1; and community skills freely
+        # reference commands outside humux's executor allowlist — the executor
+        # blocks those at runtime, so here they're a heads-up, not a failure.
+        for finding in _validate_bash_commands(path, content):
+            finding.severity = "warning"
+            errors.append(finding)
+    else:
+        errors.extend(_validate_h1_title(path, content))
+        errors.extend(_validate_bash_commands(path, content))
     errors.extend(_validate_code_blocks(path, content))
-    errors.extend(_validate_bash_commands(path, content))
     errors.extend(_validate_cross_references(path, content))
 
     if strict:
@@ -622,7 +883,7 @@ def validate_skill_dir(seed_dir: str | Path, strict: bool = False) -> list[Valid
     if not d.exists():
         return [ValidationError(str(d), 1, f"Seed directory '{seed_dir}' not found")]
     errors: list[ValidationError] = []
-    for skill_file in sorted(d.glob("*.md")):
+    for skill_file in sorted(d.glob("*.md")) + sorted(d.glob("*/SKILL.md")):
         errors.extend(validate_skill_file(skill_file, strict=strict))
     return errors
 

--- a/humux/docker-compose.yml
+++ b/humux/docker-compose.yml
@@ -6,8 +6,10 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      # data/ also holds skills installed from git repos (data/skills/, #65) —
-      # installs need a writable mount, since the skills/ seed dir below is ro.
+      # data/ also holds skills installed from git repos (data/skills/, #65).
+      # Installs always target this volume — the skills/ seed dir is read-only
+      # here and baked into the image in setups that don't mount it at all —
+      # so installed skills survive both restarts and image updates.
       - ./data:/app/data
       - ./config.yml:/app/config.yml:ro
       - ./character.md:/app/character.md:ro

--- a/humux/docker-compose.yml
+++ b/humux/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     ports:
       - "8000:8000"
     volumes:
+      # data/ also holds skills installed from git repos (data/skills/, #65) —
+      # installs need a writable mount, since the skills/ seed dir below is ro.
       - ./data:/app/data
       - ./config.yml:/app/config.yml:ro
       - ./character.md:/app/character.md:ro

--- a/humux/tests/test_skills.py
+++ b/humux/tests/test_skills.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import pytest
 
-from core.skills import SkillsEngine, ValidationError, validate_skill_dir, validate_skill_file
+from core.skills import (
+    SkillsEngine,
+    SkillsStore,
+    ValidationError,
+    validate_skill_dir,
+    validate_skill_file,
+)
 
 
 @pytest.mark.asyncio
@@ -232,3 +238,178 @@ def test_validate_nonexistent_file(tmp_path) -> None:
 def test_validate_nonexistent_dir(tmp_path) -> None:
     errors = validate_skill_dir(tmp_path / "no_such_dir")
     assert any("not found" in str(e) for e in errors)
+
+
+# --- Agent Skills format: SKILL.md dirs, frontmatter, installs (#65) ---
+
+SPEC_SKILL = """---
+name: docx
+description: Create and edit Word documents via bundled scripts.
+---
+
+# docx
+
+Run `python3 scripts/convert.py`.
+"""
+
+
+def _spec_skill_dir(root, name="docx", content=SPEC_SKILL) -> None:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(content)
+    (d / "scripts").mkdir()
+    (d / "scripts" / "convert.py").write_text('print("hi")\n')
+
+
+@pytest.mark.asyncio
+async def test_seed_spec_dir_skill(tmp_path) -> None:
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _spec_skill_dir(seed)
+    store = SkillsStore(
+        db_path=str(tmp_path / "s.db"), seed_dir=seed, installed_dir=tmp_path / "inst"
+    )
+    skills = await store.list_skills()
+    assert [s["name"] for s in skills] == ["docx"]
+    # Frontmatter description becomes the summary.
+    assert skills[0]["summary"] == "Create and edit Word documents via bundled scripts."
+    # Content carries the bundled-files pointer + the raw SKILL.md.
+    skill = await store.get_skill("docx")
+    assert "Bundled files for this skill" in skill["content"]
+    assert str(seed / "docx") in skill["content"]
+    assert skill["origin"] is None
+    assert skill["stale_seed"] is False
+
+
+@pytest.mark.asyncio
+async def test_flat_and_spec_skills_coexist(tmp_path) -> None:
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / "weather.md").write_text("# Weather\n\ncurl wttr.in")
+    _spec_skill_dir(seed)
+    store = SkillsStore(
+        db_path=str(tmp_path / "s.db"), seed_dir=seed, installed_dir=tmp_path / "inst"
+    )
+    skills = await store.list_skills()
+    assert [s["name"] for s in skills] == ["docx", "weather"]
+
+
+@pytest.mark.asyncio
+async def test_installed_dir_seeded_with_origin(tmp_path) -> None:
+    inst = tmp_path / "inst"
+    _spec_skill_dir(inst)
+    (inst / "docx" / ".origin").write_text("https://example.com/repo#skills/docx\n")
+    store = SkillsStore(
+        db_path=str(tmp_path / "s.db"), seed_dir=tmp_path / "seed", installed_dir=inst
+    )
+    skill = await store.get_skill("docx")
+    assert skill["origin"] == "https://example.com/repo#skills/docx"
+
+
+@pytest.mark.asyncio
+async def test_installed_skill_is_read_only(tmp_path) -> None:
+    inst = tmp_path / "inst"
+    _spec_skill_dir(inst)
+    (inst / "docx" / ".origin").write_text("https://example.com/repo#skills/docx\n")
+    store = SkillsStore(
+        db_path=str(tmp_path / "s.db"), seed_dir=tmp_path / "seed", installed_dir=inst
+    )
+    await store.ensure_seeded()
+    with pytest.raises(ValueError, match="read-only"):
+        await store.upsert_skill("docx", "# hacked")
+
+
+@pytest.mark.asyncio
+async def test_delete_installed_skill_removes_dir(tmp_path) -> None:
+    inst = tmp_path / "inst"
+    _spec_skill_dir(inst)
+    store = SkillsStore(
+        db_path=str(tmp_path / "s.db"), seed_dir=tmp_path / "seed", installed_dir=inst
+    )
+    await store.ensure_seeded()
+    assert await store.delete_skill("docx") is True
+    assert not (inst / "docx").exists()
+    # ensure_seeded can't resurrect it.
+    await store.ensure_seeded()
+    assert await store.get_skill("docx") is None
+
+
+@pytest.mark.asyncio
+async def test_install_from_git_and_update(tmp_path) -> None:
+    import subprocess
+
+    repo = tmp_path / "repo"
+    _spec_skill_dir(repo / "document-skills")
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"],
+        check=True,
+    )
+    store = SkillsStore(
+        db_path=str(tmp_path / "s.db"),
+        seed_dir=tmp_path / "seed",
+        installed_dir=tmp_path / "inst",
+    )
+    result = await store.install_from_git(str(repo), "document-skills/docx")
+    assert result["name"] == "docx"
+    assert result["origin"] == f"{repo}#document-skills/docx"
+    skill = await store.get_skill("docx")
+    assert skill["origin"] == result["origin"]
+    assert (tmp_path / "inst" / "docx" / "scripts" / "convert.py").exists()
+    # Update re-fetches from the recorded origin.
+    updated = await store.update_installed_skill("docx")
+    assert updated["name"] == "docx"
+
+
+@pytest.mark.asyncio
+async def test_install_rejects_missing_skill_md(tmp_path) -> None:
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "README.md").write_text("nope")
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"],
+        check=True,
+    )
+    store = SkillsStore(
+        db_path=str(tmp_path / "s.db"),
+        seed_dir=tmp_path / "seed",
+        installed_dir=tmp_path / "inst",
+    )
+    with pytest.raises(ValueError, match="No SKILL.md"):
+        await store.install_from_git(str(repo), "")
+
+
+def test_validate_spec_skill_frontmatter(tmp_path) -> None:
+    _spec_skill_dir(tmp_path)
+    errors = validate_skill_file(tmp_path / "docx" / "SKILL.md")
+    assert errors == []
+
+
+def test_validate_spec_skill_missing_frontmatter(tmp_path) -> None:
+    d = tmp_path / "docx"
+    d.mkdir()
+    (d / "SKILL.md").write_text("# docx\n\nNo frontmatter here.")
+    errors = validate_skill_file(d / "SKILL.md")
+    assert any("frontmatter" in str(e).lower() for e in errors)
+
+
+def test_validate_spec_skill_name_dir_mismatch(tmp_path) -> None:
+    d = tmp_path / "other"
+    d.mkdir()
+    (d / "SKILL.md").write_text(SPEC_SKILL)
+    errors = validate_skill_file(d / "SKILL.md")
+    assert any("does not match directory" in str(e) for e in errors)
+
+
+def test_spec_skill_commands_downgrade_to_warnings(tmp_path) -> None:
+    d = tmp_path / "docx"
+    d.mkdir()
+    (d / "SKILL.md").write_text(SPEC_SKILL + "\n```bash\nnpm install\n```\n")
+    errors = validate_skill_file(d / "SKILL.md")
+    assert errors  # the disallowed command is flagged...
+    assert all(e.severity == "warning" for e in errors)  # ...but only as a warning

--- a/humux/tools/skills.py
+++ b/humux/tools/skills.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""Skills CLI — list, show, create, and delete skills.
+"""Skills CLI — list, show, create, delete, and install skills.
 
 Usage examples:
   python3 /app/tools/skills.py list --output json
   python3 /app/tools/skills.py show memory --output json
   python3 /app/tools/skills.py upsert --name weather --stdin
   python3 /app/tools/skills.py delete weather
+  python3 /app/tools/skills.py install https://github.com/anthropics/skills \
+      --path document-skills/docx
+  python3 /app/tools/skills.py update docx
+  python3 /app/tools/skills.py cat docx scripts/example.py
 """
 
 from __future__ import annotations
@@ -39,6 +43,12 @@ def _default_seed_dir() -> str:
     if Path("/app/skills").exists():
         return "/app/skills"
     return str(_ROOT / "skills")
+
+
+def _default_installed_dir() -> str:
+    if Path("/app/data").exists():
+        return "/app/data/skills"
+    return str(_ROOT / "data/skills")
 
 
 def _validate_name(name: str) -> str:
@@ -113,6 +123,25 @@ async def _delete_skill(store: SkillsStore, name: str) -> None:
         sys.exit(1)
 
 
+async def _cat_bundled_file(store: SkillsStore, name: str, relpath: str) -> None:
+    """Print a file bundled with a directory skill (#65), confined to the
+    skill's own directory (same realpath-containment rail as the workspace
+    file tools, #76)."""
+    base = store.skill_base_dir(name)
+    if base is None:
+        print(json.dumps({"error": f"Skill '{name}' has no bundled files"}))
+        sys.exit(1)
+    base = base.resolve()
+    target = (base / relpath).resolve()
+    if not target.is_relative_to(base):
+        print(json.dumps({"error": "Path escapes the skill directory"}))
+        sys.exit(1)
+    if not target.is_file():
+        print(json.dumps({"error": f"No such file in skill '{name}': {relpath}"}))
+        sys.exit(1)
+    sys.stdout.write(target.read_text(errors="replace"))
+
+
 def _write_seed_file(seed_dir: str, name: str, content: str) -> Path:
     seed_path = Path(seed_dir)
     if not seed_path.exists():
@@ -129,6 +158,11 @@ def main() -> None:
         "--seed-dir",
         default=_default_seed_dir(),
         help="Seed directory for skills markdown files",
+    )
+    parser.add_argument(
+        "--installed-dir",
+        default=_default_installed_dir(),
+        help="Directory for skills installed from git repos",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -153,9 +187,28 @@ def main() -> None:
     delete_parser = subparsers.add_parser("delete", help="Delete a skill")
     delete_parser.add_argument("name")
 
+    install_parser = subparsers.add_parser(
+        "install", help="Install an Agent Skills skill from a git repo"
+    )
+    install_parser.add_argument("repo_url", help="Git repo URL")
+    install_parser.add_argument(
+        "--path",
+        default="",
+        help="Directory inside the repo holding SKILL.md (default: repo root)",
+    )
+
+    update_parser = subparsers.add_parser(
+        "update", help="Re-install an installed skill from its recorded origin"
+    )
+    update_parser.add_argument("name")
+
+    cat_parser = subparsers.add_parser("cat", help="Print a file bundled with a skill")
+    cat_parser.add_argument("name")
+    cat_parser.add_argument("relpath", help="Path relative to the skill directory")
+
     args = parser.parse_args()
 
-    store = SkillsStore(db_path=args.db, seed_dir=args.seed_dir)
+    store = SkillsStore(db_path=args.db, seed_dir=args.seed_dir, installed_dir=args.installed_dir)
 
     try:
         if args.command == "list":
@@ -173,6 +226,16 @@ def main() -> None:
         elif args.command == "delete":
             name = _validate_name(args.name)
             asyncio.run(_delete_skill(store, name))
+        elif args.command == "install":
+            result = asyncio.run(store.install_from_git(args.repo_url, args.path))
+            print(json.dumps({"status": "installed", **result}))
+        elif args.command == "update":
+            name = _validate_name(args.name)
+            result = asyncio.run(store.update_installed_skill(name))
+            print(json.dumps({"status": "updated", **result}))
+        elif args.command == "cat":
+            name = _validate_name(args.name)
+            asyncio.run(_cat_bundled_file(store, name, args.relpath))
         else:
             parser.print_help()
     except ValueError as exc:

--- a/humux/tools/skills.py
+++ b/humux/tools/skills.py
@@ -7,7 +7,7 @@ Usage examples:
   python3 /app/tools/skills.py upsert --name weather --stdin
   python3 /app/tools/skills.py delete weather
   python3 /app/tools/skills.py install https://github.com/anthropics/skills \
-      --path document-skills/docx
+      --path skills/docx
   python3 /app/tools/skills.py update docx
   python3 /app/tools/skills.py cat docx scripts/example.py
 """


### PR DESCRIPTION
Closes #65.

## What

humux now understands the [Agent Skills](https://agentskills.io) format used by [anthropics/skills](https://github.com/anthropics/skills) and other frameworks, alongside its existing flat markdown skills.

### Format support (both formats coexist)
- Seed loader also accepts `skills/<name>/SKILL.md` directories next to flat `skills/*.md`
- YAML frontmatter parsed: `description` becomes the index summary (better than the first-line heuristic), `name` must match the directory
- Bundled files (`scripts/`, `references/`, …) stay on disk; the stored skill body starts with a base-directory pointer so the model can resolve relative references

### Installing community skills
- `python3 tools/skills.py install <repo-url> --path skills/docx` — shallow clone, validate, copy to `data/skills/<name>/`, seed the DB
- Same flow from the admin Skills tab ("Install from a git repo" form)
- Installed skills go under `data/` because `skills/` is mounted read-only in Docker; installs survive image rebuilds, and a `.origin` marker lets a rebuilt DB re-seed with provenance intact

### Read-only + update semantics
- Installed skills are origin-tagged and **read-only**: the editor shows a banner and the server rejects upserts (customize = delete + create your own copy)
- Update = re-install from the recorded origin (`skills.py update <name>` or the ⟳ button); `updated_at` reflects the refresh
- Delete removes the DB row **and** the installed directory, so `ensure_seeded` can't resurrect it

### Reading bundled files
- New `skills.py cat <name> <relpath>` prints a bundled file with realpath containment inside the skill's directory (same rail as the workspace file tools, #76) — needed because workspace tools can't reach outside the workspace and `cat` isn't an allowed bash prefix

### Validation
- SKILL.md files get frontmatter checks (name/description required, spec length caps, name↔directory match)
- Command-allowlist findings downgrade to **warnings** for spec skills: community skills freely reference commands humux doesn't allow, the executor still blocks them at runtime — the security boundary is unchanged

### No changes needed
- Telegram `/zz_skill_*` menu, CLI channel, and scheduled jobs/subagents all pick up installed skills automatically — the per-turn `<available_skills>` index and on-demand `skills.py show` flow is untouched

## Verified
- Full test suite: 982 passed (12 new tests covering dual-format seeding, origin/read-only/delete semantics, git install/update, frontmatter validation)
- Real-world: installed `docx` from `anthropics/skills` end-to-end via the CLI — frontmatter description lands as the summary, bundled scripts readable via `cat`, allowlist warnings surfaced as designed