### PR TITLE
fix: make admin PWA installable on mobile

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -733,6 +733,17 @@ def create_admin_app(
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
+    # Serve the service worker from root so its scope covers "/" (the manifest
+    # start_url). A SW served from /static/ only controls /static/ and can't make
+    # the app installable. Public (no auth) so the browser can fetch it pre-login.
+    @app.get("/sw.js", include_in_schema=False)
+    async def service_worker() -> Response:
+        return FileResponse(
+            static_dir / "sw.js",
+            media_type="text/javascript",
+            headers={"Cache-Control": "no-cache"},
+        )
+
     # ── Agent web artifacts (public files under {workspace}/artifacts/, issue #82) ──
     @app.get("/artifacts/{artifact_id}", response_model=None)
     async def artifact_root(artifact_id: str) -> Response:

--- a/humux/api/static/sw.js
+++ b/humux/api/static/sw.js
@@ -8,12 +8,15 @@ const SHELL = [
   "/static/icon-192.png",
   "/static/icon-512.png",
   "/static/style.css",
-  "/offline",
 ];
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE).then((cache) => cache.addAll(SHELL)),
+    // allSettled, not addAll: a single missing asset must not abort SW install
+    // (that would leave the app with no controller = not installable).
+    caches
+      .open(CACHE)
+      .then((cache) => Promise.allSettled(SHELL.map((u) => cache.add(u)))),
   );
   self.skipWaiting();
 });

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -103,7 +103,7 @@
   <script>
     // Register service worker for PWA installability (#177)
     if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/static/sw.js');
+      navigator.serviceWorker.register('/sw.js');
     }
 
     // Global: set HTMX auth header from localStorage

--- a/humux/tests/test_admin_ui.py
+++ b/humux/tests/test_admin_ui.py
@@ -141,6 +141,15 @@ class TestPageRoutes:
         assert resp.status_code == 302
         assert resp.headers["location"] == "/setup"
 
+    def test_service_worker_served_at_root_scope_without_auth(self):
+        # SW must be reachable at "/sw.js" (root scope) and public, else it can't
+        # control start_url "/" and the app is not installable.
+        client = _client()
+        resp = client.get("/sw.js")
+        assert resp.status_code == 200
+        assert "javascript" in resp.headers["content-type"]
+        assert "addEventListener" in resp.text
+
     def test_login_page_returns_html(self):
         client = _client()
         resp = client.get("/login")


### PR DESCRIPTION
## Problem
Opening the admin on mobile offered no "Install app" / "Add to Home Screen" prompt.

## Root cause
Two independent bugs, both fatal to installability:

1. **Service worker scope.** `sw.js` was served from `/static/sw.js`, so its scope was `/static/`. A SW can only control URLs under its scope — it could not control the manifest `start_url` (`/`), which browsers require for install.
2. **SW install aborted.** `cache.addAll(SHELL)` rejects atomically if *any* entry fails. `SHELL` listed `/offline` (no such route) and `/static/style.css` (not present), so the install event always threw → no active service worker → not installable.

## Fix
- Serve the worker from root (`GET /sw.js`, public, no auth) so its scope covers `/`.
- Register `/sw.js` instead of `/static/sw.js`.
- Precache with `Promise.allSettled` so a missing shell asset can't abort install.
- Drop the nonexistent `/offline` entry.

## Test
`test_service_worker_served_at_root_scope_without_auth` — asserts `/sw.js` is public, root-scoped, JS. Full `test_admin_ui.py` green.