### PR TITLE
fix(telegram): don't skip agent reply in forum topics

### DIFF
--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -219,6 +219,14 @@ class TelegramChannel:
 
     def _reply_context(self, message) -> str:
         reply = getattr(message, "reply_to_message", None)
+        # In a forum topic, the first message's reply_to_message is the topic's
+        # creation service message (non-text) — not a real reply. Rendering it
+        # poisons the reply-decision gate into SKIP (#forum). Ignore it.
+        if reply and (
+            getattr(reply, "forum_topic_created", None)
+            or getattr(reply, "message_id", None) == getattr(message, "message_thread_id", None)
+        ):
+            reply = None
         if not reply:
             return ""
         author = ""

--- a/humux/tests/test_forum_reply_context.py
+++ b/humux/tests/test_forum_reply_context.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+from channels.telegram import TelegramChannel
+
+_rc = TelegramChannel._reply_context
+
+
+def test_forum_topic_root_ignored():
+    # First msg in a forum topic: reply_to is the topic-creation service message.
+    root = SimpleNamespace(forum_topic_created=object(), message_id=40, text=None)
+    msg = SimpleNamespace(reply_to_message=root, message_thread_id=40)
+    assert _rc(None, msg) == ""
+
+
+def test_real_reply_still_rendered():
+    replied = SimpleNamespace(
+        forum_topic_created=None,
+        message_id=99,
+        text="hi",
+        from_user=SimpleNamespace(full_name="Bob", username=None, id=1),
+    )
+    msg = SimpleNamespace(reply_to_message=replied, message_thread_id=40)
+    assert "Bob: hi" in _rc(None, msg)


### PR DESCRIPTION
## Problem

Triggering an agent from a thread in a forum-mode Telegram group always skipped the reply:

```
core.reply_decision — Reply decision: SKIP ([from Matteo Merola]
[reply_to]
Matteo Merola: (non-text message)
[/reply_to]
@M)
channels.telegram — Skipping empty response for chat_id=-1004376425717:40
```

## Root cause

The first message in a forum topic has `reply_to_message` pointing to the topic's **creation service message** (`forum_topic_created`, non-text) — not a real reply. `_reply_context` rendered it as `(non-text message)`, which poisoned the reply-decision gate into `SKIP`, dropping every thread-triggered turn.

## Fix

Ignore the topic-root service message in `_reply_context` (detected via `forum_topic_created`, or `message_id == message_thread_id`) so the gate sees the real message. Per-thread routing (`_fold`/`_route`) is untouched.

Test added covering both the topic-root-ignored and real-reply-still-rendered cases.