### PR TITLE
fix(agent): explicit @mention must bypass reply-decision gate

### DIFF
--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -1376,6 +1376,7 @@ class AgentCore:
         rd_cfg = self.config.reply_decision
         if (
             rd_cfg.enabled
+            and not addressed  # explicit @mention of THIS bot always replies (#185)
             and channel != "system"
             and (not rd_cfg.group_only or self._is_group_chat(user_id, chat_id))
         ):

--- a/humux/tests/test_reply_decision.py
+++ b/humux/tests/test_reply_decision.py
@@ -72,9 +72,7 @@ async def test_history_and_siblings_feed_the_prompt() -> None:
         {"role": "user", "content": "Chef, what's for dinner?"},
         {"role": "assistant", "content": "Pasta."},
     ]
-    await should_reply(
-        llm, "m", "and dessert?", "Coach", history=history, others=["Chef", "Coach"]
-    )
+    await should_reply(llm, "m", "and dessert?", "Coach", history=history, others=["Chef", "Coach"])
     p = llm.last_prompt
     assert "Chef, what's for dinner?" in p  # recent turns are included
     assert "user: " in p and "assistant: " in p
@@ -161,7 +159,11 @@ async def test_process_suppresses_on_skip(agent, monkeypatch) -> None:
     _stub_dispatch(agent, monkeypatch)
 
     resp = await agent.process(
-        message="lol same", channel="telegram", user_id="111", chat_id="-999"
+        message="lol same",
+        channel="telegram",
+        user_id="111",
+        chat_id="-999",
+        addressed=False,
     )
     assert resp.text == ""
     # The reserved slot is released on SKIP, so a quiet chat keeps its budget.
@@ -174,7 +176,11 @@ async def test_process_replies_in_group_and_records_slot(agent, monkeypatch) -> 
     _stub_dispatch(agent, monkeypatch, text="here you go")
 
     resp = await agent.process(
-        message="can you help me?", channel="telegram", user_id="111", chat_id="-999"
+        message="can you help me?",
+        channel="telegram",
+        user_id="111",
+        chat_id="-999",
+        addressed=False,
     )
     assert resp.text == "here you go"
     # A real reply keeps its reserved slot — the backstop counts it.
@@ -218,7 +224,13 @@ async def test_concurrent_burst_is_bounded_by_cap(agent, monkeypatch) -> None:
 
     resps = await asyncio.gather(
         *(
-            agent.process(message=f"loop {i}", channel="telegram", user_id="111", chat_id="-999")
+            agent.process(
+                message=f"loop {i}",
+                channel="telegram",
+                user_id="111",
+                chat_id="-999",
+                addressed=False,
+            )
             for i in range(50)
         )
     )
@@ -237,6 +249,10 @@ async def test_process_suppresses_when_rate_capped(agent, monkeypatch) -> None:
     monkeypatch.setattr(agent, "_background_llm", lambda *a, **k: _BoomLLM())
     _stub_dispatch(agent, monkeypatch)
     resp = await agent.process(
-        message="still going", channel="telegram", user_id="111", chat_id="-999"
+        message="still going",
+        channel="telegram",
+        user_id="111",
+        chat_id="-999",
+        addressed=False,
     )
     assert resp.text == ""


### PR DESCRIPTION
## Problem

Follow-up to #206. Triggering an agent by name in a group still skipped every reply:

```
Reply decision: SKIP ([from Matteo Merola] @MatteoPersonalAgentDefaultBot hello)
Skipping empty response for chat_id=-1004376425717:53
```

The Inspect tab also stayed empty for these turns.

## Root cause

An explicitly-addressed message (`@bot ...`) still ran through the `should_reply` gate. The gate LLM can't map the `@botusername` to the agent's identity (`clio`) and, seeing sibling-bot names in `others`, classifies it as "addressed to someone else" → `SKIP`. Every direct mention was dropped.

The Inspect tab is a downstream symptom: `set_capture_context` runs *after* the gate, so a `SKIP` returns before `generate()` ever captures a payload.

## Fix

The gate exists for ambient/unaddressed group chatter. An explicit mention of THIS bot (`addressed`, #185) always warrants a reply — bypass the gate. The rate-cap backstop still bounds any bot-to-bot loop.

Gate tests updated to pass `addressed=False` so they exercise the gate path.