### PR TITLE
fix(agent-editor): keep saved GitHub secret selects on reload

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1265,7 +1265,7 @@ def create_admin_app(
 
     @app.get("/version", dependencies=[Depends(auth)])
     async def version() -> HTMLResponse:
-        """Latest release version from GitHub."""
+        """Latest release version from GitHub, linked to its release page."""
         try:
             async with httpx.AsyncClient(timeout=5) as client:
                 resp = await client.get(
@@ -1274,7 +1274,12 @@ def create_admin_app(
                 )
                 if resp.is_success:
                     tag = resp.json().get("tag_name", "") or ""
-                    return HTMLResponse(tag)
+                    url = f"https://github.com/mattmezza/humux/releases/tag/{tag}"
+                    link = (
+                        f'<a href="{url}" target="_blank"'
+                        f' class="hover:text-accent transition-colors">{tag}</a>'
+                    )
+                    return HTMLResponse(link)
         except Exception:
             pass
         return HTMLResponse("dev")

--- a/humux/api/templates/agent_editor.html
+++ b/humux/api/templates/agent_editor.html
@@ -324,9 +324,12 @@
                       <label class="label">Token source</label>
                       <select class="select input-sm" x-model="ghTokenSecret">
                         <option value="">Type a new token…</option>
-                        <template x-for="n in infraNames" :key="n">
-                          <option :value="n" x-text="'Vault secret: ' + n"></option>
-                        </template>
+                        {# Options rendered server-side so they exist before Alpine's
+                           x-model binds — an x-for select drops its saved value at init
+                           because the <option>s aren't in the DOM yet. #}
+                        {% for n in infra_names %}
+                          <option value="{{ n }}">Vault secret: {{ n }}</option>
+                        {% endfor %}
                       </select>
                     </div>
                     <div x-show="!ghTokenSecret">
@@ -363,9 +366,12 @@
                       <label class="label">Private key</label>
                       <select class="select input-sm" x-model="ghKeySecret">
                         <option value="">— use the system-wide App —</option>
-                        <template x-for="n in infraNames" :key="n">
-                          <option :value="n" x-text="'Vault secret: ' + n"></option>
-                        </template>
+                        {# Options rendered server-side so they exist before Alpine's
+                           x-model binds — an x-for select drops its saved value at init
+                           because the <option>s aren't in the DOM yet. #}
+                        {% for n in infra_names %}
+                          <option value="{{ n }}">Vault secret: {{ n }}</option>
+                        {% endfor %}
                       </select>
                       <p class="text-xs text-muted mt-1">
                         Paste this app's PEM as an infra secret in the <strong>Secrets</strong> tab,
@@ -379,9 +385,12 @@
                       <label class="label">Webhook secret <span class="text-muted">(optional)</span></label>
                       <select class="select input-sm" x-model="ghWebhookSecret">
                         <option value="">— inbound webhook off —</option>
-                        <template x-for="n in infraNames" :key="n">
-                          <option :value="n" x-text="'Vault secret: ' + n"></option>
-                        </template>
+                        {# Options rendered server-side so they exist before Alpine's
+                           x-model binds — an x-for select drops its saved value at init
+                           because the <option>s aren't in the DOM yet. #}
+                        {% for n in infra_names %}
+                          <option value="{{ n }}">Vault secret: {{ n }}</option>
+                        {% endfor %}
                       </select>
                       <p class="text-xs text-muted mt-1">
                         Store the App's webhook secret as an infra secret, pick it here, and set

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -3085,11 +3085,11 @@ class AgentCore:
         path = str(params.get("path", "")).strip()
         if not path:
             return {"error": "Missing 'path'."}
-        log.info("Tool call: read — %s", path)
+        offset = _as_int(params.get("offset"), 0)
+        limit = _as_int(params.get("limit"), 100)
+        log.info("Tool call: read — %s:%d-%d", path, offset + 1, offset + limit)
         try:
-            return coding.read_file(
-                workspace, path, _as_int(params.get("offset"), 0), _as_int(params.get("limit"), 100)
-            )
+            return coding.read_file(workspace, path, offset, limit)
         except coding.WorkspaceError as exc:
             return {"error": str(exc)}
         except OSError as exc:


### PR DESCRIPTION
## Bug

In `/admin/agents/<slug>` → Tools → Tool identities → GitHub, the **Private key** `<select>` reset to its default on every page load. Same latent bug on the **Token source** (PAT) and **Webhook secret** selects.

## Root cause

The three selects rendered their `<option>`s via Alpine `<template x-for="n in infraNames">`. On init, `x-model` sets the select's value from component data *before* the x-for options exist in the DOM, so the browser silently drops the value and snaps to the first option.

## Fix

`infraNames` never mutates client-side, so render the options with a Jinja `{% for %}` loop instead of `x-for`. Options are in the DOM before Alpine binds → `x-model` finds the matching option and keeps the stored value. Matches how the voice `<select>` on the same page already works.

## Verify

- Standalone Jinja render asserts `<option value="GITHUB_APP_PRIVATE_KEY">` is present at render time.
- Booted the editor against the real `agents.db` (agent `clio`); confirmed the `x-for` template is gone and options are static HTML.