### PR TITLE
Rename /jobs Telegram command to /subagents

### DIFF
--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -177,7 +177,7 @@ class TelegramChannel:
         # agent as an ordinary message. (Plain text — incl. /new, /clear — still
         # falls through to _on_text, which handles those.)
         self.app.add_handler(CommandHandler("subagents", self._on_subagents_command))
-        self.app.add_handler(CommandHandler("jobs", self._on_subagents_command))  # alias during deprecation
+        self.app.add_handler(CommandHandler("jobs", self._on_subagents_command))  # compat alias
         self.app.add_handler(MessageHandler(filters.TEXT, self._on_text))
         self.app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, self._on_voice))
         self.app.add_handler(MessageHandler(filters.PHOTO | filters.Document.IMAGE, self._on_photo))

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -53,7 +53,7 @@ _AGENT_COMMANDS = frozenset(
 # under its /yolo_on alias (the runtime accepts both — see _COMMAND_ALIASES).
 _MENU_COMMANDS = [
     BotCommand("new", "Clear the conversation"),
-    BotCommand("jobs", "Show scheduled jobs"),
+    BotCommand("subagents", "List active subagent runs"),
     BotCommand("yolo_on", "Run actions without asking for approval"),
     BotCommand("yolo_off", "Restore approval prompts"),
     BotCommand("stop", "Stop the current turn"),
@@ -173,10 +173,11 @@ class TelegramChannel:
         self._bot_id: int | None = None
         self._bot_username: str | None = None
         self.app = Application.builder().token(config.bot_token).concurrent_updates(8).build()
-        # Commands are checked before the text handler so "/jobs" doesn't reach the
+        # Commands are checked before the text handler so "/subagents" doesn't reach the
         # agent as an ordinary message. (Plain text — incl. /new, /clear — still
         # falls through to _on_text, which handles those.)
-        self.app.add_handler(CommandHandler("jobs", self._on_jobs_command))
+        self.app.add_handler(CommandHandler("subagents", self._on_subagents_command))
+        self.app.add_handler(CommandHandler("jobs", self._on_subagents_command))  # alias during deprecation
         self.app.add_handler(MessageHandler(filters.TEXT, self._on_text))
         self.app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, self._on_voice))
         self.app.add_handler(MessageHandler(filters.PHOTO | filters.Document.IMAGE, self._on_photo))
@@ -725,8 +726,8 @@ class TelegramChannel:
         except Exception:
             log.exception("Skill command failed: %s", slug)
 
-    async def _on_jobs_command(self, update: Update, context) -> None:
-        """/jobs — list active subagent runs with inline cancel buttons (issue #15)."""
+    async def _on_subagents_command(self, update: Update, context) -> None:
+        """/subagents — list active subagent runs with inline cancel buttons (issue #15)."""
         user = update.effective_user
         message = update.message
         chat = update.effective_chat

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -723,7 +723,7 @@ TOOLS = [
             "read or send them.\n"
             "Use background=true for long-running work: you get a run id "
             "immediately and the result is posted to this chat when done (monitor "
-            "or cancel it with /jobs or the admin Jobs page). Use background=false "
+            "or cancel it via /subagents or the admin Jobs page). Use background=false "
             "(default) to block and get the result back in this turn.\n"
             "Subagents are depth-limited, so prefer one focused delegation over "
             "deep nesting."
@@ -3647,7 +3647,7 @@ class AgentCore:
                 return {
                     "error": (
                         f"Too many subagents running (max {cfg.max_concurrent}). "
-                        "Wait for one to finish or cancel it via /jobs."
+                        "Wait for one to finish or cancel it via /subagents."
                     )
                 }
             self.subagents.register(run)

--- a/humux/tests/test_group_chat.py
+++ b/humux/tests/test_group_chat.py
@@ -373,7 +373,7 @@ def test_is_group_off_when_disabled() -> None:
 
 @pytest.mark.asyncio
 async def test_callback_respects_per_chat_gate() -> None:
-    # A /jobs Cancel (and any approve/deny) button is an action in the chat, so a
+    # A /subagents Cancel (and any approve/deny) button is an action in the chat, so a
     # user the resolved agent bars there (#129) must not drive it via the callback.
     ch = _channel()
     ch._finalize_approval_response = AsyncMock()
@@ -409,7 +409,7 @@ def test_addressed_via_mention_entity() -> None:
 
 def test_addressed_via_command_entity() -> None:
     ch = _channel()
-    msg = _msg("/jobs@coachbot", entities=[_ent("bot_command", "/jobs@coachbot")])
+    msg = _msg("/subagents@coachbot", entities=[_ent("bot_command", "/subagents@coachbot")])
     assert ch._addressed_to_me(msg) is True
 
 


### PR DESCRIPTION
Closes #216

## Summary

Renames the `/jobs` Telegram command to `/subagents` to avoid confusion with scheduled jobs/CI — the command lists active subagent runs, not cron tasks.

## Changes

- **`_MENU_COMMANDS`**: `BotCommand("jobs", ...)` → `BotCommand("subagents", "List active subagent runs")`
- **Command handler**: Registered as `CommandHandler("subagents", self._on_subagents_command)`; old `/jobs` kept as a backward-compatibility alias
- **Handler method**: Renamed `_on_jobs_command` → `_on_subagents_command`, docstring updated
- **User-facing messages** in `agent.py`: references changed from `/jobs` → `/subagents`
- **Tests**: `/jobs@coachbot` → `/subagents@coachbot`, comment updated

## Backward compatibility

`/jobs` continues to work (registered as a second CommandHandler pointing to the same method). The command menu only advertises `/subagents`.