### PR TITLE
feat: per-agent LLM inference override

### DIFF
--- a/docs/content/docs/agents.mdx
+++ b/docs/content/docs/agents.mdx
@@ -59,6 +59,10 @@ secrets: []
 tool_config:
   gh: {enabled: true}            # uses this agent's own GitHub token
   browser: {enabled: true, profile: forge}
+llm:                             # per-agent LLM override — see below
+  provider: anthropic
+  model: claude-4-6-opus
+  thinking_level: high
 chat_settings:                   # per-chat trigger/DM gate — see below
   "-1001234567890": {mode: users, users: [111111111]}
 character: |
@@ -156,6 +160,30 @@ hand-picked per chat; the project is built around **one agent = one bot** (a ded
 `telegram:<slug>` bot per identity), so the admin UI no longer offers a per-chat agent
 dropdown. A binding applies on the next turn; the open chat keeps its current identity
 until then (its messages are preserved).
+
+## Per-agent LLM
+
+By default every agent runs on the global LLM settings (**Dashboard → LLM**). The **LLM**
+tab in the agent editor lets an agent override any of them, so different agents can run on
+different setups — a *senior engineer* on a top-tier reasoning model while a *junior
+assistant* stays on a cheap, fast one:
+
+```yaml
+llm:
+  provider: anthropic       # any globally configured provider
+  model: claude-4-6-opus
+  thinking_level: high      # "" forces thinking OFF; omit to inherit the global level
+  max_tokens: 32000
+  temperature: 0.2
+```
+
+Every key is optional and overrides only itself — an agent with just `model:` keeps the
+global provider, thinking level, token ceiling and temperature. An empty/absent `llm`
+means the agent inherits everything (existing agents are unchanged on upgrade). API keys
+and base URLs are **always** the global ones (LLM → Providers): the override picks *which*
+configured provider and model the agent runs on, it never carries its own credentials.
+The override applies to the agent's whole agentic loop, including the subagent runs it
+spawns; background inferences (memory, compaction, reflection, …) keep their own models.
 
 ## Tool identities
 

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -672,6 +672,9 @@ class AgentUpsertIn(BaseModel):
     contacts_accounts: list[dict] = []  # [{account, access_level}] — #110 (contacts)
     chat_settings: dict = {}  # {chat_id: {mode, users}} per-chat trigger/DM gate — #129
     group_chat: dict = {}  # {enabled, reply_when_addressed_only, ignore_bots} group rooms — #133
+    # Per-agent LLM override {provider, model, thinking_level, max_tokens,
+    # temperature}; {} = inherit the global LLM config.
+    llm: dict = {}
     gh_token: str = ""  # this agent's GitHub PAT → infra vault; empty = leave unchanged
     raw: str = ""  # when set, the markdown doc is parsed instead of the fields above
 
@@ -1117,6 +1120,15 @@ def create_admin_app(
             "available_contacts_accounts": [
                 p["name"] for p in await _contact_providers_context(config_store) if p["name"]
             ],
+            # Global LLM settings, shown as the "inherit" placeholders on the
+            # per-agent LLM override tab.
+            "llm_defaults": {
+                "provider": (await config_store.get("agent.llm_provider")) or "anthropic",
+                "model": (await config_store.get("agent.model")) or "",
+                "thinking_level": (await config_store.get("agent.thinking_level")) or "",
+                "max_tokens": (await config_store.get("agent.max_tokens")) or "8192",
+                "temperature": (await config_store.get("agent.temperature")) or "0.5",
+            },
         }
 
     async def _agent_chats(name: str) -> list[dict]:
@@ -3211,6 +3223,7 @@ def create_admin_app(
             _as_chat_settings,
             _as_group_chat,
             _as_int_list,
+            _as_llm_config,
             _as_tool_config,
             parse_markdown,
         )
@@ -3241,6 +3254,7 @@ def create_admin_app(
                 contacts_accounts=_as_account_list(body.contacts_accounts),
                 chat_settings=_as_chat_settings(body.chat_settings),
                 group_chat=_as_group_chat(body.group_chat),
+                llm=_as_llm_config(body.llm),
             )
         # A per-agent GitHub token goes into the infra vault (machine-key,
         # boot-unsealed so it works headless), namespaced per agent (#93). Empty

--- a/humux/api/templates/agent_editor.html
+++ b/humux/api/templates/agent_editor.html
@@ -19,6 +19,7 @@
   <div x-show="mode === 'guided'">
     <div class="flex border-b border-border mb-4 overflow-x-auto">
       <button type="button" class="tab-link" :class="tab === 'identity' && 'tab-link-active'" @click="tab = 'identity'">Identity</button>
+      <button type="button" class="tab-link" :class="tab === 'llm' && 'tab-link-active'" @click="tab = 'llm'">LLM</button>
       <button type="button" class="tab-link" :class="tab === 'telegram' && 'tab-link-active'" @click="tab = 'telegram'">Telegram</button>
       <button type="button" class="tab-link" :class="tab === 'accounts' && 'tab-link-active'" @click="tab = 'accounts'">Accounts</button>
       <button type="button" class="tab-link" :class="tab === 'skills' && 'tab-link-active'" @click="tab = 'skills'">Skills</button>
@@ -95,6 +96,85 @@
           {% if backend == 'kokoro' %}Kokoro voice names (<code>af_bella</code>) — the active backend. You can override the pronunciation language.{% else %}Edge TTS voice names (<code>en-US-AvaNeural</code>) — the active backend.{% endif %}
           Preview plays the selected voice. Change the engine in the <strong>Voice</strong> tab.
         </p>
+      </div>
+    </div>
+
+    {# ── LLM: per-agent inference override ── #}
+    <div x-show="tab === 'llm'" class="space-y-3">
+      <div class="card space-y-3">
+        <h3 class="text-xs text-muted uppercase tracking-wider">Model &amp; inference</h3>
+        <p class="text-xs text-muted">
+          By default this agent runs on the global LLM settings (Dashboard → LLM).
+          Override them here to give it its own brain — e.g. a senior engineer on a
+          top-tier reasoning model while a junior stays on a cheap, fast one. Only
+          the fields you set are overridden; everything else keeps following the
+          global config. API keys and base URLs always come from the globally
+          configured providers.
+        </p>
+        <label class="flex items-center gap-2 text-sm">
+          <input type="checkbox" x-model="llmOverride">
+          Custom LLM settings for this agent
+        </label>
+
+        <p class="text-xs text-muted" x-show="!llmOverride">
+          Inheriting the global setup:
+          <code x-text="llmDefaults.provider + ' · ' + (llmDefaults.model || '(no model set)')"></code>
+        </p>
+
+        <div x-show="llmOverride" class="space-y-3">
+          <div>
+            <label class="label">Provider</label>
+            <select class="select input-sm" style="max-width:300px" x-model="llmProvider">
+              <option value="" x-text="'Global — ' + llmDefaults.provider"></option>
+              <template x-for="p in llmProviders" :key="'agent-llm-' + p.value">
+                <option :value="p.value" x-text="p.label"></option>
+              </template>
+            </select>
+            <p class="text-xs text-muted mt-1">The provider must have its API key configured in Dashboard → LLM → Providers.</p>
+          </div>
+          <div>
+            <label class="label">Model</label>
+            <input type="text" class="input-sm" style="max-width:300px" x-model="llmModel"
+                   list="dl-agent-llm-model" :placeholder="'Global — ' + (llmDefaults.model || 'unset')">
+            <datalist id="dl-agent-llm-model">
+              <template x-for="m in llmModelOptions()" :key="'agent-llm-m-' + m">
+                <option :value="m"></option>
+              </template>
+            </datalist>
+            <p class="text-xs text-muted mt-1">Type any model id, or pick a suggestion for the selected provider. Blank = the global model.</p>
+          </div>
+          <div>
+            <label class="label">Thinking level</label>
+            <select class="select input-sm" style="max-width:300px" x-model="llmThinking">
+              <option value="inherit" x-text="'Global — ' + (llmDefaults.thinking_level || 'off')"></option>
+              <option value="off">Off</option>
+              <option value="low">Low</option>
+              <option value="medium">Medium</option>
+              <option value="high">High</option>
+            </select>
+            <p class="text-amber-600 text-xs mt-1"
+               x-show="['low','medium','high'].includes(llmThinking) && !window.llmModelSupportsThinking(llmModel || llmDefaults.model)">
+              Heads up: “<span x-text="llmModel || llmDefaults.model"></span>” isn't a recognized reasoning model — only set a level if you know it supports thinking.
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-4">
+            <div>
+              <label class="label">Max output tokens</label>
+              <input type="number" min="256" class="input-sm" style="max-width:160px"
+                     x-model="llmMaxTokens" :placeholder="'Global — ' + llmDefaults.max_tokens">
+            </div>
+            <div>
+              <label class="label">Temperature</label>
+              <input type="number" min="0" max="2" step="0.05" class="input-sm" style="max-width:160px"
+                     x-model="llmTemperature" :placeholder="'Global — ' + llmDefaults.temperature">
+            </div>
+          </div>
+          <p class="text-xs text-muted border-t border-border pt-2">
+            This agent will run on
+            <code x-text="(llmProvider || llmDefaults.provider) + ' · ' + (llmModel.trim() || llmDefaults.model || 'unset')"></code><span x-show="llmThinking !== 'inherit' && llmThinking !== 'off'"> · thinking <span x-text="llmThinking"></span></span>.
+            Subagent runs it spawns use the same setup.
+          </p>
+        </div>
       </div>
     </div>
 
@@ -457,7 +537,7 @@
   <div x-show="mode === 'raw'" class="card">
     <label class="label">Markdown (YAML frontmatter)</label>
     <textarea class="textarea" x-model="raw" style="min-height:460px; font-size:0.8rem; line-height:1.5; tab-size:2"></textarea>
-    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, voice, bot_token, allowed_user_ids, group_chat, skills, tools, secrets, email_accounts, calendar_accounts, contacts_accounts, chat_settings, character).</p>
+    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, voice, bot_token, allowed_user_ids, group_chat, llm, skills, tools, secrets, email_accounts, calendar_accounts, contacts_accounts, chat_settings, character).</p>
   </div>
 
   <div class="flex items-center gap-2 mt-3">
@@ -488,6 +568,17 @@
       raw: {{ raw|tojson }},
       result: '',
       ok: false,
+
+      // Per-agent LLM inference override. Empty = inherit the global config.
+      llmCfg: {{ agent.llm|tojson }},
+      llmDefaults: {{ llm_defaults|tojson }},
+      llmProviders: window.LLM_PROVIDERS,
+      llmOverride: false,
+      llmProvider: '',
+      llmModel: '',
+      llmThinking: 'inherit',
+      llmMaxTokens: '',
+      llmTemperature: '',
 
       // Per-agent tool identities (#93).
       toolConfig: {{ agent.tool_config|tojson }},
@@ -534,6 +625,19 @@
       ),
 
       init() {
+        // Seed the LLM override controls from the stored config. A stored
+        // thinking_level of "" means "force thinking off" (distinct from the
+        // key being absent = inherit the global level).
+        const lc = this.llmCfg || {};
+        if (Object.keys(lc).length) {
+          this.llmOverride = true;
+          this.llmProvider = lc.provider || '';
+          this.llmModel = lc.model || '';
+          this.llmThinking = ('thinking_level' in lc) ? (lc.thinking_level || 'off') : 'inherit';
+          this.llmMaxTokens = lc.max_tokens != null ? String(lc.max_tokens) : '';
+          this.llmTemperature = lc.temperature != null ? String(lc.temperature) : '';
+        }
+
         for (const k of this.toolKeys) {
           const e = this.toolConfig[k];
           this.modes[k] = !e ? 'inherit' : (e.enabled ? 'on' : 'off');
@@ -641,6 +745,24 @@
         return out;
       },
 
+      llmModelOptions() {
+        return (window.LLM_MODELS[this.llmProvider || this.llmDefaults.provider] || []);
+      },
+
+      // Emit only the deliberately-set keys; {} = inherit the global LLM config.
+      buildLlm() {
+        if (!this.llmOverride) return {};
+        const o = {};
+        if (this.llmProvider) o.provider = this.llmProvider;
+        if (this.llmModel.trim()) o.model = this.llmModel.trim();
+        if (this.llmThinking !== 'inherit') o.thinking_level = this.llmThinking === 'off' ? '' : this.llmThinking;
+        const mt = parseInt(this.llmMaxTokens, 10);
+        if (mt > 0) o.max_tokens = mt;
+        const t = parseFloat(this.llmTemperature);
+        if (Number.isFinite(t)) o.temperature = t;
+        return o;
+      },
+
       // Only configured tools get an entry; 'inherit' leaves them out so the
       // agent keeps using the system-wide config (migration-safe).
       buildToolConfig() {
@@ -704,6 +826,7 @@
           'contacts_accounts: ' + JSON.stringify(this.buildContactsAccounts()) + '\n' +
           'chat_settings: ' + JSON.stringify(this.buildChatSettings()) + '\n' +
           'group_chat: ' + JSON.stringify(this.buildGroupChat()) + '\n' +
+          'llm: ' + JSON.stringify(this.buildLlm()) + '\n' +
           'character: |\n  ' + esc(this.character) + '\n' +
           '---\n';
       },
@@ -733,6 +856,7 @@
               contacts_accounts: this.buildContactsAccounts(),
               chat_settings: this.buildChatSettings(),
               group_chat: this.buildGroupChat(),
+              llm: this.buildLlm(),
             };
         fetch('/agents', { method: 'POST', headers: this._headers(), body: JSON.stringify(body) })
           .then(r => { this.ok = r.ok; return r.text().then(t => ({ ok: r.ok, t })); })

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -203,6 +203,33 @@
     }
     window.previewVoice = previewVoice;
 
+    // Shared LLM catalogs — one source of truth for the LLM tab and the
+    // per-agent LLM override in the agent editor.
+    window.LLM_PROVIDERS = [
+      {value: 'anthropic', label: 'Anthropic'},
+      {value: 'openai', label: 'OpenAI'},
+      {value: 'google', label: 'Google Gemini'},
+      {value: 'grok', label: 'Grok (xAI)'},
+      {value: 'deepseek', label: 'DeepSeek'},
+      {value: 'openrouter', label: 'OpenRouter'}
+    ];
+    window.LLM_MODELS = {
+      anthropic: ['claude-4-6-opus', 'claude-4-6-sonnet', 'claude-haiku-4-5'],
+      openai: ['gpt-5.2-thinking', 'gpt-5.2-pro', 'gpt-5.2-instant', 'gpt-5-mini'],
+      google: ['gemini-deep-think-latest', 'gemini-pro-latest', 'gemini-flash-latest'],
+      grok: ['grok-4.20-beta', 'grok-4-latest', 'grok-4.1-fast'],
+      deepseek: ['deepseek-chat', 'deepseek-reasoner'],
+      openrouter: ['anthropic/claude-sonnet-4.5', 'openai/gpt-5', 'google/gemini-2.5-flash', 'deepseek/deepseek-chat']
+    };
+    // ponytail: substring heuristic for reasoning-capable models — extend the
+    // list as model ids change.
+    window.llmModelSupportsThinking = function (modelId) {
+      const id = (modelId || '').toLowerCase();
+      if (!id) return false;
+      return ['opus', 'sonnet', 'thinking', 'pro', 'deep-think', 'reasoner', 'grok-4']
+        .some(pat => id.includes(pat));
+    };
+
     function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, openrouterKey, openrouterBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens, temperature, trMaxReflections) {
       const currentProvider = provider || 'anthropic';
       return {
@@ -230,14 +257,7 @@
           } catch (e) {}
         },
         reloadLlmPartial() { if (window.htmx) { htmx.ajax('GET', '/partials/llm', {target: '#tab-content', swap: 'innerHTML'}); } },
-        providerOptions: [
-          {value: 'anthropic', label: 'Anthropic'},
-          {value: 'openai', label: 'OpenAI'},
-          {value: 'google', label: 'Google Gemini'},
-          {value: 'grok', label: 'Grok (xAI)'},
-          {value: 'deepseek', label: 'DeepSeek'},
-          {value: 'openrouter', label: 'OpenRouter'}
-        ],
+        providerOptions: window.LLM_PROVIDERS,
         provider: currentProvider,
         apiKey: apiKey || '',
         model: model || '',
@@ -323,39 +343,7 @@
           deepseek: '',
           openrouter: ''
         },
-        models: {
-          anthropic: [
-            {value: 'claude-4-6-opus', label: 'claude-4-6-opus'},
-            {value: 'claude-4-6-sonnet', label: 'claude-4-6-sonnet'},
-            {value: 'claude-haiku-4-5', label: 'claude-haiku-4-5'}
-          ],
-          openai: [
-            {value: 'gpt-5.2-thinking', label: 'gpt-5.2-thinking'},
-            {value: 'gpt-5.2-pro', label: 'gpt-5.2-pro'},
-            {value: 'gpt-5.2-instant', label: 'gpt-5.2-instant'},
-            {value: 'gpt-5-mini', label: 'gpt-5-mini'}
-          ],
-          google: [
-            {value: 'gemini-deep-think-latest', label: 'gemini-deep-think-latest'},
-            {value: 'gemini-pro-latest', label: 'gemini-pro-latest'},
-            {value: 'gemini-flash-latest', label: 'gemini-flash-latest'}
-          ],
-          grok: [
-            {value: 'grok-4.20-beta', label: 'grok-4.20-beta'},
-            {value: 'grok-4-latest', label: 'grok-4-latest'},
-            {value: 'grok-4.1-fast', label: 'grok-4.1-fast'}
-          ],
-          deepseek: [
-            {value: 'deepseek-chat', label: 'deepseek-chat'},
-            {value: 'deepseek-reasoner', label: 'deepseek-reasoner'}
-          ],
-          openrouter: [
-            {value: 'anthropic/claude-sonnet-4.5', label: 'anthropic/claude-sonnet-4.5'},
-            {value: 'openai/gpt-5', label: 'openai/gpt-5'},
-            {value: 'google/gemini-2.5-flash', label: 'google/gemini-2.5-flash'},
-            {value: 'deepseek/deepseek-chat', label: 'deepseek/deepseek-chat'}
-          ]
-        },
+        models: window.LLM_MODELS,
         fetchedModels: {anthropic: [], openai: [], google: [], grok: [], deepseek: [], openrouter: []},
         fetchingModels: {anthropic: false, openai: false, google: false, grok: false, deepseek: false, openrouter: false},
         fetchModelsResult: {anthropic: '', openai: '', google: '', grok: '', deepseek: '', openrouter: ''},
@@ -364,16 +352,9 @@
           if (fetched && fetched.length) {
             return fetched.map(id => ({value: id, label: id}));
           }
-          return this.models[prov] || [];
+          return (this.models[prov] || []).map(id => ({value: id, label: id}));
         },
-        // ponytail: substring heuristic for reasoning-capable models — extend the
-        // list as model ids change; the thinking-level control shows only when true.
-        modelSupportsThinking(modelId) {
-          const id = (modelId || '').toLowerCase();
-          if (!id) return false;
-          return ['opus', 'sonnet', 'thinking', 'pro', 'deep-think', 'reasoner', 'grok-4']
-            .some(pat => id.includes(pat));
-        },
+        modelSupportsThinking(modelId) { return window.llmModelSupportsThinking(modelId); },
         // ponytail: mirror of model_supports_vision() in core/llm.py — keep in
         // sync. True when the model reads images natively (no fallback needed).
         modelSupportsVision(modelId, prov) {

--- a/humux/api/templates/partials/agents.html
+++ b/humux/api/templates/partials/agents.html
@@ -38,6 +38,7 @@
         {{ p.skills|length or 'all' }} skill{{ '' if p.skills|length == 1 else 's' }}
         · {{ p.tools|length or 'all' }} tool{{ '' if p.tools|length == 1 else 's' }}
         {% if p.voice %}· 🔊 {{ p.voice }}{% endif %}
+        {% if p.llm %}· 🧠 {{ p.llm.model or p.llm.provider or 'custom LLM' }}{% endif %}
       </div>
 
       <div class="flex items-center gap-1.5 mt-auto pt-1 flex-wrap">

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -1826,7 +1826,7 @@ class AgentCore:
         return system
 
     async def _maybe_compact(
-        self, channel: str, user_id: str, chat_id: str, response: Any
+        self, channel: str, user_id: str, chat_id: str, response: Any, model: str = ""
     ) -> str | None:
         """Compact the session if the context exceeds the configured threshold.
 
@@ -1838,7 +1838,9 @@ class AgentCore:
             return None
         usage = getattr(response, "usage", None) or {}
         context_tokens = int(usage.get("context_tokens") or 0)
-        if not should_compact(cfg, context_tokens, self.config.agent.model):
+        # Threshold % is judged against the model the turn actually ran on
+        # (a per-agent override may have a different context window).
+        if not should_compact(cfg, context_tokens, model or self.config.agent.model):
             return None
 
         session = await self.history.get_session(channel, user_id, chat_id)
@@ -1872,8 +1874,14 @@ class AgentCore:
         message: str,
         attachments: list[Attachment] | None = None,
         preamble: str = "",
+        llm: LLMClient | None = None,
+        model: str = "",
     ) -> dict:
         """Build the user message dict, handling multimodal content.
+
+        ``llm``/``model`` are the client and model this turn actually runs on
+        (a per-agent override may differ from the globals) — they pick the
+        image-block format and decide whether the vision fallback engages.
 
         ``preamble`` (live date/time + optional execution plan) is prepended to
         the message text so the agent always knows 'now' for the current turn.
@@ -1882,10 +1890,12 @@ class AgentCore:
         configured, images are captioned by a secondary model and the text is
         injected in place of the image blocks so the model can still "see".
         """
+        llm = llm or self.llm
+        model = model or self.config.agent.model
         text = f"{preamble}\n\n{message}" if preamble else message
         image_attachments = [a for a in (attachments or []) if a.is_image]
         if image_attachments:
-            if self._vision_fallback_active():
+            if self.config.vision.enabled and not model_supports_vision(llm.provider, model):
                 captions = await self._caption_images(image_attachments, message)
                 if captions:
                     text = "\n\n".join([text, *captions]) if text else "\n\n".join(captions)
@@ -1895,18 +1905,12 @@ class AgentCore:
             if text:
                 content_blocks.append({"type": "text", "text": text})
             for att in image_attachments:
-                if self.llm.provider == "anthropic":
+                if llm.provider == "anthropic":
                     content_blocks.append(att.to_anthropic_block())
                 else:
                     content_blocks.append(att.to_openai_block())
             return {"role": "user", "content": content_blocks}
         return {"role": "user", "content": text}
-
-    def _vision_fallback_active(self) -> bool:
-        """True when the active model lacks vision and a fallback is enabled."""
-        return self.config.vision.enabled and not model_supports_vision(
-            self.llm.provider, self.config.agent.model
-        )
 
     async def _caption_images(self, images: list[Attachment], user_text: str) -> list[str]:
         """Caption each image with a task-aware prompt, returning ``[Image: ...]``
@@ -1975,6 +1979,7 @@ class AgentCore:
     ) -> AgentResponse:
         """Injection mode: replay windowed history as native alternating messages."""
         tools = tools if tools is not None else TOOLS
+        llm, model, max_tokens = self._agent_llm(agent)
         history = await self.history.get_messages(channel, user_id, chat_id)
         messages: list[dict] = []
 
@@ -1984,7 +1989,7 @@ class AgentCore:
                 messages.append({"role": turn["role"], "content": turn["content"]})
 
         # The actual current request — always the last user message.
-        messages.append(await self._build_user_message(message, attachments, preamble))
+        messages.append(await self._build_user_message(message, attachments, preamble, llm, model))
 
         log.info(
             "Processing message (injection) from %s/%s/%s: %s",
@@ -1995,9 +2000,9 @@ class AgentCore:
         )
 
         # Initial LLM call
-        response = await self.llm.generate(
-            model=self.config.agent.model,
-            max_tokens=self.config.agent.max_tokens,
+        response = await llm.generate(
+            model=model,
+            max_tokens=max_tokens,
             system=system,
             messages=messages,
             tools=cast(Any, tools),
@@ -2057,8 +2062,8 @@ class AgentCore:
                     break
 
             # Feed tool results back to the LLM
-            messages.append(self.llm.assistant_message(response))
-            messages.extend(self.llm.tool_result_messages(tool_results))
+            messages.append(llm.assistant_message(response))
+            messages.extend(llm.tool_result_messages(tool_results))
             # Mid-turn steering (#145): fold any follow-up the user sent while we
             # worked into the next call. Appended after the tool_result user turn;
             # generate() merges the consecutive user turns, so alternation holds.
@@ -2067,9 +2072,9 @@ class AgentCore:
             steer = self._drain_steer(channel, user_id, chat_id)
             if steer:
                 messages.append(self._steer_message(steer))
-            response = await self.llm.generate(
-                model=self.config.agent.model,
-                max_tokens=self.config.agent.max_tokens,
+            response = await llm.generate(
+                model=model,
+                max_tokens=max_tokens,
                 system=system,
                 messages=messages,
                 tools=cast(Any, tools),
@@ -2142,12 +2147,13 @@ class AgentCore:
         continuity with a cache-friendly prefix.
         """
         tools = tools if tools is not None else TOOLS
+        llm, model, max_tokens = self._agent_llm(agent)
 
         # Load existing session (from memory cache or DB)
         session = await self.history.get_session(channel, user_id, chat_id)
 
         # Append the new user message (with the live date/time preamble)
-        user_msg = await self._build_user_message(message, attachments, preamble)
+        user_msg = await self._build_user_message(message, attachments, preamble, llm, model)
         await self.history.append_session_message(channel, user_id, user_msg, chat_id)
 
         log.info(
@@ -2159,9 +2165,9 @@ class AgentCore:
         )
 
         # Initial LLM call with the full session
-        response = await self.llm.generate(
-            model=self.config.agent.model,
-            max_tokens=self.config.agent.max_tokens,
+        response = await llm.generate(
+            model=model,
+            max_tokens=max_tokens,
             system=system,
             messages=session,
             tools=cast(Any, tools),
@@ -2226,8 +2232,8 @@ class AgentCore:
                     break
 
             # Append tool exchange to session
-            assistant_msg = self.llm.assistant_message(response)
-            tool_result_msgs = self.llm.tool_result_messages(tool_results)
+            assistant_msg = llm.assistant_message(response)
+            tool_result_msgs = llm.tool_result_messages(tool_results)
 
             new_messages.append(assistant_msg)
             new_messages.extend(tool_result_msgs)
@@ -2250,9 +2256,9 @@ class AgentCore:
                 new_messages.append(steer_msg)
                 await self.history.append_session_messages(channel, user_id, [steer_msg], chat_id)
 
-            response = await self.llm.generate(
-                model=self.config.agent.model,
-                max_tokens=self.config.agent.max_tokens,
+            response = await llm.generate(
+                model=model,
+                max_tokens=max_tokens,
                 system=system,
                 messages=session,
                 tools=cast(Any, tools),
@@ -2290,7 +2296,7 @@ class AgentCore:
         # Compaction — if the context has grown past the configured threshold,
         # summarise the oldest turns. ``response.usage`` reflects the full
         # session that was just sent, so it's the authoritative context size.
-        system_notice = await self._maybe_compact(channel, user_id, chat_id, response)
+        system_notice = await self._maybe_compact(channel, user_id, chat_id, response, model)
 
         # Automatic memory extraction
         if channel != "system":
@@ -3772,14 +3778,17 @@ class AgentCore:
         preamble = await self._turn_preamble(None, query=task, scope=_agent_scope(child_agent))
         messages: list[dict] = [await self._build_user_message(task, None, preamble)]
 
-        # effort None = inherit the main client's level; otherwise an effort-scoped
-        # clone (same provider/connection, overridden thinking level).
-        llm = self.llm
+        # The child runs on its own agent's LLM override when it has one (so a
+        # "senior" subagent gets its bigger model); an explicit spawn effort
+        # still wins over the inherited/overridden thinking level.
+        llm, model, max_tokens = self._agent_llm(child_agent)
         if run.effort is not None:
-            llm = self._background_llm(self.llm.provider, run.effort)
+            clone = copy.copy(llm)
+            clone.thinking_level = run.effort
+            llm = clone
         response = await llm.generate(
-            model=self.config.agent.model,
-            max_tokens=self.config.agent.max_tokens,
+            model=model,
+            max_tokens=max_tokens,
             system=system,
             messages=messages,
             tools=cast(Any, tools),
@@ -3809,8 +3818,8 @@ class AgentCore:
             messages.append(llm.assistant_message(response))
             messages.extend(llm.tool_result_messages(tool_results))
             response = await llm.generate(
-                model=self.config.agent.model,
-                max_tokens=self.config.agent.max_tokens,
+                model=model,
+                max_tokens=max_tokens,
                 system=system,
                 messages=messages,
                 tools=cast(Any, tools),
@@ -4353,6 +4362,28 @@ class AgentCore:
         API key / base-URL already stored in the agent config.
         """
         return self._background_llm(provider, thinking_level)
+
+    def _agent_llm(self, agent: Agent | None) -> tuple[LLMClient, str, int]:
+        """The ``(client, model, max_tokens)`` a turn runs on.
+
+        An agent's ``llm`` override wins key-by-key over the global LLM config
+        (so a "senior" agent can run a bigger model while a "junior" one stays
+        cheap); no override = the shared main client, unchanged. Credentials and
+        base URLs are always the globally configured ones — the override only
+        picks provider/model/thinking/max_tokens/temperature.
+        """
+        cfg = self.config.agent
+        o = getattr(agent, "llm", None) if agent else None
+        if not isinstance(o, dict) or not o:
+            return self.llm, cfg.model, cfg.max_tokens
+        provider = o.get("provider") or self.llm.provider
+        thinking = o.get("thinking_level", cfg.thinking_level)
+        # ponytail: a fresh (or cloned, same-provider) client per turn — same
+        # cost profile as _background_llm's per-call construction; cache per
+        # agent if profiling ever says otherwise.
+        llm = self._background_llm(provider, thinking)
+        llm.temperature = o.get("temperature", cfg.temperature)
+        return llm, o.get("model") or cfg.model, o.get("max_tokens") or cfg.max_tokens
 
     def _background_llm(self, provider: str, thinking_level: str = "") -> LLMClient:
         """Return an LLM client for background tasks (memory, reflection, etc.).

--- a/humux/core/agents.py
+++ b/humux/core/agents.py
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS agents (
     contacts_accounts TEXT DEFAULT '',
     chat_settings TEXT DEFAULT '',
     group_chat TEXT DEFAULT '',
+    llm_config TEXT DEFAULT '',
     is_default INTEGER NOT NULL DEFAULT 0,
     enabled INTEGER NOT NULL DEFAULT 1,
     created_at DATETIME DEFAULT (datetime('now')),
@@ -78,6 +79,7 @@ _MIGRATIONS = (
     "ALTER TABLE agents ADD COLUMN contacts_accounts TEXT DEFAULT ''",  # #110 (contacts)
     "ALTER TABLE agents ADD COLUMN chat_settings TEXT DEFAULT ''",  # #129
     "ALTER TABLE agents ADD COLUMN group_chat TEXT DEFAULT ''",  # #133 (per-agent group rooms)
+    "ALTER TABLE agents ADD COLUMN llm_config TEXT DEFAULT ''",  # per-agent LLM override
     "ALTER TABLE agents ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0",  # #115 flw
     "ALTER TABLE agents ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1",  # #115 flw kill-switch
     # #98: personalia merged into character. Prepend any existing personalia to
@@ -153,6 +155,12 @@ class Agent:
     # {"mode": "everyone"|"nobody"|"users", "users": [int]}. A chat with no entry
     # (or mode "everyone") is unrestricted — so the default is unchanged.
     chat_settings: dict = field(default_factory=dict)
+    # Per-agent LLM inference override. Any subset of {provider, model,
+    # thinking_level, max_tokens, temperature}; absent keys inherit the global
+    # LLM config, empty dict = inherit everything (unchanged behaviour). API
+    # keys/base URLs stay global — an agent picks WHICH configured provider and
+    # model it runs on, never carries its own credentials.
+    llm: dict = field(default_factory=dict)
     # This agent's Telegram group-room behaviour (#30, moved per-agent in #133).
     # Shape: {"enabled": bool, "reply_when_addressed_only": bool, "ignore_bots": bool}.
     # Empty = group rooms off (the GroupChatConfig defaults). Built into a
@@ -358,6 +366,47 @@ def _as_group_chat(value: object) -> dict:
     }
 
 
+_LLM_THINKING_LEVELS = ("", "low", "medium", "high")
+
+
+def _as_llm_config(value: object) -> dict:
+    """Coerce a frontmatter / form / DB-column value into a per-agent LLM override.
+
+    Shape: any subset of ``{provider, model, thinking_level, max_tokens,
+    temperature}``. Accepts a parsed dict or a JSON string. Blank strings and
+    malformed numbers drop out, so ``{}`` (inherit the global LLM config) is the
+    result of anything not deliberately set — a broken value never breaks load.
+    """
+    if isinstance(value, str) and value.strip():
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError, ValueError:
+            return {}
+    if not isinstance(value, dict):
+        return {}
+    out: dict = {}
+    for key in ("provider", "model"):
+        v = str(value.get(key, "") or "").strip()
+        if v:
+            out[key] = v.lower() if key == "provider" else v
+    lvl = str(value.get("thinking_level", "") or "").strip().lower()
+    if lvl in _LLM_THINKING_LEVELS and "thinking_level" in value:
+        out["thinking_level"] = lvl  # "" is meaningful: force thinking OFF
+    try:
+        mt = int(value["max_tokens"])
+        if mt > 0:
+            out["max_tokens"] = mt
+    except KeyError, TypeError, ValueError:
+        pass
+    try:
+        temp = float(value["temperature"])
+        if 0.0 <= temp <= 2.0:
+            out["temperature"] = temp
+    except KeyError, TypeError, ValueError:
+        pass
+    return out
+
+
 _ACCESS_LEVELS = ("read", "read_write")
 
 
@@ -469,6 +518,7 @@ def parse_markdown(text: str, *, name: str) -> Agent:
         contacts_accounts=_as_account_list(fm.get("contacts_accounts")),
         chat_settings=_as_chat_settings(fm.get("chat_settings")),
         group_chat=_as_group_chat(fm.get("group_chat")),
+        llm=_as_llm_config(fm.get("llm")),
     )
 
 
@@ -489,6 +539,7 @@ def to_markdown(a: Agent) -> str:
         "contacts_accounts": a.contacts_accounts,
         "chat_settings": a.chat_settings,
         "group_chat": a.group_chat,
+        "llm": a.llm,
         "character": a.character,
     }
     dumped = yaml.safe_dump(fm, sort_keys=False, allow_unicode=True, default_flow_style=False)
@@ -668,8 +719,9 @@ class AgentStore:
             "INSERT INTO agents "
             "(name, agent_name, role, voice, character, skills, tools, "
             "secrets, bot_token, allowed_user_ids, tool_config, "
-            "email_accounts, calendar_accounts, contacts_accounts, chat_settings, group_chat) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "email_accounts, calendar_accounts, contacts_accounts, chat_settings, group_chat, "
+            "llm_config) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(name) DO UPDATE SET "
             "agent_name=excluded.agent_name, role=excluded.role, "
             "voice=excluded.voice, character=excluded.character, "
@@ -679,6 +731,7 @@ class AgentStore:
             "calendar_accounts=excluded.calendar_accounts, "
             "contacts_accounts=excluded.contacts_accounts, "
             "chat_settings=excluded.chat_settings, group_chat=excluded.group_chat, "
+            "llm_config=excluded.llm_config, "
             "updated_at=datetime('now')",
             (
                 a.name,
@@ -697,6 +750,7 @@ class AgentStore:
                 json.dumps(a.contacts_accounts) if a.contacts_accounts else "",
                 json.dumps(a.chat_settings) if a.chat_settings else "",
                 json.dumps(a.group_chat) if a.group_chat else "",
+                json.dumps(a.llm) if a.llm else "",
             ),
         )
 
@@ -729,6 +783,7 @@ class AgentStore:
                 row["chat_settings"] if "chat_settings" in row.keys() else ""
             ),
             group_chat=_as_group_chat(row["group_chat"] if "group_chat" in row.keys() else ""),
+            llm=_as_llm_config(row["llm_config"] if "llm_config" in row.keys() else ""),
             is_default=bool(row["is_default"]) if "is_default" in row.keys() else False,
             enabled=bool(row["enabled"]) if "enabled" in row.keys() else True,
         )
@@ -870,6 +925,12 @@ contacts_accounts:
     access_level: read_write
   - account: shared
     access_level: read
+llm:
+  provider: Anthropic
+  model: claude-4-6-opus
+  thinking_level: high
+  max_tokens: 32000
+  temperature: 0.3
 personalia: |
   You are Forge, a strength coach.
 character: |
@@ -909,6 +970,24 @@ Extra prose in the body.
     assert a.tool_setting("gh") == {"enabled": True}, a.tool_setting("gh")
     assert a.tool_setting("browser") == {"enabled": True, "profile": "forge"}
     assert a.tool_setting("weather") is None  # no entry = inherit system config
+
+    # Per-agent LLM override: normalised keys, provider lowercased.
+    assert a.llm == {
+        "provider": "anthropic",
+        "model": "claude-4-6-opus",
+        "thinking_level": "high",
+        "max_tokens": 32000,
+        "temperature": 0.3,
+    }, a.llm
+    # Partial override keeps only the set keys; junk values drop out; "" level kept
+    # only when explicitly present (= force thinking off).
+    assert _as_llm_config({"model": "gpt-5-mini", "max_tokens": "notanum"}) == {
+        "model": "gpt-5-mini"
+    }
+    assert _as_llm_config({"thinking_level": ""}) == {"thinking_level": ""}
+    assert _as_llm_config({"temperature": 9}) == {}  # out of range → inherit
+    assert _as_llm_config("") == {} and _as_llm_config("not json") == {}
+    assert Agent(name="plain").llm == {}  # default = inherit everything
 
     # #110: email/calendar account bindings + access levels.
     assert a.email_access("fitness-agent") == "read_write", a.email_accounts
@@ -952,4 +1031,5 @@ Extra prose in the body.
     assert a2.email_accounts == a.email_accounts, a2.email_accounts
     assert a2.calendar_accounts == a.calendar_accounts, a2.calendar_accounts
     assert a2.contacts_accounts == a.contacts_accounts, a2.contacts_accounts
+    assert a2.llm == a.llm, a2.llm
     print("agents.py self-check OK")

--- a/humux/tests/test_agent_llm_override.py
+++ b/humux/tests/test_agent_llm_override.py
@@ -1,0 +1,88 @@
+"""Per-agent LLM inference override: an agent's ``llm`` dict wins key-by-key
+over the global LLM config (senior agent → big model, junior → cheap one);
+no override = the shared main client, byte-for-byte unchanged behaviour."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.agents import Agent, AgentStore, _as_llm_config
+from core.config import Config
+
+
+@pytest.fixture
+def core(tmp_path, monkeypatch):
+    from core.agent import AgentCore
+
+    monkeypatch.chdir(tmp_path)
+    cfg = Config()
+    cfg.agent.llm_provider = "deepseek"
+    cfg.agent.model = "deepseek-v4-flash"
+    cfg.agent.max_tokens = 8192
+    cfg.agent.temperature = 0.5
+    cfg.memory.embedding.enabled = False
+    return AgentCore(cfg)
+
+
+def test_no_override_returns_main_client(core):
+    for agent in (None, Agent(name="plain")):
+        llm, model, max_tokens = core._agent_llm(agent)
+        assert llm is core.llm
+        assert model == "deepseek-v4-flash" and max_tokens == 8192
+
+
+def test_full_override(core):
+    a = Agent(
+        name="senior",
+        llm={
+            "provider": "deepseek",  # same provider → cloned client
+            "model": "deepseek-reasoner",
+            "thinking_level": "high",
+            "max_tokens": 32000,
+            "temperature": 0.2,
+        },
+    )
+    llm, model, max_tokens = core._agent_llm(a)
+    assert llm is not core.llm  # clone, main client untouched
+    assert core.llm.thinking_level == "" and core.llm.temperature == 0.5
+    assert llm.provider == "deepseek"
+    assert llm.thinking_level == "high" and llm.temperature == 0.2
+    assert model == "deepseek-reasoner" and max_tokens == 32000
+
+
+def test_partial_override_inherits_the_rest(core):
+    a = Agent(name="junior", llm={"model": "deepseek-chat"})
+    llm, model, max_tokens = core._agent_llm(a)
+    assert model == "deepseek-chat"
+    assert max_tokens == 8192  # inherited
+    assert llm.provider == "deepseek" and llm.temperature == 0.5  # inherited
+
+
+def test_cross_provider_override_uses_global_credentials(core):
+    core.config.agent.anthropic_api_key = "sk-test"
+    a = Agent(name="senior", llm={"provider": "anthropic", "model": "claude-4-6-opus"})
+    llm, model, _ = core._agent_llm(a)
+    assert llm.provider == "anthropic" and model == "claude-4-6-opus"
+
+
+async def test_llm_override_persists_through_store(tmp_path):
+    store = AgentStore(db_path=str(tmp_path / "a.db"), seed_dir=None)
+    await store.upsert(Agent(name="senior", llm={"model": "claude-4-6-opus", "max_tokens": 64000}))
+    loaded = await store.get("senior")
+    assert loaded.llm == {"model": "claude-4-6-opus", "max_tokens": 64000}
+    # And an agent saved without one stays inherit-everything.
+    await store.upsert(Agent(name="junior"))
+    assert (await store.get("junior")).llm == {}
+
+
+def test_coercer_drops_junk():
+    assert _as_llm_config({"provider": " Anthropic ", "max_tokens": "9000"}) == {
+        "provider": "anthropic",
+        "max_tokens": 9000,
+    }
+    assert _as_llm_config('{"model": "m", "temperature": 0.1}') == {
+        "model": "m",
+        "temperature": 0.1,
+    }
+    assert _as_llm_config({"temperature": 99, "max_tokens": -1, "thinking_level": "ultra"}) == {}
+    assert _as_llm_config("broken json") == {}

--- a/humux/tests/test_agents_admin.py
+++ b/humux/tests/test_agents_admin.py
@@ -495,3 +495,41 @@ def test_kill_switch_enable_disable(tmp_path) -> None:
 
     assert _toggle("ghost").status_code == 404
     assert _toggle("").status_code == 400
+
+
+def test_agent_llm_override_roundtrip_and_editor(tmp_path) -> None:
+    # Per-agent LLM override: saved via the API, normalised, echoed back, and
+    # surfaced in the editor (LLM tab) + the list badge.
+    client, _ = _client(tmp_path)
+    r = client.post(
+        "/agents",
+        json={
+            "name": "senior",
+            "llm": {
+                "provider": "Anthropic",
+                "model": "claude-4-6-opus",
+                "thinking_level": "high",
+                "max_tokens": "32000",
+                "temperature": 0.2,
+            },
+        },
+        headers=AUTH,
+    )
+    assert r.status_code == 200
+    got = client.get("/agents/senior", headers=AUTH).json()["llm"]
+    assert got == {
+        "provider": "anthropic",
+        "model": "claude-4-6-opus",
+        "thinking_level": "high",
+        "max_tokens": 32000,
+        "temperature": 0.2,
+    }
+    # No override = {} (inherit) — and junk never persists.
+    client.post("/agents", json={"name": "junior", "llm": {"temperature": 99}}, headers=AUTH)
+    assert client.get("/agents/junior", headers=AUTH).json()["llm"] == {}
+
+    page = client.get("/admin/agents/senior", headers=AUTH).text
+    assert "Custom LLM settings for this agent" in page  # LLM tab renders
+    assert "claude-4-6-opus" in page  # stored override seeds the controls
+    listing = client.get("/partials/agents", headers=AUTH).text
+    assert "🧠 claude-4-6-opus" in listing  # list badge shows the model

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -574,17 +574,22 @@ async def test_run_subagent_effort_inherits_by_default(agent, monkeypatch) -> No
 
 @pytest.mark.asyncio
 async def test_run_subagent_effort_uses_scoped_client(agent, monkeypatch) -> None:
-    agent.llm = _ScriptedLLM([LLMResponse(text="ok", tool_calls=[])])
+    # The effort-scoped client is a clone: the run generates with the overridden
+    # thinking level while the main client stays untouched.
     captured: dict = {}
 
-    def spy(provider, level=""):
-        captured["level"] = level
-        return _ScriptedLLM([LLMResponse(text="ok", tool_calls=[])])
+    class _Recording(_ScriptedLLM):
+        thinking_level = ""
 
-    monkeypatch.setattr(agent, "_background_llm", spy)
+        async def generate(self, **kw) -> LLMResponse:
+            captured["level"] = self.thinking_level
+            return await super().generate(**kw)
+
+    agent.llm = _Recording([LLMResponse(text="ok", tool_calls=[])])
     result = await agent.run_subagent(task="x", thinking_effort="high")
     assert result["ok"] is True
     assert captured["level"] == "high"
+    assert agent.llm.thinking_level == ""  # main client untouched
     assert agent.subagents.get(result["run_id"]).effort == "high"
 
 


### PR DESCRIPTION
## What

Each agent can now override any part of the active LLM inference config — provider, model, thinking level, max output tokens, temperature — so different agents run on different setups (e.g. a *senior engineer* agent on a top-tier reasoning model while a *junior* one stays on a cheap, fast model).

## How

- **Store** (`core/agents.py`): new `llm` dict on `Agent` (+ `llm_config` column, in-place migration). Coerced by `_as_llm_config`: any subset of `{provider, model, thinking_level, max_tokens, temperature}`, junk drops out, `{}` = inherit everything — existing agents are unchanged on upgrade. Round-trips through frontmatter (`llm:` key), the DB and the API.
- **Runtime** (`core/agent.py`): `_agent_llm(agent)` resolves `(client, model, max_tokens)` per turn — override wins key-by-key over the globals; same-provider overrides clone the main client (shared connection), cross-provider ones build from the globally configured credentials. Wired into both main loops (injection + session) and the subagent loop (a child adopts its own agent's setup; an explicit spawn `thinking_effort` still wins).
- Correctness ride-alongs: the image-block format and the vision-fallback decision now follow the model the turn actually runs on (a cross-provider override previously would have sent the wrong block shape), and compaction thresholds are judged against the turn's model.
- **Admin**: new **LLM** tab in the agent editor — inherit by default, opt-in override with per-field inheritance (blank = global), provider/model suggestions, thinking-level guardrail warning and a live "runs on …" summary. Agents list shows a 🧠 model badge. Shared provider/model catalogs hoisted to one source of truth in `base.html` (deduped from the LLM tab).
- API keys and base URLs stay global: an override picks *which* configured provider/model to run on, it never carries credentials.

## Notes

- Per-key semantics: `thinking_level: ""` explicitly forces thinking off; an absent key inherits the global level.
- Background inferences (memory, compaction, reflection, …) keep their own model config, as before.

## Tests

- `tests/test_agent_llm_override.py`: resolution (none/partial/full/cross-provider), store persistence, coercer.
- `tests/test_agents_admin.py`: API roundtrip + normalisation, editor render, list badge.
- `core/agents.py` self-check extended (frontmatter round-trip).
- Full suite: 1026 passed.