### PR TITLE
fix: token attribution — subagents + drop (unknown) from top-agent card

### DIFF
--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -3777,10 +3777,19 @@ class AgentCore:
         # contextvar but is a different conversation — don't clobber the parent's
         # last-sent payload with the child's.
         cap_token = set_capture_context(None)
+        # Attribute the subagent's token usage to the child agent (#199 flw) so its
+        # (often heavy) generate() calls don't land in the parent's bucket or, for a
+        # scheduled/background spawn that ran outside any turn, in "(unknown)". Only
+        # override when there IS a named child: an anonymous subagent runs "as
+        # yourself", so it should keep the spawner's inherited attribution.
+        child_name = run.agent or (child_agent.name if child_agent else "")
+        usage_token = set_usage_agent(child_name) if child_name else None
         try:
             with subagent_stream(run.agent or run.run_id, fallback=run.agent):
                 return await self._run_subagent_loop_inner(task, child_agent, child_state, run)
         finally:
+            if usage_token is not None:
+                reset_usage_agent(usage_token)
             reset_capture_context(cap_token)
 
     async def _run_subagent_loop_inner(

--- a/humux/core/metrics.py
+++ b/humux/core/metrics.py
@@ -132,15 +132,18 @@ class TokenUsageStore:
                 }
 
             # Per-agent totals (all token kinds), most-consuming first — feeds the
-            # "top agent" dashboard card. Rows recorded before the agent column
-            # existed (or from subagents) carry ''; surface those as "(unknown)".
+            # "top agent" dashboard card. Only rows with a recorded agent: usage
+            # with no attribution (rows written before this column shipped, or a
+            # scheduled/anonymous run outside any turn) is NOT an agent, so it must
+            # not headline a "top agent" ranking — it still counts in the total /
+            # cached cards, which sum the whole table.
             cursor = await db.execute(
-                "SELECT COALESCE(NULLIF(agent, ''), '(unknown)') AS agent, "
+                "SELECT agent, "
                 "COALESCE(SUM(input_tokens + output_tokens + cache_read_input_tokens "
                 "+ cache_creation_input_tokens), 0) AS total "
                 "FROM token_usage "
-                "WHERE recorded_at >= datetime('now', ?) "
-                "GROUP BY 1 ORDER BY total DESC",
+                "WHERE recorded_at >= datetime('now', ?) AND agent IS NOT NULL AND agent != '' "
+                "GROUP BY agent ORDER BY total DESC",
                 (f"-{hours} hours",),
             )
             top_agents = [

--- a/humux/tests/test_metrics.py
+++ b/humux/tests/test_metrics.py
@@ -19,10 +19,12 @@ async def test_top_agents_sorted_by_total(tmp_path) -> None:
 
     tot = await store.totals_since(24)
     agents = tot["top_agents"]
-    # scribe (505) > coach (165) > (unknown) (2), most-consuming first.
-    assert [a["agent"] for a in agents] == ["scribe", "coach", "(unknown)"]
+    # Only attributed agents, most-consuming first: scribe (505) > coach (165).
+    # The un-attributed row (no agent) is excluded from the "top agent" ranking...
+    assert [a["agent"] for a in agents] == ["scribe", "coach"]
     assert agents[0]["total"] == 505
-    assert tot["total_input"] == 651  # cached/uncached still aggregated
+    # ...but still counts in the grand totals (which sum the whole table).
+    assert tot["total_input"] == 651
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #219 (per-agent token dashboard).

`(unknown)` was topping the "top agent" card. Confirmed: **it's historical, pre-merge usage.** All un-attributed rows predate 2026-07-06 12:42 (before the attribution code shipped that evening); the migration backfilled those old completions' `agent` as `''`. New usage attributes correctly (`clio` turns recorded 21:57 show up under `clio`).

Two fixes:

1. **Subagent attribution** — a subagent's (often heavy) `generate()` calls ran with the parent's or an empty `_usage_agent`. Bind the child agent's slug in the subagent loop so its tokens count as the child's; anonymous subagents keep the spawner's inherited attribution.
2. **Top-agent card** — `(unknown)` isn't an agent, so it no longer headlines the ranking. Un-attributed usage (historical rows, anonymous/scheduled runs) is excluded from the top-**agent** query but still counts in the Total and Cached/uncached cards, which sum the whole table.

The historical `(unknown)` already ages out of the 24h/7d windows; this just stops it dominating 30d.
