### PR TITLE
feat: YOLO mode ON by default when engaging with an agent (#222)

### DIFF
--- a/humux/core/permissions.py
+++ b/humux/core/permissions.py
@@ -376,7 +376,7 @@ class PermissionEngine:
                 count,
             )
             db.execute("DELETE FROM yolo")
-        db.execute("INSERT INTO yolo (scope) VALUES (?)", (self._YOLO_SENTINEL,))
+        db.execute("INSERT OR IGNORE INTO yolo (scope) VALUES (?)", (self._YOLO_SENTINEL,))
         db.commit()
 
     @classmethod

--- a/humux/core/permissions.py
+++ b/humux/core/permissions.py
@@ -281,6 +281,10 @@ class PermissionEngine:
     over a default rule of the same pattern; everything else falls back.
     """
 
+    # Sentinel row in the yolo table marking the #222 migration as complete.
+    _YOLO_SENTINEL = "__migrated_yolo_default_on__"
+
+
     def __init__(self, db_path: str = "data/config.db") -> None:
         self.db_path = db_path
         self.rules: dict[str, str] = dict(DEFAULT_RULES)
@@ -289,8 +293,9 @@ class PermissionEngine:
         self._ready = False
         # Pending approval requests: request_id → PendingApproval
         self._pending: dict[str, PendingApproval] = {}
-        # YOLO scopes (channels) with the approval prompt bypassed — see is_yolo.
-        self._yolo: set[str] = set()
+        # YOLO-opted-out scopes (channels). YOLO is ON by default (#222) for any
+        # scope NOT in this set. Use /yolo-off to opt out, /yolo-on to re-enable.
+        self._yolo_off: set[str] = set()
         self._load_persisted_rules()
         self._load_yolo()
 
@@ -315,7 +320,7 @@ class PermissionEngine:
                 db.execute("DROP TABLE permissions_legacy")
             else:
                 db.execute(_CREATE_PERMISSIONS)
-            db.execute("CREATE TABLE IF NOT EXISTS yolo (scope TEXT PRIMARY KEY)")
+            self._migrate_yolo(db)
             self._migrate_tool_renames(db)
         self._ready = True
 
@@ -346,6 +351,33 @@ class PermissionEngine:
             return pattern
         new_head = LEGACY_TOOL_RENAMES[head]
         return None if new_head is None else new_head + rest
+
+    def _migrate_yolo(self, db: sqlite3.Connection) -> None:
+        """Migrate the yolo table for the default-on semantic (#222).
+
+        Prior to #222 the yolo table stored opted-IN scopes and YOLO was OFF
+        by default. After #222 the table stores opted-OUT scopes and YOLO is ON
+        by default. Existing rows would invert meaning, so we clear the table
+        (all previously opted-in scopes get the new default = ON, which is the
+        same end state they had) and write a sentinel row so the migration
+        only runs once.
+        """
+        db.execute("CREATE TABLE IF NOT EXISTS yolo (scope TEXT PRIMARY KEY)")
+        row = db.execute(
+            "SELECT scope FROM yolo WHERE scope = ?", (self._YOLO_SENTINEL,)
+        ).fetchone()
+        if row:
+            return  # migration already ran
+        count = db.execute("SELECT COUNT(*) FROM yolo").fetchone()[0]
+        if count > 0:
+            log.warning(
+                "YOLO migration #222: clearing %d opted-in row(s) from yolo table "
+                "(default is now ON, table tracks opted-out scopes)",
+                count,
+            )
+            db.execute("DELETE FROM yolo")
+        db.execute("INSERT INTO yolo (scope) VALUES (?)", (self._YOLO_SENTINEL,))
+        db.commit()
 
     @classmethod
     def _migrate_tool_renames(cls, db: sqlite3.Connection) -> None:
@@ -404,30 +436,38 @@ class PermissionEngine:
     def _load_yolo(self) -> None:
         self._ensure_schema()
         with sqlite3.connect(self.db_path) as db:
-            rows = db.execute("SELECT scope FROM yolo").fetchall()
-        self._yolo = {scope for (scope,) in rows}
+            rows = db.execute(
+                "SELECT scope FROM yolo WHERE scope != ?",
+                (self._YOLO_SENTINEL,),
+            ).fetchall()
+        self._yolo_off = {scope for (scope,) in rows}
 
     def set_yolo(self, scope: str, on: bool) -> None:
         """Turn the approval-bypass (YOLO) on/off for a scope (a channel name).
 
-        A scope in YOLO has ASK actions auto-approved without a prompt. NEVER
-        rules still hold — this is "act without asking", not "self-destruct".
-        Persisted so the choice survives a restart until explicitly turned off.
+        YOLO is ON by default (#222). A scope NOT in the opted-out set has
+        ASK actions auto-approved without a prompt. NEVER rules still hold —
+        this is "act without asking", not "self-destruct". Persisted so the
+        choice survives a restart until explicitly toggled.
         """
         self._ensure_schema()
         with sqlite3.connect(self.db_path) as db:
             if on:
-                db.execute("INSERT OR IGNORE INTO yolo (scope) VALUES (?)", (scope,))
-                self._yolo.add(scope)
-            else:
                 db.execute("DELETE FROM yolo WHERE scope = ?", (scope,))
-                self._yolo.discard(scope)
+                self._yolo_off.discard(scope)
+            else:
+                db.execute("INSERT OR IGNORE INTO yolo (scope) VALUES (?)", (scope,))
+                self._yolo_off.add(scope)
             db.commit()
         log.warning("YOLO mode %s for scope %r", "ON" if on else "OFF", scope)
 
     def is_yolo(self, scope: str) -> bool:
-        """True if the scope (channel) currently bypasses approval prompts."""
-        return scope in self._yolo
+        """True if the scope (channel) currently bypasses approval prompts.
+
+        YOLO is ON by default (#222). Only scopes explicitly opted out via
+        ``/yolo-off`` return False.
+        """
+        return scope not in self._yolo_off
 
     def _build_match_key(self, tool_name: str, params: dict | None = None) -> str:
         if tool_name == "bash" and params and "command" in params:

--- a/humux/tests/test_group_chat.py
+++ b/humux/tests/test_group_chat.py
@@ -234,18 +234,19 @@ async def test_yolo_toggle_requires_addressing_and_scopes_per_chat(tmp_path) -> 
 
     # Unaddressed (a bare "/yolo-on" reaching a gate-off bot): must NOT toggle, so
     # one bare command can't flip every bot in a multi-agent room.
+    # YOLO is ON by default (#222), so is_yolo is True before any toggle.
     resp = await agent.process(
         "/yolo-on", channel="telegram", user_id="g1", chat_id="g1", addressed=False
     )
     assert resp.text == ""
-    assert agent.permissions.is_yolo(scope) is False
+    assert agent.permissions.is_yolo(scope) is True
 
     # Addressed "/yolo-on@coachbot": this agent+chat enters YOLO...
     resp = await agent.process("/yolo-on@coachbot", channel="telegram", user_id="g1", chat_id="g1")
     assert "YOLO mode ON" in resp.text
     assert agent.permissions.is_yolo(scope) is True
-    # ...but only this chat — the same bot in another chat is unaffected.
-    assert agent.permissions.is_yolo(agent._yolo_scope("telegram", "g2")) is False
+    # ...and the same bot in another chat also defaults ON (#222).
+    assert agent.permissions.is_yolo(agent._yolo_scope("telegram", "g2")) is True
 
     resp = await agent.process("/yolo-off@coachbot", channel="telegram", user_id="g1", chat_id="g1")
     assert "YOLO mode OFF" in resp.text

--- a/humux/tests/test_permissions.py
+++ b/humux/tests/test_permissions.py
@@ -146,16 +146,16 @@ def test_rule_pattern_still_generalizes_script_runner() -> None:
 def test_yolo_toggle_persists_and_scopes_by_channel(tmp_path) -> None:
     db = str(tmp_path / "config.db")
     engine = PermissionEngine(db_path=db)
-    assert not engine.is_yolo("telegram:coach")
+    assert engine.is_yolo("telegram:coach")  # ON by default (#222)
 
     engine.set_yolo("telegram:coach", True)
     assert engine.is_yolo("telegram:coach")
-    assert not engine.is_yolo("telegram:finance")  # other agent unaffected
+    assert engine.is_yolo("telegram:finance")  # other agent also defaults ON (#222)
 
     # Survives a restart (reloaded from the db).
     assert PermissionEngine(db_path=db).is_yolo("telegram:coach")
 
-    engine.set_yolo("telegram:coach", False)
+    engine.set_yolo("telegram:coach", False)  # opt out
     assert not engine.is_yolo("telegram:coach")
     assert not PermissionEngine(db_path=db).is_yolo("telegram:coach")
 


### PR DESCRIPTION
## Problem

YOLO mode (auto-approving ASK-level actions without a prompt) is off by default for every scope. Every new conversation requires sending `/yolo-on@botname` to enable it, which is friction for a single-user system where the owner trusts their own agents.

## Solution

Invert the default: YOLO mode is **on** by default for any scope not yet tracked. The `yolo` table now stores **opted-out** scopes instead of **opted-in** ones (Option A from the issue).

### Key changes

- **`PermissionEngine`**: Renamed internal set from `_yolo` to `_yolo_off`; `is_yolo()` returns `scope not in self._yolo_off` so new/unlisted scopes default to `True`.
- **`set_yolo(on=True)`**: Removes from the opted-out set (re-enables YOLO after a `/yolo-off`).
- **`set_yolo(on=False)`**: Adds to the opted-out set (opts out of YOLO).
- **Migration**: `_migrate_yolo()` clears legacy opt-in rows on first boot after upgrade and writes a sentinel row so the migration only runs once.
- **`/yolo-on`** / **`/yolo-off`**: Continue to work exactly as before — just the meaning of the stored rows is inverted.

## Acceptance criteria

- [x] New conversations start with YOLO mode ON (no `/yolo-on` needed)
- [x] `/yolo-off` disables YOLO for that scope and persists
- [x] `/yolo-on` re-enables YOLO after it was turned off
- [x] Existing persisted yolo-on scopes are migrated correctly (all cleared to get the new default ON)
- [x] NEVER-rail actions still block even in YOLO mode (unchanged logic)

Closes #222