### PR TITLE
fix: persist ping chat value independently of webhook secret

### DIFF
--- a/humux/api/templates/agent_editor.html
+++ b/humux/api/templates/agent_editor.html
@@ -848,7 +848,7 @@
             if (this.ghWebhookSecret && this.ghWebhookMention.trim()) {
               e.webhook_mention = this.ghWebhookMention.trim().replace(/^@/, '');
             }
-            if (this.ghWebhookSecret && this.ghWebhookChat) {
+            if (this.ghWebhookChat) {
               e.webhook_chat_id = this.ghWebhookChat;
             }
             // Per-agent repo allowlist. Blank = no restriction.


### PR DESCRIPTION
## Problem

The "Ping chat" field under the Tools tab of the agent editor reverts to its default value on page refresh.

**Root cause:** `buildToolConfig()` in `agent_editor.html` gated `webhook_chat_id` behind **both** `ghWebhookSecret` and `ghWebhookChat`. When the webhook secret dropdown was cleared (or never set), the ping chat value was silently dropped on save, so the next page load restored the default empty field.

```js
// Before (line 851): requires both
if (this.ghWebhookSecret && this.ghWebhookChat) {
    e.webhook_chat_id = this.ghWebhookChat;
}
```

## Fix

Removed the `ghWebhookSecret` dependency. The ping chat is now saved whenever it has a value, independent of the webhook secret state. The field remains visually gated by `x-show="ghWebhookSecret"` in the Tools tab UI — this only affects serialization persistence.

```js
// After
if (this.ghWebhookChat) {
    e.webhook_chat_id = this.ghWebhookChat;
}
```

## Acceptance criteria

- [x] Value is restored from `toolConfig` on page load (the `init()` function already seeds it correctly at line 706)
- [x] Value is included in `buildToolConfig()` output when saved
- [x] Page refresh shows the previously saved value

Closes #231