### PR TITLE
feat #229: increase max_tokens default, add max_tool_rounds config, expose both in LLM admin UI

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1195,7 +1195,8 @@ def create_admin_app(
                 "provider": (await config_store.get("agent.llm_provider")) or "anthropic",
                 "model": (await config_store.get("agent.model")) or "",
                 "thinking_level": (await config_store.get("agent.thinking_level")) or "",
-                "max_tokens": (await config_store.get("agent.max_tokens")) or "8192",
+                "max_tokens": (await config_store.get("agent.max_tokens")) or "16384",
+                "max_tool_rounds": (await config_store.get("agent.max_tool_rounds")) or "50",
                 "temperature": (await config_store.get("agent.temperature")) or "0.5",
             },
         }
@@ -1530,7 +1531,8 @@ def create_admin_app(
         deepseek_vaulted = _is_vault_ref(deepseek_api_key)
         openrouter_vaulted = _is_vault_ref(openrouter_api_key)
         model = await config_store.get("agent.model") or "claude-4-6-sonnet"
-        max_tokens = await config_store.get("agent.max_tokens") or "8192"
+        max_tokens = await config_store.get("agent.max_tokens") or "16384"
+        max_tool_rounds = await config_store.get("agent.max_tool_rounds") or "50"
         thinking_level = await config_store.get("agent.thinking_level") or ""
         temperature = await config_store.get("agent.temperature") or "0.5"
         extraction_provider = await config_store.get("memory.extraction_provider") or "deepseek"
@@ -1594,6 +1596,7 @@ def create_admin_app(
             openrouter_base_url=openrouter_base_url,
             model=model,
             max_tokens=max_tokens,
+            max_tool_rounds=max_tool_rounds,
             temperature=temperature,
             thinking_level=thinking_level,
             extraction_provider=extraction_provider,

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -230,7 +230,7 @@
         .some(pat => id.includes(pat));
     };
 
-    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, openrouterKey, openrouterBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens, temperature, trMaxReflections) {
+    function llmTab(provider, apiKey, model, openaiKey, openaiBaseUrl, googleKey, googleBaseUrl, grokKey, grokBaseUrl, deepseekKey, deepseekBaseUrl, openrouterKey, openrouterBaseUrl, extractionProvider, extractionModel, consolidationProvider, consolidationModel, gdEnabled, gdProvider, gdModel, trEnabled, trProvider, trModel, compactionProvider, compactionModel, thinkingLevel, extractionThinkingLevel, consolidationThinkingLevel, gdThinkingLevel, trThinkingLevel, compactionThinkingLevel, visionEnabled, visionProvider, visionModel, rdEnabled, rdProvider, rdModel, rdThinkingLevel, rdGroupOnly, rdMaxReplies, rdWindowSeconds, maxTokens, maxToolRounds, temperature, trMaxReflections) {
       const currentProvider = provider || 'anthropic';
       return {
         // Sub-tab within the LLM tab (issue #114): inference | providers | history.
@@ -261,7 +261,8 @@
         provider: currentProvider,
         apiKey: apiKey || '',
         model: model || '',
-        maxTokens: maxTokens || '8192',
+        maxTokens: maxTokens || '16384',
+        maxToolRounds: maxToolRounds || '50',
         temperature: temperature || '0.5',
         thinkingLevel: thinkingLevel || '',
         extractionThinkingLevel: extractionThinkingLevel || '',

--- a/humux/api/templates/partials/llm.html
+++ b/humux/api/templates/partials/llm.html
@@ -68,7 +68,8 @@
   {{ rd_group_only|default('true', true)|tojson|forceescape }},
   {{ rd_max_replies|default('6', true)|tojson|forceescape }},
   {{ rd_window_seconds|default('120', true)|tojson|forceescape }},
-  {{ max_tokens|default('8192', true)|tojson|forceescape }},
+  {{ max_tokens|default('16384', true)|tojson|forceescape }},
+  {{ max_tool_rounds|default('50', true)|tojson|forceescape }},
   {{ temperature|default('0.5', true)|tojson|forceescape }},
   {{ tr_max_reflections|default('12', true)|tojson|forceescape }}
 )">
@@ -124,10 +125,17 @@
         </div>
       </div>
 
-      <div>
-        <label class="label">Max output tokens</label>
-        <input type="number" min="256" class="input-sm" style="max-width:200px" x-model="maxTokens">
-        <p class="text-muted text-xs mt-1">Hard ceiling on tokens the model may emit per response. Too low truncates large outputs (e.g. web artifacts) mid-generation. Default 8192; raise for capable models (Claude allows up to 128000).</p>
+      <div class="flex flex-wrap gap-4">
+        <div>
+          <label class="label">Max output tokens</label>
+          <input type="number" min="256" class="input-sm" style="max-width:200px" x-model="maxTokens">
+          <p class="text-muted text-xs mt-1">Hard ceiling on tokens the model may emit per response. Too low truncates large outputs (e.g. web artifacts) mid-generation. Default 16384; raise for capable models (Claude allows up to 128000).</p>
+        </div>
+        <div>
+          <label class="label">Max tool rounds</label>
+          <input type="number" min="1" class="input-sm" style="max-width:160px" x-model="maxToolRounds">
+          <p class="text-muted text-xs mt-1">Hard backstop on LLM round-trips in a single user turn. Default 50; raise if a legitimate workflow needs more rounds.</p>
+        </div>
       </div>
 
       <div>
@@ -153,6 +161,7 @@
                     'agent.model': model,
                     'agent.thinking_level': thinkingLevel,
                     'agent.max_tokens': String(maxTokens),
+                    'agent.max_tool_rounds': String(maxToolRounds),
                     'agent.temperature': String(temperature)
                   }})
                 })

--- a/humux/config.yml.example
+++ b/humux/config.yml.example
@@ -14,7 +14,8 @@ agent:
   openrouter_api_key: "${OPENROUTER_API_KEY}"   # one key, many models via an OpenAI-compatible gateway
   openrouter_base_url: "${OPENROUTER_BASE_URL}" # optional; defaults to https://openrouter.ai/api/v1
   model: "deepseek-v4-flash"
-  max_tokens: 8192                  # max tokens the model may emit per response; raise for capable models (Claude up to 128000)
+  max_tokens: 16384                 # max tokens the model may emit per response; raise for capable models (Claude up to 128000)
+  max_tool_rounds: 50              # max LLM round-trips per user turn; raise for complex multi-step workflows
   timezone: "Europe/Zurich"
   skills_dir: "skills/"
   agents_dir: "agents/"        # optional seed dir — drop agent .md files here to auto-seed (empty by default)

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -147,11 +147,6 @@ _REPEAT_FAILURE_NOTICE = (
     "kept failing. Stop retrying it — change the arguments, take a different "
     "approach, or report the problem to the user."
 )
-# Hard backstop on LLM round-trips in a single user turn (each round may hold
-# several tool calls), so even a model that ignores every error signal can't loop
-# forever. ponytail: generous ceiling — normal turns use a handful; raise it if a
-# legitimate workflow needs more.
-_MAX_TOOL_ROUNDS = 50
 _LOOP_ABORT_MESSAGE = (
     "I had to stop — I made too many tool calls without reaching an answer. "
     "Could you rephrase, or break the request into smaller steps?"
@@ -2059,7 +2054,7 @@ class AgentCore:
         rounds = 0
         abort = self._active_turns_map().get((channel, user_id, chat_id))
         stopped = False
-        while response.tool_calls and rounds < _MAX_TOOL_ROUNDS:
+        while response.tool_calls and rounds < self.config.agent.max_tool_rounds:
             rounds += 1
             if abort and abort.is_set():  # /stop or the Stop button fired (#146)
                 stopped = True
@@ -2225,7 +2220,7 @@ class AgentCore:
         rounds = 0
         abort = self._active_turns_map().get((channel, user_id, chat_id))
         stopped = False
-        while response.tool_calls and rounds < _MAX_TOOL_ROUNDS:
+        while response.tool_calls and rounds < self.config.agent.max_tool_rounds:
             rounds += 1
             if abort and abort.is_set():  # /stop or the Stop button fired (#146)
                 stopped = True

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -96,10 +96,15 @@ class AgentConfig(BaseModel):
     thinking_level: str = ""  # "" (off) | "low" | "medium" | "high" — only for reasoning models
     # Hard ceiling on tokens the model may emit per response. The agentic loop
     # truncates mid-tool-call when this is too small for the output (e.g. a large
-    # file written via the write tool), so keep it generous. 8192 is safe across providers;
+    # file written via the write tool), so keep it generous. 16384 is safe across providers;
     # raise it on the LLM admin tab for capable models (Claude allows up to
     # 128000 — note large non-streaming outputs can approach provider timeouts).
-    max_tokens: int = 8192
+    max_tokens: int = 16384
+    # Hard backstop on LLM round-trips in a single user turn (each round may hold
+    # several tool calls), so even a model that ignores every error signal can't loop
+    # forever. Normal turns use a handful; raise it if a legitimate workflow needs more.
+    # Exposed on the LLM admin tab.
+    max_tool_rounds: int = 50
     # Sampling temperature for the main agent loop. Lower = steadier tool calls;
     # higher = more varied prose. Skipped automatically for reasoning calls. Tune
     # on the LLM admin tab. (#12)


### PR DESCRIPTION
Closes #229

## Changes

### config.py
- **max_tokens** default raised from 8192 → **16384** (existing explicit YAML values unaffected)
- **max_tool_rounds** added to `AgentConfig` (default **50**)

### agent.py
- Removed the hardcoded `_MAX_TOOL_ROUNDS = 50` constant
- Both tool-loops (injection + non-injection) now read `self.config.agent.max_tool_rounds`

### admin.py
- Loads/saves `agent.max_tool_rounds` from the config store
- Default fallback for `max_tokens` updated to `"16384"`

### Admin UI (LLM tab)
- **Max output tokens** and **Max tool rounds** sit side-by-side in a `flex flex-wrap gap-4` row under the Inference sub-tab
- Both saved via the existing PATCH `/config` endpoint
- `maxToolRounds` parameter added to the `llmTab()` Alpine.js component in `base.html`
- Help text explains each field and its default

### docs
- `config.yml.example` updated to document both new defaults

## UI/UX notes
- The two number inputs are placed together in a clean flex row, visually grouping the "ceiling" controls
- Same compact `input-sm` styling as Temperature and other fields
- Tooltip text mirrors the code comments so admins understand what each cap controls without leaving the page

## Testing
- All existing tests pass (`test_agent_llm_override.py`, `test_agents_admin.py`)