### PR TITLE
fix: isolate scheduler job conversation contexts per job_id (#235)

### DIFF
--- a/humux/core/scheduler.py
+++ b/humux/core/scheduler.py
@@ -159,7 +159,10 @@ async def run_subagent_task(
         # Scope fallback context with job_id so different scheduled jobs
         # don't share conversation history when no origin was captured (#235).
         _ctx_chat = f"scheduler:{job_id}" if (job_id and not origin_chat_id) else (target or "")
-        _ctx_user = f"scheduler:{job_id}" if (job_id and not origin_user_id) else (origin_user_id or owner or "scheduler")
+        _ctx_user = (
+            f"scheduler:{job_id}" if (job_id and not origin_user_id)
+            else (origin_user_id or owner or "scheduler")
+        )
         result = await agent.run_subagent(
             task=task,
             agent_name=agent_name or "",

--- a/humux/core/scheduler.py
+++ b/humux/core/scheduler.py
@@ -84,7 +84,7 @@ async def run_agent_task(
             message=task,
             channel="system",
             user_id="scheduler",
-            chat_id="scheduler",
+            chat_id=f"scheduler:{job_id}" if job_id else "scheduler",
             agent_name=agent_name or gen_agent,
         )
 
@@ -156,12 +156,16 @@ async def run_subagent_task(
     target = origin_chat_id or owner
     log.info("Scheduler running subagent (agent=%s): %s", agent_name or "default", task[:100])
     try:
+        # Scope fallback context with job_id so different scheduled jobs
+        # don't share conversation history when no origin was captured (#235).
+        _ctx_chat = f"scheduler:{job_id}" if (job_id and not origin_chat_id) else (target or "")
+        _ctx_user = f"scheduler:{job_id}" if (job_id and not origin_user_id) else (origin_user_id or owner or "scheduler")
         result = await agent.run_subagent(
             task=task,
             agent_name=agent_name or "",
             origin_channel=channel,
-            origin_user_id=str(origin_user_id or owner or "scheduler"),
-            origin_chat_id=str(target or ""),
+            origin_user_id=str(_ctx_user),
+            origin_chat_id=str(_ctx_chat),
             background=False,
         )
         text = result.get("result") or result.get("error") or ""


### PR DESCRIPTION
## Problem

Every scheduled job in `run_agent_task()` and `run_subagent_task()` uses the same fixed `(channel="system", user_id="scheduler", chat_id="scheduler")` triple as its conversation context key. This means:

- Job history leaks between unrelated jobs (context grows unbounded)
- The per-chat lock serialises all jobs even though they are independent
- Session caches are shared across different jobs
- A `/new` for one job clears every job's context

## Solution

**`run_agent_task()`** — Append `job_id` to `chat_id` so each job gets its own conversation key:

```python
chat_id=f"scheduler:{job_id}" if job_id else "scheduler"
```

Jobs without a `job_id` (legacy pre-#71 jobs, config-seeded tasks) fall back to `"scheduler"`, preserving backward compatibility.

**`run_subagent_task()`** — When no captured origin exists (pre-#71 fallback), scope the fallback context with `job_id` so that different jobs don't share the owner-conversation context:

```python
_ctx_chat = f"scheduler:{job_id}" if (job_id and not origin_chat_id) else (target or "")
_ctx_user = f"scheduler:{job_id}" if (job_id and not origin_user_id) else (origin_user_id or owner or "scheduler")
```

When `origin_chat_id` / `origin_user_id` *are* present (post-#71 jobs with a real origin), the origin values are used as before — the fix only applies in the fallback path.

## Acceptance criteria

- [x] Each scheduled job with a `job_id` gets its own conversation history key
- [x] Job A's turns do not appear in job B's context
- [x] The per-chat lock does not serialise unrelated jobs
- [x] Jobs without a `job_id` continue to work (legacy fallback)
- [x] The `run_subagent_task()` function gets the same fix
- [x] `/new` for one job does not clear another job's context

Closes #235
