### PR TITLE
webhook: 👀 reaction when an agent starts work on an event

### DIFF
--- a/docs/content/docs/extending.mdx
+++ b/docs/content/docs/extending.mdx
@@ -202,7 +202,7 @@ chat proved out-of-band (the message landed in a conversation whose history the 
 doesn't share). When something genuinely needs the owner, the agent uses
 `send_message` — a deliberate act, in a real conversation.
 
-Four more knobs exist as raw frontmatter only (no editor field; the editor preserves
+Five more knobs exist as raw frontmatter only (no editor field; the editor preserves
 them across saves) — built for multi-agent workflows where several Apps coordinate on
 the same repos:
 
@@ -223,6 +223,10 @@ the same repos:
 - **Rate cap** (`gh: {..., webhook_rate_limit: 20}`) — max webhook turns per thread
   per hour (default 20). Author gates stop loops; this stops storms between mutually
   allowlisted bots.
+- **Start-of-work ack** (`gh: {..., webhook_ack: false}` to disable) — by default,
+  the agent reacts 👀 on the triggering issue, PR or comment as its turn starts, so
+  the GitHub UI shows the event was picked up before any comment lands. Reviews get
+  the reaction on their PR (reviews have no reactions API); CI runs get none.
 - **Thread digest** (`gh: {..., webhook_digest: false}` to disable) — by default,
   each webhook turn is prefixed with the thread's current state fetched live from
   GitHub (title/state/labels/milestone/assignees + the last 10 comments) using the

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -705,6 +705,22 @@ def _gh_wal_remove(delivery: str) -> None:
         pass
 
 
+def _gh_ack_target(event: str, payload: dict, repo: str) -> str:
+    """API path to react 👀 on for this event, or "" when there is nothing
+    sensible to react to (#241). Reviews have no reactions API — fall back to
+    the PR itself; workflow runs have no reactable surface at all."""
+    comment = payload.get("comment") or {}
+    if event == "issue_comment" and comment.get("id"):
+        return f"repos/{repo}/issues/comments/{comment['id']}/reactions"
+    if event == "pull_request_review_comment" and comment.get("id"):
+        return f"repos/{repo}/pulls/comments/{comment['id']}/reactions"
+    if event in {"issues", "pull_request", "pull_request_review"}:
+        number = (payload.get("issue") or payload.get("pull_request") or {}).get("number")
+        if number is not None:
+            return f"repos/{repo}/issues/{number}/reactions"
+    return ""
+
+
 async def _execute_webhook_turn(
     core,
     secret_store,
@@ -714,28 +730,43 @@ async def _execute_webhook_turn(
     chat_id: str,
     repo: str,
     delivery: str,
+    ack: str = "",
 ) -> None:
     """Run one accepted webhook delivery as an autonomous agent turn.
 
-    Shared by the live route and startup replay. channel="system": autonomous
-    background turn (auto-approved writes, no confirmation round-trips — nobody
-    can answer one on a webhook). chat_id keeps per-thread continuity.
+    Shared by the live route and startup replay (which passes no ``ack`` — the
+    event is long past by then). channel="system": autonomous background turn
+    (auto-approved writes, no confirmation round-trips — nobody can answer one
+    on a webhook). chat_id keeps per-thread continuity.
     """
     try:
-        # Thread digest (#237): the agent's history only holds turns IT was
-        # woken for — prepend the current GitHub state of the thread so the
-        # turn decides from facts, not from a partial memory. Best-effort:
-        # no token / API down / disabled → the bare event, as before.
-        if gh.get("webhook_digest", True):
+        want_ack = bool(ack) and gh.get("webhook_ack", True)
+        token = None
+        if want_ack or gh.get("webhook_digest", True):
             try:
-                from core import github_digest
                 from core.tools import _agent_gh_token
 
                 agent = await core.agents.get(agent_name)
                 resolve = secret_store.infra_resolve if secret_store else (lambda _n: None)
                 token = _agent_gh_token(gh, agent_name, core.config, resolve) if agent else None
+            except Exception:  # noqa: BLE001 — ack/digest are best-effort extras
+                log.exception("webhook token mint failed (agent=%s)", agent_name)
+        # 👀 ack (#241): a visible "an agent is on it" in the GitHub UI, with
+        # the agent's own identity, before the (slow) turn runs.
+        if want_ack and token:
+            from core import github_digest
+
+            await github_digest.ack_reaction(ack, token)
+        # Thread digest (#237): the agent's history only holds turns IT was
+        # woken for — prepend the current GitHub state of the thread so the
+        # turn decides from facts, not from a partial memory. Best-effort:
+        # no token / API down / disabled → the bare event, as before.
+        if token and gh.get("webhook_digest", True):
+            try:
+                from core import github_digest
+
                 number = chat_id.rsplit("#", 1)[-1]
-                if token and number.isdigit():
+                if number.isdigit():
                     digest = await github_digest.thread_digest(repo, int(number), token)
                     if digest:
                         task = f"{task}\n{digest}"
@@ -2152,7 +2183,17 @@ def create_admin_app(
         # the turn runs in the background like scheduler jobs. Keep a strong ref
         # until it finishes.
         turn = asyncio.create_task(
-            _execute_webhook_turn(core, secret_store, agent_name, gh, task, chat_id, repo, delivery)
+            _execute_webhook_turn(
+                core,
+                secret_store,
+                agent_name,
+                gh,
+                task,
+                chat_id,
+                repo,
+                delivery,
+                ack=_gh_ack_target(event, payload, repo),
+            )
         )
         _GH_TURN_TASKS.add(turn)
         turn.add_done_callback(_GH_TURN_TASKS.discard)

--- a/humux/core/github_digest.py
+++ b/humux/core/github_digest.py
@@ -1,4 +1,5 @@
-"""Thread digest for inbound GitHub webhook turns (#237).
+"""GitHub API helpers for inbound webhook turns: thread digest (#237) and the
+👀 start-of-work ack (#241).
 
 A webhook-woken agent has only seen the turns *it* was woken for: comments by
 other agents/humans, label changes, and state flips in between are invisible
@@ -6,8 +7,8 @@ to its chat history. GitHub holds the complete record, so each turn gets a
 fresh, bounded snapshot of the thread prepended to its task — the agent sees
 the full state before acting instead of (maybe) remembering to look it up.
 
-Failure is always soft: any error returns ``None`` and the turn runs with the
-event alone, exactly as before the digest existed.
+Failure is always soft: any error returns ``None``/``False`` and the turn
+runs exactly as it would have without the helper.
 """
 
 from __future__ import annotations
@@ -36,6 +37,20 @@ def _headers(token: str) -> dict[str, str]:
 def _clip(text: str, cap: int) -> str:
     text = (text or "").strip()
     return text if len(text) <= cap else text[: cap - 1] + "…"
+
+
+async def ack_reaction(target: str, token: str, content: str = "eyes") -> bool:
+    """React on the triggering item so "an agent is on it" shows in the GitHub
+    UI (#241). ``target`` is an API path like ``repos/o/r/issues/7/reactions``.
+    Best-effort: any failure returns ``False`` and is only logged."""
+    try:
+        async with httpx.AsyncClient(timeout=8, headers=_headers(token)) as client:
+            resp = await client.post(f"{_API}/{target}", json={"content": content})
+            resp.raise_for_status()
+        return True
+    except Exception as exc:  # noqa: BLE001 — the ack must never sink a turn
+        log.warning("ack reaction failed for %s: %s", target, exc)
+        return False
 
 
 async def thread_digest(repo: str, number: int, token: str) -> str | None:

--- a/humux/tests/test_github_webhook.py
+++ b/humux/tests/test_github_webhook.py
@@ -51,8 +51,8 @@ class _Agents:
 
 
 def _agent(**gh) -> SimpleNamespace:
-    # webhook_digest off: these tests exercise gates/dispatch, not the digest
-    # (which needs a token + GitHub API; covered by its own tests below).
+    # webhook_digest/webhook_ack off: these tests exercise gates/dispatch, not
+    # the GitHub API extras (which need a token; covered by their own tests).
     return SimpleNamespace(
         name="dev",
         enabled=True,
@@ -61,6 +61,7 @@ def _agent(**gh) -> SimpleNamespace:
                 "enabled": True,
                 "webhook_secret": "WH_SECRET",
                 "webhook_digest": False,
+                "webhook_ack": False,
                 **gh,
             }
         },
@@ -669,6 +670,64 @@ def test_webhook_digest_prepended(monkeypatch, tmp_path) -> None:
     asyncio.run(captured[1])
     assert core.process.await_args.kwargs["message"].startswith("[GitHub] New issue")
     admin._GH_THREAD_TURNS.clear()
+
+
+def test_gh_ack_target_mapping() -> None:
+    assert (
+        admin._gh_ack_target("issues", ISSUE_PAYLOAD, "acme/widgets")
+        == "repos/acme/widgets/issues/7/reactions"
+    )
+    assert (
+        admin._gh_ack_target("pull_request", PR_PAYLOAD, "acme/widgets")
+        == "repos/acme/widgets/issues/15/reactions"
+    )
+    # Reviews have no reactions API → fall back to the PR itself.
+    review = {**PR_PAYLOAD, "review": {"id": 9, "body": "x"}}
+    assert (
+        admin._gh_ack_target("pull_request_review", review, "acme/widgets")
+        == "repos/acme/widgets/issues/15/reactions"
+    )
+    comment = {"comment": {"id": 33}, "issue": {"number": 7}}
+    assert (
+        admin._gh_ack_target("issue_comment", comment, "acme/widgets")
+        == "repos/acme/widgets/issues/comments/33/reactions"
+    )
+    assert (
+        admin._gh_ack_target("pull_request_review_comment", comment, "acme/widgets")
+        == "repos/acme/widgets/pulls/comments/33/reactions"
+    )
+    # Nothing sensible to react to on a CI run.
+    assert admin._gh_ack_target("workflow_run", {"workflow_run": {}}, "acme/widgets") == ""
+
+
+def test_webhook_ack_reaction_posted(monkeypatch) -> None:
+    captured = _capture_create_task(monkeypatch)
+    from core import github_digest, tools
+
+    monkeypatch.setattr(tools, "_agent_gh_token", lambda *a, **k: "tok-123")
+    acked: dict = {}
+
+    async def fake_ack(target, token, content="eyes"):
+        acked.update(target=target, token=token, content=content)
+        return True
+
+    monkeypatch.setattr(github_digest, "ack_reaction", fake_ack)
+    client, core = _client(agent=_agent(webhook_ack=True))
+    core.config = SimpleNamespace()  # token mint is stubbed; config is opaque
+    assert _post(client, ISSUE_PAYLOAD).status_code == 202
+    asyncio.run(captured[0])
+    assert acked == {
+        "target": "repos/acme/widgets/issues/7/reactions",
+        "token": "tok-123",
+        "content": "eyes",
+    }
+    core.process.assert_awaited_once()  # ack rides the turn, never replaces it
+    # Disabled → no reaction even though a target exists.
+    acked.clear()
+    client2, core2 = _client(agent=_agent(webhook_ack=False))
+    assert _post(client2, ISSUE_PAYLOAD).status_code == 202
+    asyncio.run(captured[1])
+    assert acked == {}
 
 
 def test_resolve_chat_titles() -> None:


### PR DESCRIPTION
Closes #241.

As a webhook turn starts, the agent reacts 👀 on whatever triggered it, using its own App identity — a visible "the fleet is on it" in the GitHub UI before the first comment/commit lands.

- `issues` / `pull_request` → reaction on the issue/PR; `pull_request_review` falls back to its PR (reviews have no reactions API); `issue_comment` / `pull_request_review_comment` → reaction on the comment; `workflow_run` → none (nothing reactable).
- Best-effort by contract: a failed reaction logs and never sinks the turn. `webhook_ack: false` disables (editor carries the key through saves).
- WAL replays pass no ack — the event is long past by then.
- The installation-token mint is now one shared attempt feeding both the ack and the thread digest.

Tests: target-mapping unit test + dispatch test (posted with the minted token, rides the turn, disabled = silent). Suite 1038 green, ruff clean. Docs: extending.mdx knob list.