### PR TITLE
chore(docker): bundle Node.js LTS (node/npm/npx)

### DIFF
--- a/humux/Dockerfile
+++ b/humux/Dockerfile
@@ -26,6 +26,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
+# Node.js LTS (node/npm/npx) for JS/TS builds in the coding workspace — these
+# run through the coding-harness bash (permissions.py rules); they are NOT in
+# the run_command prefix allowlist (`npm run` = arbitrary execution).
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && node --version && npm --version
+
 # Install wacli from pinned upstream tag (github.com/openclaw/wacli).
 # Bump WACLI_VERSION to cross WhatsApp protocol breaks (e.g. 405 Client Outdated).
 ARG WACLI_VERSION=v0.11.0


### PR DESCRIPTION
Skill installs warned about a missing `npm` executable, and any Node-based product build in the coding workspace needs it. Adds Node.js 22 LTS via NodeSource (~180MB).

Deliberately NOT added to the `run_command` prefix allowlist — `npm run` executes arbitrary package scripts, so it stays on the coding-harness bash path under the permissions.py rules (ASK-gated interactively, auto-approved on system-channel turns like every other write there). The remaining skill-lint warnings (`PASS`, `FAIL`, `security`, `codesign`) are example-output false positives in community skill docs, not missing dependencies.