### PR TITLE
webhook: per-agent conversation isolation + mention slug normalization

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -2133,7 +2133,12 @@ def create_admin_app(
         # Mention gate (webhook_mention): when the App's handle is configured,
         # only events whose text @-mentions it wake the agent — except the
         # webhook_auto_events role triggers (#237).
-        mention = str(gh.get("webhook_mention") or "").strip().lstrip("@").lower()
+        # Normalize: the handle is the bare App slug. A stored "@x" or "x[bot]"
+        # (an easy config mistake) would break the self-loop guard — it compares
+        # the sender to "<mention>[bot]", so "x[bot]" self-matches never (#244).
+        mention = (
+            str(gh.get("webhook_mention") or "").strip().lstrip("@").lower().removesuffix("[bot]")
+        )
         parsed = _github_event_task(
             event,
             payload,
@@ -2145,6 +2150,12 @@ def create_admin_app(
         if parsed is None:
             return Response("ignored")
         task, chat_id, repo = parsed
+        # Per-agent conversation (#244): a chat is keyed by (channel, user_id,
+        # chat_id) with NO agent dimension, so two agents woken by the same
+        # thread would share one history — each seeing the other's turns as its
+        # own. Scope the key by agent; cross-agent visibility comes from the
+        # thread digest, rebuilt from GitHub every turn.
+        chat_id = chat_id.replace("github:", f"github:{agent_name}:", 1)
         # Repo gate — same semantics as github_repo_violation (core/tools.py).
         allowed_repos = _allowlist(gh.get("repos"))
         if allowed_repos is not None and repo.lower() not in allowed_repos:

--- a/humux/tests/test_github_webhook.py
+++ b/humux/tests/test_github_webhook.py
@@ -402,7 +402,7 @@ def test_webhook_runs_turn_in_background(monkeypatch) -> None:
     core.process.assert_awaited_once()
     kwargs = core.process.await_args.kwargs
     assert kwargs["agent_name"] == "dev"
-    assert kwargs["chat_id"] == "github:acme/widgets#7"
+    assert kwargs["chat_id"] == "github:dev:acme/widgets#7"  # agent-scoped (#244)
     assert kwargs["channel"] == "system"
 
 
@@ -569,7 +569,7 @@ def test_webhook_rate_cap(monkeypatch, tmp_path) -> None:
     other = {**ISSUE_PAYLOAD, "issue": {**ISSUE_PAYLOAD["issue"], "number": 8}}
     assert _post(client, other).status_code == 202
     # Old timestamps age out of the window.
-    key = "github:acme/widgets#7"
+    key = "github:dev:acme/widgets#7"
     admin._GH_THREAD_TURNS[key] = [t - 4000 for t in admin._GH_THREAD_TURNS[key]]
     assert _post(client, ISSUE_PAYLOAD).status_code == 202
     admin._GH_THREAD_TURNS.clear()
@@ -588,7 +588,7 @@ def test_webhook_wal_written_and_cleared(monkeypatch, tmp_path) -> None:
     files = list(wal.glob("*.json"))
     assert len(files) == 1
     record = json.loads(files[0].read_text())
-    assert record["agent_name"] == "dev" and record["chat_id"] == "github:acme/widgets#7"
+    assert record["agent_name"] == "dev" and record["chat_id"] == "github:dev:acme/widgets#7"
     asyncio.run(captured[0])  # turn completes → WAL entry gone
     assert list(wal.glob("*.json")) == []
     # A failed turn clears its WAL entry too (replay must be a human decision).
@@ -670,6 +670,29 @@ def test_webhook_digest_prepended(monkeypatch, tmp_path) -> None:
     asyncio.run(captured[1])
     assert core.process.await_args.kwargs["message"].startswith("[GitHub] New issue")
     admin._GH_THREAD_TURNS.clear()
+
+
+def test_webhook_mention_bot_suffix_normalized(monkeypatch) -> None:
+    # A webhook_mention stored as "cliobit[bot]" (easy config mistake) must
+    # behave exactly like the bare slug (#244): mentions still wake the agent,
+    # and the SELF-LOOP GUARD still drops the agent's own echoes — unnormalized
+    # it compared the sender to "cliobit[bot][bot]" and never matched.
+    captured = _capture_create_task(monkeypatch)
+    mentioned = {
+        **ISSUE_PAYLOAD,
+        "issue": {**ISSUE_PAYLOAD["issue"], "body": "hey @cliobit[bot] please look"},
+    }
+    client, core = _client(agent=_agent(webhook_mention="cliobit[bot]"))
+    assert _post(client, mentioned).status_code == 202
+    asyncio.run(captured[0])
+    message = core.process.await_args.kwargs["message"]
+    assert "You act on GitHub as @cliobit[bot]." in message  # not [bot][bot]
+    own_echo = {**mentioned, "sender": {"login": "cliobit[bot]", "type": "Bot"}}
+    client2, core2 = _client(
+        agent=_agent(webhook_mention="cliobit[bot]", webhook_users=["cliobit[bot]"])
+    )
+    assert _post(client2, own_echo).text == "ignored"
+    core2.process.assert_not_called()
 
 
 def test_gh_ack_target_mapping() -> None:


### PR DESCRIPTION
Closes #244. Found on a live 2-agent fleet test — the captured payload showed one agent's system prompt with the other agent's turns interleaved as its own.

- **Per-agent chat keys**: conversations are keyed `(channel, user_id, chat_id)` with no agent dimension, and every agent woken by a thread used the same `github:<repo>#<n>` — shared history, cross-agent identity confusion, and each agent's injected memories/accounts visible to the other. Webhook chat keys are now `github:<agent>:<repo>#<n>`. Cross-agent visibility is preserved by design via the thread digest (#237), rebuilt from GitHub each turn. Old-key histories are abandoned (fresh chat + digest is fully functional), same approach as the scheduler fix (#235).
- **Mention normalization**: `webhook_mention: cliobit[bot]` (instead of the bare slug) produced `You act on GitHub as @cliobit[bot][bot]` and — worse — silently disabled the self-loop guard, which compares the sender to `<mention>[bot]` = `cliobit[bot][bot]`, never matching. The route now strips `@` and a trailing `[bot]`, so both spellings behave identically.

Tests: normalization test (mention wakes + self-echo dropped with the `[bot]` spelling), chat-key assertions updated. Suite 1039 green, ruff clean.