### PR TITLE
feat(voice): remote Kokoro TTS via OpenAI-compatible API

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Memories are extracted automatically from conversations. The agent reads AND wri
 
 - **STT**: [faster-whisper](https://github.com/SYSTRAN/faster-whisper) — local, offline, multi-language
 - **TTS**: [edge-tts](https://github.com/rany2/edge-tts) (cloud) or **Kokoro 82M** (fully offline, multilingual)
+- Kokoro can run as a **sidecar container** via an OpenAI-compatible TTS API (`docker compose --profile kokoro up`)
 - Voice marker syntax lets the model request a spoken reply per-turn
 - Per-agent voice selection
 

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1686,6 +1686,7 @@ def create_admin_app(
             "tts_voice": await config_store.get("voice.tts_voice") or "en-US-AvaNeural",
             "tts_enabled": await config_store.get("voice.tts_enabled") or "true",
             "backend": await config_store.get("voice.backend") or "edge-tts",
+            "tts_api_base_url": await config_store.get("voice.tts_api_base_url") or "",
             "kokoro_voice": await config_store.get("voice.kokoro.default_voice") or "af_bella",
             "kokoro_voices": KOKORO_VOICES,
             "kokoro_languages": KOKORO_LANGUAGES,

--- a/humux/api/templates/partials/identity.html
+++ b/humux/api/templates/partials/identity.html
@@ -6,6 +6,7 @@
   sttModel: {{ stt_model|default('base', true)|tojson|forceescape }},
   ttsVoice: {{ tts_voice|default('en-US-AvaNeural', true)|tojson|forceescape }},
   backend: {{ backend|default('edge-tts', true)|tojson|forceescape }},
+  ttsApiBaseUrl: {{ tts_api_base_url|default('', true)|tojson|forceescape }},
   kokoroVoice: {{ kokoro_voice|default('af_bella', true)|tojson|forceescape }},
   previewText: '',
   previewLang: '',
@@ -40,6 +41,14 @@
         <option value="kokoro">Kokoro 82M (offline, multilingual)</option>
       </select>
       <p class="text-muted text-xs mt-1">Kokoro runs on-device (model bundled by default); it falls back to Edge TTS if the model isn't available. Restart after changing.</p>
+    </div>
+
+    {# Remote TTS API — Kokoro sidecar or any OpenAI-compatible TTS endpoint #}
+    <div x-show="backend === 'kokoro'">
+      <label class="label">Remote TTS API URL</label>
+      <input type="text" class="input-sm" style="max-width:360px" x-model="ttsApiBaseUrl"
+             placeholder="http://kokoro:8880/v1">
+      <p class="text-muted text-xs mt-1">OpenAI-compatible TTS endpoint. When set, Kokoro runs as a sidecar container instead of bundled in the main image. Leave empty for local Kokoro.</p>
     </div>
 
     {# Edge voice #}
@@ -93,6 +102,7 @@
                 'voice.stt_model': sttModel,
                 'voice.backend': backend,
                 'voice.tts_voice': ttsVoice,
+                'voice.tts_api_base_url': ttsApiBaseUrl,
                 'voice.kokoro.default_voice': kokoroVoice
               };
               fetch('/config', {

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -213,6 +213,7 @@ class VoiceConfig(BaseModel):
     tts_voice: str = "en-US-AvaNeural"
     tts_enabled: bool = True
     backend: str = "edge-tts"  # "edge-tts" | "kokoro"
+    tts_api_base_url: str = ""  # OpenAI-compatible TTS endpoint, e.g. http://kokoro:8880/v1
     kokoro: KokoroConfig = KokoroConfig()
 
 

--- a/humux/core/main.py
+++ b/humux/core/main.py
@@ -120,6 +120,7 @@ async def _start_agent(config_store: ConfigStore):
             kokoro_model_path=config.voice.kokoro.model_path,
             kokoro_voices_path=config.voice.kokoro.voices_path,
             kokoro_default_voice=config.voice.kokoro.default_voice,
+            tts_api_base_url=config.voice.tts_api_base_url,
         )
         agent.voice = voice
 

--- a/humux/docker-compose.yml
+++ b/humux/docker-compose.yml
@@ -33,3 +33,12 @@ services:
   #   profiles: ["browser"]
   #   environment:
   #     - MAX_CONCURRENT_SESSIONS=2
+
+  # Optional Kokoro TTS sidecar — OpenAI-compatible TTS on port 8880.
+  # Start with:  docker compose --profile kokoro up
+  # Then set voice.tts_api_base_url to http://kokoro:8880/v1 in the admin UI.
+  kokoro:
+    image: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+    container_name: humux-kokoro
+    restart: unless-stopped
+    profiles: ["kokoro"]

--- a/humux/tests/test_voice_kokoro.py
+++ b/humux/tests/test_voice_kokoro.py
@@ -58,6 +58,7 @@ def _bare_pipeline():
     p.tts_enabled = True
     p.tts_voice = "en-US-AvaNeural"
     p.kokoro_default_voice = "af_bella"
+    p.tts_api_base_url = ""
     p._kokoro = None
     return p
 
@@ -251,3 +252,95 @@ def test_edge_keeps_voice_when_lang_matches(monkeypatch):
     monkeypatch.setattr(p, "_synthesize_edge", fake_edge)
     asyncio.run(p.synthesize("Ciao", voice="it-IT-DiegoNeural", lang="it"))
     assert seen["voice"] == "it-IT-DiegoNeural"  # already Italian, kept
+
+
+# -- Remote TTS API (#246) ---------------------------------------------------
+
+
+def test_remote_tts_takes_priority_over_local(monkeypatch):
+    """When tts_api_base_url is set, remote is tried before local Kokoro."""
+    p = _bare_pipeline()
+    p.tts_api_base_url = "http://kokoro:8880/v1"
+    p._kokoro = _FakeKokoro()
+    seen = {}
+
+    async def fake_remote(text, voice):
+        seen["text"] = text
+        seen["voice"] = voice
+        return b"REMOTE-AUDIO"
+
+    monkeypatch.setattr(p, "_synthesize_remote", fake_remote)
+    out = asyncio.run(p.synthesize("hello", voice="af_bella"))
+    assert out == b"REMOTE-AUDIO"
+    assert seen["text"] == "hello"
+    assert p._kokoro.calls == []  # local Kokoro not used
+
+
+def test_remote_tts_fallback_to_local_on_error(monkeypatch):
+    """Remote failure falls back to local Kokoro, then edge-tts."""
+    monkeypatch.setattr("voice.pipeline._wav_to_ogg", lambda wav: b"OGG:LOCAL")
+    p = _bare_pipeline()
+    p.tts_api_base_url = "http://kokoro:8880/v1"
+    p._kokoro = _FakeKokoro()
+
+    async def failing_remote(text, voice):
+        raise ConnectionError("unreachable")
+
+    monkeypatch.setattr(p, "_synthesize_remote", failing_remote)
+    out = asyncio.run(p.synthesize("hello"))
+    assert out == b"OGG:LOCAL"  # fell through to local Kokoro
+    assert len(p._kokoro.calls) == 1
+
+
+def test_remote_tts_fallback_to_edge_when_no_local(monkeypatch):
+    """Remote failure + no local Kokoro → edge-tts."""
+    p = _bare_pipeline()
+    p.tts_api_base_url = "http://kokoro:8880/v1"
+    seen = {}
+
+    async def failing_remote(text, voice):
+        raise ConnectionError("unreachable")
+
+    async def fake_edge(text, voice):
+        seen["used"] = True
+        return b"EDGE"
+
+    monkeypatch.setattr(p, "_synthesize_remote", failing_remote)
+    monkeypatch.setattr(p, "_synthesize_edge", fake_edge)
+    out = asyncio.run(p.synthesize("hello"))
+    assert out == b"EDGE"
+    assert seen["used"]
+
+
+def test_preview_uses_remote_for_kokoro_voice(monkeypatch):
+    """Preview routes through remote when tts_api_base_url is set."""
+    p = _bare_pipeline()
+    p.tts_api_base_url = "http://kokoro:8880/v1"
+
+    async def fake_remote(text, voice):
+        return b"REMOTE-PREVIEW"
+
+    monkeypatch.setattr(p, "_synthesize_remote", fake_remote)
+    audio, mime = asyncio.run(p.preview("test", "af_bella"))
+    assert audio == b"REMOTE-PREVIEW"
+    assert mime == "audio/ogg"
+
+
+def test_remote_skipped_for_unsupported_lang(monkeypatch):
+    """German (Kokoro can't phonemize) must skip remote Kokoro too."""
+    p = _bare_pipeline()
+    p.tts_api_base_url = "http://kokoro:8880/v1"
+    remote_calls = []
+
+    async def fake_remote(text, voice):
+        remote_calls.append(1)
+        return b"REMOTE"
+
+    async def fake_edge(text, voice):
+        return b"EDGE"
+
+    monkeypatch.setattr(p, "_synthesize_remote", fake_remote)
+    monkeypatch.setattr(p, "_synthesize_edge", fake_edge)
+    out = asyncio.run(p.synthesize("Hallo Welt", voice="af_bella", lang="de"))
+    assert out == b"EDGE"
+    assert remote_calls == []  # remote skipped for unsupported lang

--- a/humux/voice/pipeline.py
+++ b/humux/voice/pipeline.py
@@ -401,7 +401,10 @@ class VoicePipeline:
         text = clean_for_speech(text) or text
         if _is_kokoro_voice(voice):
             if self.tts_api_base_url:
-                return await self._synthesize_remote(text, voice), "audio/ogg"
+                try:
+                    return await self._synthesize_remote(text, voice), "audio/ogg"
+                except Exception:
+                    log.exception("Remote TTS preview failed, falling back")
             if self._kokoro is None:
                 raise RuntimeError(
                     "Kokoro model isn't loaded — switch the TTS backend to "

--- a/humux/voice/pipeline.py
+++ b/humux/voice/pipeline.py
@@ -220,11 +220,13 @@ class VoicePipeline:
         kokoro_model_path: str = "models/kokoro/kokoro-v1.0.onnx",
         kokoro_voices_path: str = "models/kokoro/voices-v1.0.bin",
         kokoro_default_voice: str = "af_bella",
+        tts_api_base_url: str = "",
     ):
         self.tts_voice = tts_voice
         self.tts_enabled = tts_enabled
         self.backend = backend
         self.kokoro_default_voice = kokoro_default_voice
+        self.tts_api_base_url = tts_api_base_url.rstrip("/") if tts_api_base_url else ""
         self._kokoro = None
 
         log.info("Loading Whisper model '%s' …", stt_model)
@@ -293,6 +295,12 @@ class VoicePipeline:
         # phonemize (e.g. German) — then go straight to a matching edge-tts voice.
         # An unknown/untagged language just lets Kokoro derive lang from the voice.
         skip_kokoro = known is not None and known[0] is None
+        # Remote TTS API takes priority when configured (#246)
+        if self.tts_api_base_url and not skip_kokoro:
+            try:
+                return await self._synthesize_remote(text, voice)
+            except Exception:
+                log.exception("Remote TTS failed, falling back to local")
         if self._kokoro is not None and not skip_kokoro:
             try:
                 return await self._synthesize_kokoro(text, voice, kokoro_lang)
@@ -327,6 +335,33 @@ class VoicePipeline:
 
         audio = buf.getvalue()
         log.info("Synthesized %d chars → %d bytes audio (edge-tts)", len(text), len(audio))
+        return audio
+
+    async def _synthesize_remote(self, text: str, voice: str | None) -> bytes:
+        """Call an OpenAI-compatible TTS endpoint (e.g. Kokoro FastAPI sidecar).
+
+        Returns OGG/Opus bytes. The remote API returns mp3 by default; we ask
+        for opus so Telegram can play it directly without transcoding.
+        """
+        import httpx
+
+        url = f"{self.tts_api_base_url}/audio/speech"
+        body = {
+            "model": "kokoro",
+            "input": text,
+            "voice": voice or self.kokoro_default_voice,
+            "response_format": "opus",
+        }
+        async with httpx.AsyncClient(timeout=30) as client:
+            r = await client.post(url, json=body)
+            r.raise_for_status()
+        audio = r.content
+        log.info(
+            "Synthesized %d chars → %d bytes audio (remote-tts/%s)",
+            len(text),
+            len(audio),
+            voice or self.kokoro_default_voice,
+        )
         return audio
 
     async def _synthesize_kokoro(
@@ -365,10 +400,12 @@ class VoicePipeline:
         """
         text = clean_for_speech(text) or text
         if _is_kokoro_voice(voice):
+            if self.tts_api_base_url:
+                return await self._synthesize_remote(text, voice), "audio/ogg"
             if self._kokoro is None:
                 raise RuntimeError(
                     "Kokoro model isn't loaded — switch the TTS backend to "
-                    "'kokoro' and restart to preview Kokoro voices."
+                    "'kokoro' and restart, or set a remote TTS API URL."
                 )
             return await self._synthesize_kokoro(text, voice, lang or None), "audio/ogg"
         return await self._synthesize_edge(text, voice), "audio/mpeg"


### PR DESCRIPTION
## Summary

Closes #246.

- Adds `VoiceConfig.tts_api_base_url` — when set, `synthesize()` calls a remote OpenAI-compatible TTS endpoint (`POST /v1/audio/speech`) instead of loading Kokoro locally
- Fallback chain: remote → local Kokoro → edge-tts (same resilience as existing Kokoro fallback)
- Voice/language mapping works identically — same voice names, same phoneme skipping for unsupported languages (e.g. German)
- Voice preview in admin UI routes through remote when available
- Docker Compose sidecar: `docker compose --profile kokoro up` starts the `ghcr.io/remsky/kokoro-fastapi-cpu` container
- Admin UI Voice tab exposes the URL field (shown when Kokoro backend is selected)

## Test plan

- [x] 23 voice tests pass (5 new remote-specific tests)
- [x] Full suite: 1044 passed
- [ ] Manual: set `tts_api_base_url` to a running Kokoro FastAPI instance and verify voice replies work
- [ ] Manual: verify fallback to edge-tts when remote is unreachable
- [ ] Manual: verify admin voice preview works with remote endpoint