### PR TITLE
build: slim Docker image — multi-stage Go build + browser sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Secrets are referenced as `${vault:NAME}` in config and `{{secret:NAME}}` in com
 <summary><strong>Browser automation</strong> — The agent can browse the web</summary>
 
 - Optional headless Chromium (Playwright) for JS-heavy pages
+- Chromium can run as a **sidecar container** via CDP (`docker compose --profile browser up`)
 - **Self-driving explore mode** — an inner LLM loop navigates sites, fills forms, clicks buttons until done
 - Persistent logged-in profiles (cookies survive between calls)
 - Per-domain action rules (Allow / Ask / Block)

--- a/humux/Dockerfile
+++ b/humux/Dockerfile
@@ -1,16 +1,25 @@
+# ---------- builder: compile wacli (Go + CGO) ----------
+FROM golang:1.24-bookworm AS wacli-builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+ARG WACLI_VERSION=v0.11.0
+RUN CGO_ENABLED=1 CGO_CFLAGS="-Wno-error=missing-braces" \
+    GOBIN=/out \
+    go install -tags sqlite_fts5 github.com/openclaw/wacli/cmd/wacli@${WACLI_VERSION}
+
+# ---------- runtime ----------
 FROM python:3.14-slim
 
 WORKDIR /app
 
 # System deps (ffmpeg for voice pipeline, curl for health checks, sqlite3 for memory)
-# golang + build-essential build wacli (CGO, sqlite_fts5) from the pinned upstream tag.
 # The bash-tool allowlist (core/executor.py ALLOWED_PREFIXES) promises these CLIs
 # exist — keep this list in sync with it: git (coding harness clone/commit),
 # ripgrep (rg), w3m, pandoc, poppler-utils (pdftotext, pdftoppm), yt-dlp, ncal (cal).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg curl ca-certificates jq sqlite3 \
     bash tar gzip xz-utils \
-    golang build-essential pkg-config \
     git ripgrep w3m pandoc poppler-utils yt-dlp ncal \
     && rm -rf /var/lib/apt/lists/*
 
@@ -34,13 +43,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && rm -rf /var/lib/apt/lists/* \
     && node --version && npm --version
 
-# Install wacli from pinned upstream tag (github.com/openclaw/wacli).
-# Bump WACLI_VERSION to cross WhatsApp protocol breaks (e.g. 405 Client Outdated).
-ARG WACLI_VERSION=v0.11.0
-RUN CGO_ENABLED=1 CGO_CFLAGS="-Wno-error=missing-braces" \
-    GOBIN=/usr/local/bin \
-    go install -tags sqlite_fts5 github.com/openclaw/wacli/cmd/wacli@${WACLI_VERSION} \
-    && wacli version
+# wacli binary from the builder stage — no Go toolchain in the final image.
+COPY --from=wacli-builder /out/wacli /usr/local/bin/wacli
+RUN wacli version
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -59,15 +64,15 @@ RUN if [ "$INSTALL_KOKORO" = "true" ]; then \
     fi
 
 # Bundle full Chromium for the browser tool (Tools tab: browser, issue #16).
-# ON by default: a self-contained image avoids the runtime `playwright install`
-# fetch, which flakes on remote hosts with spotty networking. Adds ~500-700MB.
+# OFF by default: use the browserless/chrome sidecar instead (see docker-compose.yml,
+# `--profile browser`).  Set tools.browser.cdp_url to ws://browser:3000.
+# Opt IN for a self-contained image:  docker build --build-arg INSTALL_BROWSER=true .
 # We install the FULL chromium (not chromium-headless-shell): its "new headless"
 # mode renders more faithfully and is far less bot-detectable than the old
 # headless shell — important since the browser/vision tooling targets exactly the
 # janky, JS-heavy, sometimes bot-protected sites where the shell gets served
-# degraded content. Opt out for a lean/sidecar deploy (point tools.browser.cdp_url
-# at a remote Chromium):  docker build --build-arg INSTALL_BROWSER=false .
-ARG INSTALL_BROWSER=true
+# degraded content.
+ARG INSTALL_BROWSER=false
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN if [ "$INSTALL_BROWSER" = "true" ]; then \
       uv run playwright install --with-deps chromium && \
@@ -125,7 +130,7 @@ ENV WACLI_DEVICE_LABEL=humux
 
 EXPOSE 8000
 
-# Health check \u2014 orchestrators (Docker Compose, Swarm, K8s) can detect a hung
+# Health check — orchestrators (Docker Compose, Swarm, K8s) can detect a hung
 # or failed process.  Curl is pre-installed (see system-deps apt-get above).
 # The start period is generous: the first boot runs the setup wizard and may
 # take a while before the /health route responds 200.

--- a/humux/docker-compose.yml
+++ b/humux/docker-compose.yml
@@ -15,24 +15,17 @@ services:
       - ./character.md:/app/character.md:ro
       - ./skills:/app/skills:ro
     env_file: .env
-    # Browser tool (issue #16). Two options:
-    #  - All-in-one (default): Chromium is bundled in the image (~500-700MB), so no
-    #    runtime download. Opt out with `--build-arg INSTALL_BROWSER=false`.
-    #  - Lean core: build with INSTALL_BROWSER=false, run the sidecar below, and set
-    #    tools.browser.cdp_url to its CDP endpoint. Profiles persist on ./data.
-    # environment:
-    #   - BROWSER_CDP_URL=ws://browser:3000
 
   # Optional headless-Chromium sidecar (keeps the main image lean). Start with:
   #   docker compose --profile browser up
-  # Exposes a CDP endpoint; point tools.browser.cdp_url at ws://browser:3000.
-  # browser:
-  #   image: browserless/chrome:latest
-  #   container_name: humux-browser
-  #   restart: unless-stopped
-  #   profiles: ["browser"]
-  #   environment:
-  #     - MAX_CONCURRENT_SESSIONS=2
+  # Then set tools.browser.cdp_url to ws://browser:3000 in the admin UI.
+  browser:
+    image: browserless/chrome:latest
+    container_name: humux-browser
+    restart: unless-stopped
+    profiles: ["browser"]
+    environment:
+      - MAX_CONCURRENT_SESSIONS=2
 
   # Optional Kokoro TTS sidecar — OpenAI-compatible TTS on port 8880.
   # Start with:  docker compose --profile kokoro up


### PR DESCRIPTION
## Summary

Stacked on #249.

Closes #251, closes #252.

Two easy wins to slim the Docker image by ~900MB-1.2GB:

- **Multi-stage Go build** (#251): wacli is compiled in a dedicated `golang:1.24-bookworm` builder stage. Only the final binary is copied into the runtime image — Go SDK, build-essential, and module cache no longer bloat it (~400-500MB saved).

- **Browser sidecar** (#252): `INSTALL_BROWSER` now defaults to `false`. The `browserless/chrome` sidecar in docker-compose is uncommented and profile-gated (`--profile browser`). The CDP code path (`tools.browser.cdp_url`) was already wired — this just promotes it as the default. (~500-700MB saved from the default image.)

## Test plan

- [ ] `docker build .` succeeds without Go toolchain in final image
- [ ] `wacli version` works in the built image
- [ ] `docker compose --profile browser up` starts the browserless sidecar
- [ ] Setting `tools.browser.cdp_url` to `ws://browser:3000` works for browsing
- [ ] `docker build --build-arg INSTALL_BROWSER=true .` still bundles Chromium