### PR TITLE
identity: fail closed on unresolved agent gh identity, bot git authorship, gh auth rails

### DIFF
--- a/humux/core/permissions.py
+++ b/humux/core/permissions.py
@@ -211,6 +211,16 @@ DEFAULT_RULES: dict[str, str] = {
     "bash:gh*issue create*": "ASK",
     "bash:gh*pr create*": "ASK",
     "bash:gh*release create*": "ASK",
+    # gh auth mutations touch SHARED container state (#263): login/logout swap
+    # the ambient keyring identity for EVERY agent, setup-git writes the global
+    # gitconfig credential helper, refresh rescopes, and `gh auth token` prints
+    # the secret into the transcript. Identity comes from the per-agent GH_TOKEN
+    # env, never from ambient auth — `gh auth status` stays readable above.
+    "bash:gh auth login*": "NEVER",
+    "bash:gh auth logout*": "NEVER",
+    "bash:gh auth setup-git*": "NEVER",
+    "bash:gh auth refresh*": "NEVER",
+    "bash:gh auth token*": "NEVER",
     # Browser automation — reading is safe, acting (click/fill/submit) asks.
     # Per-domain rules work because every command carries `--url`, e.g. add
     # "bash:*browser.py act*github.com*": "ALWAYS" via the admin UI.
@@ -283,7 +293,6 @@ class PermissionEngine:
 
     # Sentinel row in the yolo table marking the #222 migration as complete.
     _YOLO_SENTINEL = "__migrated_yolo_default_on__"
-
 
     def __init__(self, db_path: str = "data/config.db") -> None:
         self.db_path = db_path

--- a/humux/core/tools.py
+++ b/humux/core/tools.py
@@ -17,12 +17,21 @@ entry to ``_REGISTRY`` below describing its env + prompt advertisement.
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from core.config import Config
+
+log = logging.getLogger(__name__)
+
+# Sentinel GH_TOKEN for an agent whose own identity failed to resolve (#263):
+# an ABSENT token would let gh/git fall back to ambient container auth
+# (hosts.yml, a setup-git credential helper) and act as whoever logged in —
+# typically the owner. An invalid token makes gh fail loudly instead.
+GH_NO_IDENTITY = "humux-no-identity"
 
 if TYPE_CHECKING:
     from core.agents import Agent
@@ -468,6 +477,32 @@ def effective_tool_env(
             token = _agent_gh_token(gh, agent.name, config, resolve_secret)
             if token:
                 env["GH_TOKEN"] = token
+            else:
+                # Fail CLOSED (#263): no resolvable identity must mean loud gh
+                # failures, never a silent fallback to ambient container auth.
+                log.warning(
+                    "Agent %s: gh enabled but no identity resolved — failing closed",
+                    agent.name,
+                )
+                env["GH_TOKEN"] = GH_NO_IDENTITY
+            # Commits authored as the bot (#263): env beats any `git config
+            # user.*` the model sets in a shared workspace, so bot work can't
+            # carry the owner's name. The app slug rides webhook_mention; the
+            # plain noreply form displays the bot name (no avatar link — that
+            # would need the bot USER id, which isn't known offline).
+            slug = (
+                str(gh.get("webhook_mention") or "")
+                .strip()
+                .lstrip("@")
+                .lower()
+                .removesuffix("[bot]")
+            )
+            if slug and _agent_has_own_app(gh):
+                bot = f"{slug}[bot]"
+                env["GIT_AUTHOR_NAME"] = bot
+                env["GIT_COMMITTER_NAME"] = bot
+                env["GIT_AUTHOR_EMAIL"] = f"{bot}@users.noreply.github.com"
+                env["GIT_COMMITTER_EMAIL"] = f"{bot}@users.noreply.github.com"
 
     browser = agent.tool_setting("browser")
     if browser is not None and browser.get("enabled") and config.tools.browser.enabled:

--- a/humux/tests/test_agent_tool_identity.py
+++ b/humux/tests/test_agent_tool_identity.py
@@ -64,14 +64,47 @@ async def test_agent_with_own_token(agent: AgentCore, monkeypatch) -> None:
     assert cap["tool_env"]["GH_TOKEN"] == "hopper-token"  # its own, not the owner's
 
 
-async def test_agent_gh_enabled_but_no_token_does_not_borrow_owner(
-    agent: AgentCore, monkeypatch
-) -> None:
-    # gh switched on but no token stored for this agent → no GH_TOKEN at all,
-    # rather than silently inheriting the owner's.
+async def test_agent_gh_enabled_but_no_token_fails_closed(agent: AgentCore, monkeypatch) -> None:
+    # gh switched on but no token resolvable for this agent → an INVALID
+    # sentinel token (#263), not merely an absent one: with GH_TOKEN unset,
+    # gh/git fall back to ambient container auth (hosts.yml, a setup-git
+    # credential helper) and act as whoever logged in — usually the owner.
+    from core.tools import GH_NO_IDENTITY
+
     atlas = Agent(name="atlas", tool_config={"gh": {"enabled": True}})
     cap = await _run(agent, atlas, monkeypatch)
-    assert "GH_TOKEN" not in cap["tool_env"]
+    assert cap["tool_env"]["GH_TOKEN"] == GH_NO_IDENTITY
+    assert cap["tool_env"]["GH_TOKEN"] != "owner-token"
+
+
+async def test_agent_app_identity_sets_bot_git_authorship(agent: AgentCore, monkeypatch) -> None:
+    # An agent with its own App + webhook_mention commits as <slug>[bot] (#263):
+    # the env wins over any `git config user.*` the model sets in the workspace.
+    import core.tools as tools_mod
+
+    monkeypatch.setattr(tools_mod, "_agent_app_token", lambda gh, resolve: "app-token")
+    bot = Agent(
+        name="kindral",
+        tool_config={
+            "gh": {
+                "enabled": True,
+                "auth": "app",
+                "app_id": "1",
+                "installation_id": "2",
+                "private_key_secret": "PEM",
+                "webhook_mention": "kindralai",
+            }
+        },
+    )
+    cap = await _run(agent, bot, monkeypatch)
+    env = cap["tool_env"]
+    assert env["GH_TOKEN"] == "app-token"
+    assert env["GIT_AUTHOR_NAME"] == "kindralai[bot]"
+    assert env["GIT_COMMITTER_EMAIL"] == "kindralai[bot]@users.noreply.github.com"
+    # A PAT agent (no own app) gets no forced git identity.
+    pat = Agent(name="hopper", tool_config={"gh": {"enabled": True}})
+    cap2 = await _run(agent, pat, monkeypatch)
+    assert "GIT_AUTHOR_NAME" not in cap2["tool_env"]
 
 
 async def test_agent_gh_disabled_strips_owner_token(agent: AgentCore, monkeypatch) -> None:

--- a/humux/tests/test_github_app.py
+++ b/humux/tests/test_github_app.py
@@ -16,7 +16,7 @@ from core.agent import _narrow_gh_repos
 from core.agents import Agent
 from core.config import Config
 from core.config_store import ConfigStore
-from core.tools import _gh_env, effective_tool_env, github_repo_violation
+from core.tools import GH_NO_IDENTITY, _gh_env, effective_tool_env, github_repo_violation
 
 AUTH = {"Authorization": "Bearer secret"}
 
@@ -162,7 +162,8 @@ def test_agent_own_app_mint_failure_does_not_cross_to_system(monkeypatch) -> Non
             }
         },
     )
-    assert "GH_TOKEN" not in effective_tool_env(cfg, coder, {"CODER_KEY": "pem"}.get)
+    # Fail-closed (#263): the sentinel, never absent (absent = ambient auth).
+    assert effective_tool_env(cfg, coder, {"CODER_KEY": "pem"}.get)["GH_TOKEN"] == GH_NO_IDENTITY
 
 
 def test_legacy_auth_own_app_mint_failure_does_not_cross_to_system(monkeypatch) -> None:
@@ -181,7 +182,8 @@ def test_legacy_auth_own_app_mint_failure_does_not_cross_to_system(monkeypatch) 
             }
         },
     )
-    assert "GH_TOKEN" not in effective_tool_env(cfg, coder, {"CODER_KEY": "pem"}.get)
+    # Fail-closed (#263): the sentinel, never absent (absent = ambient auth).
+    assert effective_tool_env(cfg, coder, {"CODER_KEY": "pem"}.get)["GH_TOKEN"] == GH_NO_IDENTITY
 
 
 def test_agent_auth_pat_never_uses_app(monkeypatch) -> None:
@@ -193,7 +195,7 @@ def test_agent_auth_pat_never_uses_app(monkeypatch) -> None:
     assert effective_tool_env(cfg, p, vault.get)["GH_TOKEN"] == "pat-tok"
     # Explicit PAT with no token → nothing (never the App bot, never the owner).
     none = Agent(name="none", tool_config={"gh": {"enabled": True, "auth": "pat"}})
-    assert "GH_TOKEN" not in effective_tool_env(cfg, none, lambda _n: None)
+    assert effective_tool_env(cfg, none, lambda _n: None)["GH_TOKEN"] == GH_NO_IDENTITY
 
 
 def test_system_auth_pat_disables_app(monkeypatch) -> None:
@@ -205,7 +207,7 @@ def test_system_auth_pat_disables_app(monkeypatch) -> None:
     assert _gh_env(cfg) == {"GH_TOKEN": "sys-pat"}
     # And the App bot is not offered to agents.
     atlas = Agent(name="atlas", tool_config={"gh": {"enabled": True}})
-    assert "GH_TOKEN" not in effective_tool_env(cfg, atlas, lambda _n: None)
+    assert effective_tool_env(cfg, atlas, lambda _n: None)["GH_TOKEN"] == GH_NO_IDENTITY
 
 
 def test_gh_env_auth_app_uses_app(monkeypatch) -> None:

--- a/humux/tests/test_permissions.py
+++ b/humux/tests/test_permissions.py
@@ -31,6 +31,16 @@ def test_unknown_action_defaults_to_ask() -> None:
     assert engine.check("send_fax", {}) == PermissionLevel.ASK
 
 
+def test_gh_auth_mutations_are_never(tmp_path) -> None:
+    # gh auth login/logout/setup-git/refresh mutate SHARED container auth state
+    # and `gh auth token` prints the secret (#263); status stays readable.
+    engine = PermissionEngine()
+    for sub in ("login", "logout", "setup-git", "refresh", "token"):
+        got = engine.check("bash", {"command": f"gh auth {sub}"})
+        assert got == PermissionLevel.NEVER, sub
+    assert engine.check("bash", {"command": "gh auth status"}) == PermissionLevel.ALWAYS
+
+
 @pytest.mark.asyncio
 async def test_approval_request_lifecycle() -> None:
     engine = PermissionEngine()


### PR DESCRIPTION
Closes #263. Found live: the autoproduct fleet produced issues, PR comments, and commits authored as the OWNER instead of the agents' `<app>[bot]` identities.

Three fixes, one invariant — *an agent acts as its own identity or fails loudly, never as whoever the container happens to be logged in as*:

- **Fail closed on unresolved identity.** When `_agent_gh_token` returns nothing (App mint failure, missing vault secret), `effective_tool_env` previously left `GH_TOKEN` unset — and `gh`/`git` silently fell back to ambient auth (`hosts.yml`, a `gh auth setup-git` global credential helper). Now it sets an invalid sentinel (`humux-no-identity`) plus a warning log, so gh fails with Bad credentials instead of impersonating.
- **`gh auth` NEVER rails.** `login`/`logout`/`setup-git`/`refresh` mutate shared container auth state — one agent's login becomes every agent's ambient identity (an agent ran `setup-git` mid-turn in the observed incident); `gh auth token` prints the secret into the transcript. All five blocked; `gh auth status` stays readable.
- **Bot git authorship.** An agent applied the owner's commit-email preference in a bot workspace, shipping bot commits authored as the owner. Agents with their own App now get `GIT_AUTHOR_*`/`GIT_COMMITTER_*` forced to `<slug>[bot]` / `<slug>[bot]@users.noreply.github.com` (slug from `webhook_mention`) — env beats any `git config user.*`, so the model can't override it. (Plain noreply form: display-correct; avatar-linking would need the bot's user id, unknowable offline.)

Tests: sentinel on all no-crossover paths (4 existing assertions strengthened from "absent" to "fail-closed"), git authorship injection + PAT-agent exclusion, NEVER rails incl. `gh auth status` staying ALWAYS. Suite 1049 green, ruff clean.