### PR TITLE
webhook: steer in-flight turns with busy-thread events

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -778,12 +778,19 @@ async def _execute_webhook_turn(
         # reference something it has no memory of. The turn's record lives on
         # GitHub and in the thread chat; the agent reaches the owner with
         # send_message when something genuinely needs them.
+        # steerable (#266): if this thread's previous turn is still running, the
+        # event (with its fresh digest) is injected INTO that turn between tool
+        # rounds instead of queueing behind it — the working agent learns about
+        # the new comment now, not after redoing the thread from stale premises.
+        # If the turn finishes before draining it, the event runs as its own
+        # turn, unchanged.
         response = await core.process(
             message=task,
             channel="system",
             user_id="github",
             chat_id=chat_id,
             agent_name=agent_name,
+            steerable=True,
         )
         text = (response.text or "").strip()
         if text:

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -1078,8 +1078,15 @@ class AgentCore:
         respond: bool = True,
         addressed: bool = True,
         message_id: int | None = None,
+        steerable: bool = False,
     ) -> AgentResponse:
         """Serialize concurrent turns of one chat, then run the turn.
+
+        ``steerable=True`` opts a system-channel caller into mid-turn steering
+        (#266): the GitHub webhook passes it so an event landing on a thread
+        whose turn is still running is injected into THAT turn instead of
+        queueing behind it and re-running from stale premises. Chat channels
+        steer via the addressed-follow-up rule regardless of this flag.
 
         A single ``(channel, user_id, chat_id)`` is one conversation, and its
         turns share in-memory history/session caches. When two inbound messages
@@ -1113,10 +1120,9 @@ class AgentCore:
         # turn so a late steer is never lost.
         key = (channel, user_id, chat_id)
         steer_entry: dict | None = None
+        chat_steer = respond and addressed and channel != "system"
         if (
-            respond
-            and addressed
-            and channel != "system"
+            (chat_steer or steerable)
             and not _control_command(message)
             and self._active_turns_map().get(key) is not None
         ):
@@ -1193,8 +1199,11 @@ class AgentCore:
         text only — a steer's attachments are dropped; if it wasn't consumed its own
         turn still carries them, and mid-turn image steers are rare enough to defer."""
         joined = "\n\n".join(e["text"] for e in entries)
+        # Neutral label (#266): a steer may be a user's follow-up OR an inbound
+        # event (a GitHub comment on the thread being worked) — "the user said"
+        # would misattribute the latter.
         text = (
-            "[The user sent a follow-up while you were working:]\n"
+            "[A follow-up arrived while you were working:]\n"
             f"<steering_message>\n{joined}\n</steering_message>\n"
             "Continue your current task taking this into account."
         )

--- a/humux/tests/test_github_webhook.py
+++ b/humux/tests/test_github_webhook.py
@@ -404,6 +404,7 @@ def test_webhook_runs_turn_in_background(monkeypatch) -> None:
     assert kwargs["agent_name"] == "dev"
     assert kwargs["chat_id"] == "github:dev:acme/widgets#7"  # agent-scoped (#244)
     assert kwargs["channel"] == "system"
+    assert kwargs["steerable"] is True  # busy-thread events steer the running turn (#266)
 
 
 PR_PAYLOAD = {

--- a/humux/tests/test_steer.py
+++ b/humux/tests/test_steer.py
@@ -225,3 +225,63 @@ async def test_idle_message_is_not_a_steer(agent) -> None:
     resp = await agent.process("do a thing", "telegram", "u", chat_id="9")
     assert resp.text == "normal" and called["msg"] == "do a thing"
     assert not agent._steer_map().get(key)  # nothing buffered
+
+
+@pytest.mark.asyncio
+async def test_webhook_event_steers_running_turn_when_steerable(agent) -> None:
+    # #266: a GitHub event landing on a thread whose turn is still running is
+    # injected into THAT turn (steerable=True), not queued as a duplicate.
+    agent.llm = _RecordingLLM(rounds=3)
+    agent.channels = {}
+
+    async def fake_tool(call, channel, user_id, request_state):
+        await asyncio.sleep(0.01)
+        return {"ok": True}
+
+    agent._execute_tool = fake_tool
+    chat = "github:dev:acme/widgets#7"
+    key = ("system", "github", chat)
+    turn = asyncio.create_task(
+        agent.process("[GitHub] issue opened: build it", "system", "github", chat_id=chat)
+    )
+    await _wait_active(agent, key, turn)
+
+    steer = await agent.process(
+        "[GitHub] new comment: also cover the empty case",
+        "system",
+        "github",
+        chat_id=chat,
+        steerable=True,
+    )
+    assert steer.text == ""  # consumed by the running turn
+
+    resp = await asyncio.wait_for(turn, timeout=3)
+    assert resp.text == "done"
+    flat = "".join(str(m.get("content")) for seen in agent.llm.seen for m in seen)
+    assert "<steering_message>" in flat
+    assert "also cover the empty case" in flat
+
+
+@pytest.mark.asyncio
+async def test_system_without_steerable_queues_not_steers(agent) -> None:
+    # The scheduler and other system callers keep the old behaviour: a second
+    # message for a busy chat waits for the lock and runs as its own turn.
+    agent.llm = _RecordingLLM(rounds=2)
+    agent.channels = {}
+
+    async def fake_tool(call, channel, user_id, request_state):
+        await asyncio.sleep(0.01)
+        return {"ok": True}
+
+    agent._execute_tool = fake_tool
+    key = ("system", "scheduler", "job:1")
+    turn = asyncio.create_task(agent.process("run job", "system", "scheduler", chat_id="job:1"))
+    await _wait_active(agent, key, turn)
+
+    follow = asyncio.create_task(
+        agent.process("second event", "system", "scheduler", chat_id="job:1")
+    )
+    assert (await asyncio.wait_for(turn, timeout=3)).text == "done"
+    assert (await asyncio.wait_for(follow, timeout=3)).text == "done"  # own turn
+    flat = "".join(str(m.get("content")) for seen in agent.llm.seen for m in seen)
+    assert "<steering_message>" not in flat


### PR DESCRIPTION
Closes #266.

When a GitHub event lands on a thread whose turn is still running (a follow-up comment, a re-dispatch), the event is now **injected into the running turn** as a steering message (#145 machinery) instead of queueing behind the per-chat lock and re-running the thread from stale premises.

- The webhook executor calls `process(..., steerable=True)` — an explicit opt-in, so the scheduler and other system-channel callers keep the old queue-behind behaviour.
- Context completeness is free: the executor prepends the fresh thread digest *before* `process()`, so the steer carries the triggering event **plus every comment the running turn hasn't seen**.
- The existing lifecycle covers the races: turn ends before the steer is drained → the event runs as its own turn (never lost); the carrying `generate()` fails → the steer stays unconsumed and falls through likewise.
- The steer label is now source-neutral ("A follow-up arrived while you were working") — it may be a GitHub comment, not the user.
- GitHub-side 👀 ack still fires per event before `process()`, so a steered comment shows pickup in the UI too.

Tests: steerable system-channel event injected into a running turn; scheduler-style system caller still queues (no steer); route passes `steerable=True`. Suite 1049 green, ruff clean.