### PR TITLE
webhook: lifecycle reactions — 🚀 turn done, 😕 turn crashed

### DIFF
--- a/docs/content/docs/extending.mdx
+++ b/docs/content/docs/extending.mdx
@@ -224,10 +224,14 @@ same repos:
 - **Rate cap** (`gh: {..., webhook_rate_limit: 20}`) — max webhook turns per thread
   per hour (default 20). Author gates stop loops; this stops storms between mutually
   allowlisted bots.
-- **Start-of-work ack** (`gh: {..., webhook_ack: false}` to disable) — by default,
-  the agent reacts 👀 on the triggering issue, PR or comment as its turn starts, so
-  the GitHub UI shows the event was picked up before any comment lands. Reviews get
-  the reaction on their PR (reviews have no reactions API); CI runs get none.
+- **Lifecycle acks** (`gh: {..., webhook_ack: false}` to disable) — by default the
+  agent reacts on the triggering issue, PR or comment: 👀 as its turn starts (picked
+  up), 🚀 when the turn completes, 😕 when it crashes — the whole lifecycle is
+  visible on the thread without tailing logs. Posted by the runtime, never the
+  model (no tool calls, no context cost). An event that steered a running turn gets
+  its 🚀 when that turn ends. Reviews get the reactions on their PR (reviews have no
+  reactions API); CI runs get none. (GitHub's reaction set has no checkmark — rocket
+  is the closest "done".)
 - **Thread digest** (`gh: {..., webhook_digest: false}` to disable) — by default,
   each webhook turn is prefixed with the thread's current state fetched live from
   GitHub (title/state/labels/milestone/assignees + the last 10 comments) using the

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -739,18 +739,24 @@ async def _execute_webhook_turn(
     (auto-approved writes, no confirmation round-trips — nobody can answer one
     on a webhook). chat_id keeps per-thread continuity.
     """
+
+    async def _mint() -> str | None:
+        """Fresh installation token (cached ~1h in core.github_app); best-effort."""
+        try:
+            from core.tools import _agent_gh_token
+
+            agent = await core.agents.get(agent_name)
+            resolve = secret_store.infra_resolve if secret_store else (lambda _n: None)
+            return _agent_gh_token(gh, agent_name, core.config, resolve) if agent else None
+        except Exception:  # noqa: BLE001 — ack/digest are best-effort extras
+            log.exception("webhook token mint failed (agent=%s)", agent_name)
+            return None
+
+    want_ack = bool(ack) and gh.get("webhook_ack", True)
     try:
-        want_ack = bool(ack) and gh.get("webhook_ack", True)
         token = None
         if want_ack or gh.get("webhook_digest", True):
-            try:
-                from core.tools import _agent_gh_token
-
-                agent = await core.agents.get(agent_name)
-                resolve = secret_store.infra_resolve if secret_store else (lambda _n: None)
-                token = _agent_gh_token(gh, agent_name, core.config, resolve) if agent else None
-            except Exception:  # noqa: BLE001 — ack/digest are best-effort extras
-                log.exception("webhook token mint failed (agent=%s)", agent_name)
+            token = await _mint()
         # 👀 ack (#241): a visible "an agent is on it" in the GitHub UI, with
         # the agent's own identity, before the (slow) turn runs.
         if want_ack and token:
@@ -797,6 +803,17 @@ async def _execute_webhook_turn(
             log.debug("webhook turn reply discarded (agent=%s chat=%s)", agent_name, chat_id)
         if delivery:
             _gh_wal_remove(delivery)
+        # Turn-done ack (#268): 🚀 on the same item the 👀 landed on — the
+        # thread shows picked-up AND finished without tailing logs. For a
+        # steered event this executor resumed only when the carrying turn
+        # ended (it waits on the chat lock), so its own target closes at the
+        # right moment too. Re-mint: a long turn can outlive the ~1h token.
+        if want_ack:
+            from core import github_digest
+
+            token = await _mint()
+            if token:
+                await github_digest.ack_reaction(ack, token, content="rocket")
     except Exception:
         # Forget the GUID so GitHub's "Redeliver" can retry a failed turn (a
         # completed turn stays deduped). Drop the WAL entry too: the turn's
@@ -806,6 +823,14 @@ async def _execute_webhook_turn(
         if delivery:
             _gh_wal_remove(delivery)
         log.exception("GitHub webhook turn failed (agent=%s)", agent_name)
+        # Failure ack (#268): 😕 — the turn DIED, visible on the thread instead
+        # of only in the logs. Best-effort like every reaction.
+        if want_ack:
+            from core import github_digest
+
+            token = await _mint()
+            if token:
+                await github_digest.ack_reaction(ack, token, content="confused")
 
 
 async def replay_webhook_deliveries(agent_state, secret_store) -> int:

--- a/humux/tests/test_github_webhook.py
+++ b/humux/tests/test_github_webhook.py
@@ -729,10 +729,10 @@ def test_webhook_ack_reaction_posted(monkeypatch) -> None:
     from core import github_digest, tools
 
     monkeypatch.setattr(tools, "_agent_gh_token", lambda *a, **k: "tok-123")
-    acked: dict = {}
+    acked: list = []
 
     async def fake_ack(target, token, content="eyes"):
-        acked.update(target=target, token=token, content=content)
+        acked.append({"target": target, "token": token, "content": content})
         return True
 
     monkeypatch.setattr(github_digest, "ack_reaction", fake_ack)
@@ -740,18 +740,24 @@ def test_webhook_ack_reaction_posted(monkeypatch) -> None:
     core.config = SimpleNamespace()  # token mint is stubbed; config is opaque
     assert _post(client, ISSUE_PAYLOAD).status_code == 202
     asyncio.run(captured[0])
-    assert acked == {
-        "target": "repos/acme/widgets/issues/7/reactions",
-        "token": "tok-123",
-        "content": "eyes",
-    }
-    core.process.assert_awaited_once()  # ack rides the turn, never replaces it
-    # Disabled → no reaction even though a target exists.
+    # Lifecycle (#241/#268): 👀 when picked up, 🚀 when the turn completes —
+    # both on the same target, both from the executor (never the model).
+    assert [a["content"] for a in acked] == ["eyes", "rocket"]
+    assert all(a["target"] == "repos/acme/widgets/issues/7/reactions" for a in acked)
+    assert all(a["token"] == "tok-123" for a in acked)
+    core.process.assert_awaited_once()  # acks ride the turn, never replace it
+    # A crashed turn closes with 😕 instead of 🚀 (#268).
+    acked.clear()
+    core.process = AsyncMock(side_effect=RuntimeError("boom"))
+    assert _post(client, ISSUE_PAYLOAD).status_code == 202
+    asyncio.run(captured[1])
+    assert [a["content"] for a in acked] == ["eyes", "confused"]
+    # Disabled → no reactions even though a target exists.
     acked.clear()
     client2, core2 = _client(agent=_agent(webhook_ack=False))
     assert _post(client2, ISSUE_PAYLOAD).status_code == 202
-    asyncio.run(captured[1])
-    assert acked == {}
+    asyncio.run(captured[2])
+    assert acked == []
 
 
 def test_resolve_chat_titles() -> None:


### PR DESCRIPTION
Closes #268.

The 👀 pickup ack gets its closing half: when the webhook turn ends, the executor reacts **🚀** on the same item the 👀 landed on; when the turn raises, it reacts **😕** — failures become visible on the thread instead of only in humux logs. (GitHub's reaction set has no checkmark/target — of the eight available, rocket is the closest "done" and confused the clearest "broke".)

Design points, matching the concerns raised:

- **Zero context pollution**: reactions are posted by `_execute_webhook_turn`, mechanically — the model never sees them, no tool calls, nothing prompted.
- **Steering handled with no bookkeeping**: a steered delivery's executor blocks on the chat lock until the carrying turn finishes, so when its `process()` returns (steer consumed) it closes its OWN 👀-target. Every acked message gets its 🚀 from its own executor, at the moment the turn that absorbed it actually ended.
- **Which message**: always the 👀 target — trigger comment, issue, or PR — so the full lifecycle reads in one place: 👀 → work → 🚀/😕.
- Token is re-minted for the closing reaction (cached ~1h in `core.github_app`, so this is a dict hit normally) — a long steered turn can outlive the original token.
- Same `webhook_ack` toggle governs 👀/🚀/😕 together.

Tests: success lifecycle `["eyes", "rocket"]`, crash lifecycle `["eyes", "confused"]`, disabled = no reactions. Suite 1049 green, ruff clean. Docs: extending.mdx ack bullet → lifecycle description.