### PR TITLE
fix: Sidecar CDP URL not used by browser test endpoint (#264)

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -2356,6 +2356,10 @@ def create_admin_app(
         profile = str(body.get("profile", "")).strip() or "default"
         root = Path(__file__).resolve().parent.parent
         # Subprocess, not in-process: the sync Playwright API can't run in this event loop.
+        browser_cdp = (await config_store.get("tools.browser.cdp_url")) or ""
+        test_env = {**os.environ, "BROWSER_HEADLESS": "1"}
+        if browser_cdp:
+            test_env["BROWSER_CDP_URL"] = browser_cdp
         try:
             proc = await asyncio.create_subprocess_exec(
                 sys.executable,
@@ -2368,7 +2372,7 @@ def create_admin_app(
                 cwd=str(root),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                env={**os.environ, "BROWSER_HEADLESS": "1"},
+                env=test_env,
             )
             out, err = await asyncio.wait_for(proc.communicate(), timeout=60)
         except TimeoutError:


### PR DESCRIPTION
## Problem

The **Sidecar CDP URL** field (`tools.browser.cdp_url`) on the Tools tab is ignored by the browser test endpoint (`POST /tools/browser/test`). The subprocess env only injected `BROWSER_HEADLESS` — `BROWSER_CDP_URL` was never set, so the CDP URL saved via the UI had no effect on the test.

## Solution

Read `tools.browser.cdp_url` from the config store and inject `BROWSER_CDP_URL` into the test subprocess environment when the value is non-empty. The test env now matches what the main execution path (`tool_env` → `_browser_env`) produces.

The main execution path already works: `_browser_env()` reads `config.tools.browser.cdp_url`, and `patch_config` rebuilds `tool_env` on save (line 2890). No fix needed there.

## Acceptance criteria

- [x] Test endpoint injects `BROWSER_CDP_URL` from config into the browser subprocess
- [x] LLM-invoked browser commands already pick up the CDP URL saved via the UI (`_browser_env` → `tool_env` → `effective_tool_env`)
- [x] No regression for `BROWSER_CDP_URL` set via `.env` / Docker env (falls through to `os.environ`)

Closes #264