### PR TITLE
Add pagination to the Skills tab

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1790,11 +1790,42 @@ def create_admin_app(
         return await _render_permissions(scope)
 
     @app.get("/partials/skills", dependencies=[Depends(auth)])
-    async def partial_skills() -> HTMLResponse:
-        """Skills tab partial."""
+    async def partial_skills(
+        offset: int = 0,
+        limit: int = 25,
+    ) -> HTMLResponse:
+        """Skills tab partial with server-side pagination."""
         store = await _skills_store_from_config(config_store)
-        skills = await store.list_skills()
-        return _render_partial("partials/skills.html", skills=skills)
+        skills = await store.list_skills(offset=offset, limit=limit)
+        total = await store.count_skills()
+
+        # Precompute pagination info for the template.
+        total_pages = max(1, (total + limit - 1) // limit) if total > 0 else 1
+        current_page = (offset // limit) + 1 if limit > 0 else 1
+
+        # Build a list of visible page numbers for the nav bar.
+        max_visible = 8
+        half = max_visible // 2
+        start_p = max(1, current_page - half)
+        end_p = min(total_pages, start_p + max_visible - 1)
+        start_p = max(1, end_p - max_visible + 1)
+        page_numbers = list(range(start_p, end_p + 1))
+
+        prev_offset = max(0, offset - limit) if offset > 0 else None
+        next_offset = offset + limit if offset + limit < total else None
+
+        return _render_partial(
+            "partials/skills.html",
+            skills=skills,
+            total=total,
+            offset=offset,
+            limit=limit,
+            total_pages=total_pages,
+            current_page=current_page,
+            page_numbers=page_numbers,
+            prev_offset=prev_offset,
+            next_offset=next_offset,
+        )
 
     @app.get("/partials/agents", dependencies=[Depends(auth)])
     async def partial_agents() -> HTMLResponse:
@@ -3562,8 +3593,9 @@ def create_admin_app(
             await store.upsert_skill(name, content)
         except ValueError as exc:  # installed skill — read-only (#65)
             raise HTTPException(400, str(exc)) from exc
-        skills = await store.list_skills()
-        return _render_partial("partials/skills.html", skills=skills)
+        skills = await store.list_skills(offset=0, limit=25)
+        total = await store.count_skills()
+        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25)
 
     @app.post("/skills/install", dependencies=[Depends(auth)])
     async def install_skill(request: Request) -> HTMLResponse:
@@ -3582,8 +3614,9 @@ def create_admin_app(
             result = await store.install_from_git(url, path)
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
-        skills = await store.list_skills()
-        return _render_partial("partials/skills.html", skills=skills, install_result=result)
+        skills = await store.list_skills(offset=0, limit=25)
+        total = await store.count_skills()
+        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25, install_result=result)
 
     @app.post("/skills/{name}/update", dependencies=[Depends(auth)])
     async def update_skill(name: str) -> HTMLResponse:
@@ -3593,8 +3626,9 @@ def create_admin_app(
             result = await store.update_installed_skill(name)
         except ValueError as exc:
             raise HTTPException(400, str(exc)) from exc
-        skills = await store.list_skills()
-        return _render_partial("partials/skills.html", skills=skills, install_result=result)
+        skills = await store.list_skills(offset=0, limit=25)
+        total = await store.count_skills()
+        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25, install_result=result)
 
     @app.post("/skills/delete", dependencies=[Depends(auth)])
     async def delete_skill(request: Request) -> HTMLResponse:
@@ -3610,8 +3644,9 @@ def create_admin_app(
         deleted = await store.delete_skill(name)
         if not deleted:
             raise HTTPException(404, f"Skill not found: {name}")
-        skills = await store.list_skills()
-        return _render_partial("partials/skills.html", skills=skills)
+        skills = await store.list_skills(offset=0, limit=25)
+        total = await store.count_skills()
+        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25)
 
     @app.post("/skills/{name}/reset", dependencies=[Depends(auth)])
     async def reset_skill(name: str) -> HTMLResponse:
@@ -3623,8 +3658,9 @@ def create_admin_app(
             skill = await store.get_skill(name)
             if not skill:
                 raise HTTPException(404, f"Skill not found: {name}")
-        skills = await store.list_skills()
-        return _render_partial("partials/skills.html", skills=skills)
+        skills = await store.list_skills(offset=0, limit=25)
+        total = await store.count_skills()
+        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25)
 
     @app.post("/skills/validate", dependencies=[Depends(auth)])
     async def validate_skill(body: SkillUpsertIn) -> dict:

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -3595,7 +3595,10 @@ def create_admin_app(
             raise HTTPException(400, str(exc)) from exc
         skills = await store.list_skills(offset=0, limit=25)
         total = await store.count_skills()
-        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25)
+        return _render_partial(
+            "partials/skills.html",
+            skills=skills, total=total, offset=0, limit=25,
+        )
 
     @app.post("/skills/install", dependencies=[Depends(auth)])
     async def install_skill(request: Request) -> HTMLResponse:
@@ -3616,7 +3619,11 @@ def create_admin_app(
             raise HTTPException(400, str(exc)) from exc
         skills = await store.list_skills(offset=0, limit=25)
         total = await store.count_skills()
-        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25, install_result=result)
+        return _render_partial(
+            "partials/skills.html",
+            skills=skills, total=total, offset=0, limit=25,
+            install_result=result,
+        )
 
     @app.post("/skills/{name}/update", dependencies=[Depends(auth)])
     async def update_skill(name: str) -> HTMLResponse:
@@ -3628,7 +3635,11 @@ def create_admin_app(
             raise HTTPException(400, str(exc)) from exc
         skills = await store.list_skills(offset=0, limit=25)
         total = await store.count_skills()
-        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25, install_result=result)
+        return _render_partial(
+            "partials/skills.html",
+            skills=skills, total=total, offset=0, limit=25,
+            install_result=result,
+        )
 
     @app.post("/skills/delete", dependencies=[Depends(auth)])
     async def delete_skill(request: Request) -> HTMLResponse:
@@ -3646,7 +3657,10 @@ def create_admin_app(
             raise HTTPException(404, f"Skill not found: {name}")
         skills = await store.list_skills(offset=0, limit=25)
         total = await store.count_skills()
-        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25)
+        return _render_partial(
+            "partials/skills.html",
+            skills=skills, total=total, offset=0, limit=25,
+        )
 
     @app.post("/skills/{name}/reset", dependencies=[Depends(auth)])
     async def reset_skill(name: str) -> HTMLResponse:
@@ -3660,7 +3674,10 @@ def create_admin_app(
                 raise HTTPException(404, f"Skill not found: {name}")
         skills = await store.list_skills(offset=0, limit=25)
         total = await store.count_skills()
-        return _render_partial("partials/skills.html", skills=skills, total=total, offset=0, limit=25)
+        return _render_partial(
+            "partials/skills.html",
+            skills=skills, total=total, offset=0, limit=25,
+        )
 
     @app.post("/skills/validate", dependencies=[Depends(auth)])
     async def validate_skill(body: SkillUpsertIn) -> dict:

--- a/humux/api/templates/partials/skills.html
+++ b/humux/api/templates/partials/skills.html
@@ -1,12 +1,14 @@
-{# Skills tab partial #}
-<div x-data="{ filter: '' }">
+{# Skills tab partial with server-side pagination #}
+<div x-data="{ filter: '', pageSize: {{ limit }} }">
   <div class="flex items-center gap-2 mb-4 flex-wrap">
-    <button class="btn btn-sm" hx-get="/partials/skills" hx-target="#tab-content" hx-swap="innerHTML">
+    <button class="btn btn-sm" hx-get="/partials/skills?offset=0&amp;limit={{ limit }}" hx-target="#tab-content" hx-swap="innerHTML">
       Refresh
     </button>
     <input type="text" class="input-sm flex-1" style="max-width:300px"
            placeholder="Filter skills..." x-model="filter" id="filter-skills" aria-label="Filter skills">
-    <span class="text-muted text-xs">{{ skills|length }} skills</span>
+    <span class="text-muted text-xs">{{ skills|length }} shown</span>
+    <span class="text-muted text-xs">&middot;</span>
+    <span class="text-muted text-xs">{{ total }} total</span>
   </div>
 
   <div class="overflow-x-auto">
@@ -36,15 +38,15 @@
                     hx-post="/skills/{{ skill.name }}/update" hx-target="#tab-content" hx-swap="innerHTML"
                     title="Re-install from {{ skill.origin }}"
                     hx-confirm="Update &quot;{{ skill.name }}&quot; from its origin repo?">
-              ⟳
+              &#8635;
             </button>
             {% endif %}
             {% if skill.stale_seed %}
             <button class="btn-outline btn-sm ml-0.5"
                     hx-post="/skills/{{ skill.name }}/reset" hx-target="#tab-content" hx-swap="innerHTML"
-                    title="Seed file changed — reset to original"
+                    title="Seed file changed &mdash; reset to original"
                     hx-confirm="Reset &quot;{{ skill.name }}&quot; to the seed version?">
-              ↺
+              &#8634;
             </button>
             {% endif %}
             <button class="btn-danger btn-sm ml-0.5"
@@ -62,6 +64,64 @@
       </tbody>
     </table>
   </div>
+
+  {# Pagination controls #}
+  {% if total > 0 %}
+  <div class="flex items-center justify-between mt-4 flex-wrap gap-2">
+    {# Left: page size selector #}
+    <div class="flex items-center gap-2">
+      <label for="page-size" class="text-xs text-muted">Show</label>
+      <select id="page-size" class="input-sm text-xs"
+              onchange="htmx.ajax('GET', '/partials/skills?offset=0&amp;limit=' + this.value, {target:'#tab-content', swap:'innerHTML'})">
+        <option value="10"{% if limit == 10 %} selected{% endif %}>10</option>
+        <option value="25"{% if limit == 25 %} selected{% endif %}>25</option>
+        <option value="50"{% if limit == 50 %} selected{% endif %}>50</option>
+        <option value="100"{% if limit == 100 %} selected{% endif %}>100</option>
+      </select>
+      <span class="text-muted text-xs">per page</span>
+    </div>
+
+    {# Centre: "Showing X–Y of Z" #}
+    <span class="text-muted text-xs">
+      {% set showing_end = offset + skills|length %}
+      Showing {{ offset + 1 }}&ndash;{{ showing_end }} of {{ total }}
+    </span>
+
+    {# Right: page buttons #}
+    <div class="flex items-center gap-1">
+      {% if prev_offset is not none %}
+      <button class="btn btn-sm"
+              hx-get="/partials/skills?offset={{ prev_offset }}&amp;limit={{ limit }}"
+              hx-target="#tab-content" hx-swap="innerHTML">
+        &laquo; Prev
+      </button>
+      {% else %}
+      <button class="btn btn-sm opacity-40" disabled>&laquo; Prev</button>
+      {% endif %}
+
+      {% for p in page_numbers %}
+        {% set p_offset = (p - 1) * limit %}
+        {% if p == current_page %}
+        <button class="btn btn-sm btn-primary" disabled>{{ p }}</button>
+        {% else %}
+        <button class="btn btn-sm btn-ghost"
+                hx-get="/partials/skills?offset={{ p_offset }}&amp;limit={{ limit }}"
+                hx-target="#tab-content" hx-swap="innerHTML">{{ p }}</button>
+        {% endif %}
+      {% endfor %}
+
+      {% if next_offset is not none %}
+      <button class="btn btn-sm"
+              hx-get="/partials/skills?offset={{ next_offset }}&amp;limit={{ limit }}"
+              hx-target="#tab-content" hx-swap="innerHTML">
+        Next &raquo;
+      </button>
+      {% else %}
+      <button class="btn btn-sm opacity-40" disabled>Next &raquo;</button>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
 
   <div class="mt-5 flex items-center gap-2">
     <a class="btn btn-sm" href="/admin/skills/new">Create new skill</a>

--- a/humux/core/skills.py
+++ b/humux/core/skills.py
@@ -292,14 +292,22 @@ class SkillsStore:
             await db.commit()
             return True
 
-    async def list_skills(self) -> list[dict]:
+    async def list_skills(self, offset: int | None = None, limit: int | None = None) -> list[dict]:
         await self.ensure_seeded()
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
-            cursor = await db.execute(
+            query = (
                 "SELECT name, summary, content, seed_hash, origin, updated_at"
                 " FROM skills ORDER BY name"
             )
+            params: list[int] = []
+            if limit is not None:
+                query += " LIMIT ?"
+                params.append(limit)
+            if offset is not None:
+                query += " OFFSET ?"
+                params.append(offset)
+            cursor = await db.execute(query, params)
             rows = [dict(row) for row in await cursor.fetchall()]
         # Annotate each row with whether the seed has drifted.
         for r in rows:
@@ -309,6 +317,14 @@ class SkillsStore:
             else:
                 r["stale_seed"] = False
         return rows
+
+    async def count_skills(self) -> int:
+        """Return the total number of skills in the store."""
+        await self.ensure_seeded()
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute("SELECT COUNT(*) FROM skills")
+            row = await cursor.fetchone()
+            return row[0] if row else 0
 
     async def get_skill(self, name: str) -> dict | None:
         await self.ensure_seeded()


### PR DESCRIPTION
## Summary

The Skills tab currently renders every skill in a single flat table with no pagination. This adds server-side pagination using HTMX.

## Changes

### `humux/core/skills.py`
- **`list_skills(offset=None, limit=None)`** — new optional parameters; `None` = unlimited (backward compatible)
- **`count_skills()`** — new method returning total number of skills

### `humux/api/admin.py`
- **`GET /partials/skills`** — accepts `offset` (default 0) and `limit` (default 25) query params; passes `total`, `prev_offset`, `next_offset`, `page_numbers`, `current_page`, `total_pages` to the template
- All mutation routes (upsert, delete, install, update, reset) now reload page 1 with pagination context

### `humux/api/templates/partials/skills.html`
- **Page size selector** — dropdown: 10 / 25 / 50 / 100
- **Page navigation** — Previous (prev) / Next buttons + numbered page links (smart range, max ~8 visible)
- **"Showing X–Y of Z"** counter
- **Client-side Alpine.js filter** — preserved, scoped to current page
- **All navigation uses `hx-get`** with `hx-target="#tab-content"` — instant HTMX swaps

### Acceptance criteria
- [ ] `SkillsStore.list_skills()` accepts `offset` and `limit` (default unlimited for backward compat)
- [ ] `SkillsStore.count_skills()` returns the total number of skills
- [ ] `GET /partials/skills` accepts `offset` and `limit` query params
- [ ] Pagination controls rendered below the table
- [ ] Page size selector (10/25/50/100)
- [ ] "Showing X–Y of Z" counter
- [ ] Client-side Alpine.js filter still works (scoped to current page)
- [ ] Works on mobile — pagination controls are touch-friendly
- [ ] No regression for the skill editor links or delete buttons

Closes #274