### PR TITLE
memory: split tab into Settings, Long-term, Short-term sub-tabs with pagination and search

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -2416,14 +2416,81 @@ def create_admin_app(
             agent.permissions.remove_rule(pattern)
         return {"ok": True, "rules": _browser_rules()}
 
-    async def _render_memory_partial() -> HTMLResponse:
-        """Build the Memory tab partial (config + stored memories).
+    async def _fetch_memories_paginated(
+        memory_db: str, tier: str, offset: int, limit: int, q: str | None = None
+    ) -> tuple[list[dict], int]:
+        """Fetch a paginated slice of memory entries with optional search.
 
-        Shared by the tab load and the post-delete refresh so both render the
-        full embedding/lifecycle config, not just the memory tables.
+        Returns (entries, total_count).
         """
         import aiosqlite
 
+        entries: list[dict] = []
+        total = 0
+        if not Path(memory_db).exists():
+            return entries, total
+
+        from core.memory import MemoryStore
+        await MemoryStore(db_path=memory_db)._ensure_schema()
+
+        if tier == "long-term":
+            cols = "id, category, subject, content, source, confidence, created_at, updated_at, scope"
+            table = "long_term"
+            base_where = ""
+            order = "updated_at DESC"
+        elif tier == "short-term":
+            cols = "id, content, context, expires_at, created_at, scope"
+            table = "short_term"
+            base_where = "expires_at > datetime('now')"
+            order = "created_at DESC"
+        else:
+            return entries, total
+
+        search_clause = ""
+        params: list[str] = []
+        if q:
+            like_q = f"%{q}%"
+            if tier == "long-term":
+                search_clause = "AND (content LIKE ? OR subject LIKE ? OR category LIKE ?)"
+                params = [like_q, like_q, like_q]
+            else:
+                search_clause = "AND content LIKE ?"
+                params = [like_q]
+
+        where_parts = [p for p in [base_where] if p]
+        where_clause = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+        if search_clause and where_parts:
+            where_clause += " " + search_clause.lstrip()
+        elif search_clause:
+            where_clause = search_clause
+
+        async with aiosqlite.connect(memory_db) as db:
+            db.row_factory = aiosqlite.Row
+
+            # Total count
+            count_sql = f"SELECT COUNT(*) as cnt FROM {table} {where_clause}"
+            cursor = await db.execute(count_sql, params)
+            row = await cursor.fetchone()
+            if row:
+                total = row["cnt"]
+
+            # Paginated rows
+            data_sql = f"SELECT {cols} FROM {table} {where_clause} ORDER BY {order} LIMIT ? OFFSET ?"
+            cursor = await db.execute(data_sql, params + [str(limit), str(offset)])
+            entries = [dict(row) for row in await cursor.fetchall()]
+
+        return entries, total
+
+    async def _render_memory_partial(
+        view: str = "settings",
+        offset: int = 0,
+        limit: int = 25,
+        q: str | None = None,
+    ) -> HTMLResponse:
+        """Build the Memory tab partial for the given sub-tab view.
+
+        Shared by the tab load, pagination, search, and post-delete/update refresh.
+        """
         async def _cfg(key: str, default: str) -> str:
             val = await config_store.get(key)
             return default if val is None or val == "" else str(val)
@@ -2432,7 +2499,15 @@ def create_admin_app(
             val = await config_store.get(key)
             return default if val is None else str(val).lower()
 
+        allowed_views = ("settings", "long-term", "short-term")
+        if view not in allowed_views:
+            view = "settings"
+
         ctx: dict[str, object] = {
+            "memory_view": view,
+            "memory_offset": offset,
+            "memory_limit": limit,
+            "memory_q": q or "",
             "memory_long_term_limit": await _cfg("memory.long_term_limit", "50"),
             "emb_enabled": await _bool("memory.embedding.enabled", "true"),
             "emb_provider": await _cfg("memory.embedding.provider", "sidecar"),
@@ -2452,38 +2527,39 @@ def create_admin_app(
         agent_store = await _agent_store_from_config(config_store)
         ctx["agent_slugs"] = [a.name for a in await agent_store.list_agents()]
 
-        # Memory data — read directly from DB (works even when agent is stopped)
         memory_db = await config_store.get("memory.db_path") or "data/memory.db"
-        long_term: list[dict] = []
-        short_term: list[dict] = []
-        if Path(memory_db).exists():
-            # Idempotent migrate-on-read so a legacy DB has the scope column (#42)
-            # even when no agent is running to have migrated it on startup.
-            from core.memory import MemoryStore
 
-            await MemoryStore(db_path=memory_db)._ensure_schema()
-            cols = (
-                "id, category, subject, content, source, confidence, created_at, updated_at, scope"
-            )
-            async with aiosqlite.connect(memory_db) as db:
-                db.row_factory = aiosqlite.Row
-                cursor = await db.execute(f"SELECT {cols} FROM long_term ORDER BY updated_at DESC")
-                long_term = [dict(row) for row in await cursor.fetchall()]
-                cursor = await db.execute(
-                    "SELECT id, content, context, expires_at, created_at, scope "
-                    "FROM short_term WHERE expires_at > datetime('now') "
-                    "ORDER BY created_at DESC"
-                )
-                short_term = [dict(row) for row in await cursor.fetchall()]
+        if view == "settings":
+            # Settings view: no memory data needed
+            pass
+        elif view == "long-term":
+            entries, total = await _fetch_memories_paginated(memory_db, "long-term", offset, limit, q)
+            ctx["long_term"] = entries
+            ctx["long_term_total"] = total
+        elif view == "short-term":
+            entries, total = await _fetch_memories_paginated(memory_db, "short-term", offset, limit, q)
+            ctx["short_term"] = entries
+            ctx["short_term_total"] = total
 
-        return _render_partial(
-            "partials/memory.html", long_term=long_term, short_term=short_term, **ctx
-        )
+        return _render_partial("partials/memory.html", **ctx)
 
     @app.get("/partials/memory", dependencies=[Depends(auth)])
-    async def partial_memory() -> HTMLResponse:
-        """Memory tab partial."""
-        return await _render_memory_partial()
+    async def partial_memory(
+        request: Request,
+        view: str = "settings",
+        offset: int = 0,
+        limit: int = 25,
+        q: str | None = None,
+    ) -> HTMLResponse:
+        """Memory tab partial with sub-tab support.
+
+        Query params:
+          view    — sub-tab: settings | long-term | short-term (default: settings)
+          offset  — row offset for pagination (default: 0)
+          limit   — page size (default: 25)
+          q       — search query to filter by content/subject/category
+        """
+        return await _render_memory_partial(view=view, offset=offset, limit=limit, q=q)
 
     async def _history_ctx() -> dict:
         """History + compaction config, shared by the History sub-tab of the LLM
@@ -4023,8 +4099,8 @@ def create_admin_app(
             if cursor.rowcount == 0:
                 raise HTTPException(404, f"Memory {memory_id} not found in {tier}")
 
-        # Return refreshed memory partial (full config + tables)
-        return await _render_memory_partial()
+        # Return refreshed sub-view based on the deleted tier
+        return await _render_memory_partial(view=tier)
 
     @app.post("/memory/update", dependencies=[Depends(auth)])
     async def update_memory(request: Request) -> HTMLResponse:
@@ -4067,7 +4143,8 @@ def create_admin_app(
             )
         if rows == 0:
             raise HTTPException(404, f"Memory {memory_id} not found in {tier}")
-        return await _render_memory_partial()
+        # Return refreshed sub-view based on the updated tier
+        return await _render_memory_partial(view=tier)
 
     @app.get("/memory/embedding/status", dependencies=[Depends(auth)])
     async def embedding_status() -> dict:

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -2434,7 +2434,10 @@ def create_admin_app(
         await MemoryStore(db_path=memory_db)._ensure_schema()
 
         if tier == "long-term":
-            cols = "id, category, subject, content, source, confidence, created_at, updated_at, scope"
+            cols = (
+                "id, category, subject, content, source, "
+                "confidence, created_at, updated_at, scope"
+            )
             table = "long_term"
             base_where = ""
             order = "updated_at DESC"
@@ -2462,7 +2465,7 @@ def create_admin_app(
         if search_clause and where_parts:
             where_clause += " " + search_clause.lstrip()
         elif search_clause:
-            where_clause = search_clause
+            where_clause = "WHERE " + search_clause.lstrip("AND ")
 
         async with aiosqlite.connect(memory_db) as db:
             db.row_factory = aiosqlite.Row
@@ -2475,7 +2478,10 @@ def create_admin_app(
                 total = row["cnt"]
 
             # Paginated rows
-            data_sql = f"SELECT {cols} FROM {table} {where_clause} ORDER BY {order} LIMIT ? OFFSET ?"
+            data_sql = (
+                f"SELECT {cols} FROM {table} {where_clause} "
+                f"ORDER BY {order} LIMIT ? OFFSET ?"
+            )
             cursor = await db.execute(data_sql, params + [str(limit), str(offset)])
             entries = [dict(row) for row in await cursor.fetchall()]
 
@@ -2533,11 +2539,15 @@ def create_admin_app(
             # Settings view: no memory data needed
             pass
         elif view == "long-term":
-            entries, total = await _fetch_memories_paginated(memory_db, "long-term", offset, limit, q)
+            entries, total = await _fetch_memories_paginated(
+                memory_db, "long-term", offset, limit, q
+            )
             ctx["long_term"] = entries
             ctx["long_term_total"] = total
         elif view == "short-term":
-            entries, total = await _fetch_memories_paginated(memory_db, "short-term", offset, limit, q)
+            entries, total = await _fetch_memories_paginated(
+                memory_db, "short-term", offset, limit, q
+            )
             ctx["short_term"] = entries
             ctx["short_term_total"] = total
 

--- a/humux/api/templates/partials/memory.html
+++ b/humux/api/templates/partials/memory.html
@@ -1,74 +1,136 @@
-{# Memory tab partial #}
-  <div x-data="{
-    longTermLimit: {{ memory_long_term_limit|default('50', true)|tojson|forceescape }},
-    cfgResult: '',
-    cfgOk: false,
-    // Embeddings (Tier 2)
-    embEnabled: {{ emb_enabled|default('true', true)|tojson|forceescape }} === 'true',
-    embProvider: {{ emb_provider|default('local', true)|tojson|forceescape }},
-    embModel: {{ emb_model|default('intfloat/multilingual-e5-small', true)|tojson|forceescape }},
-    embBaseUrl: {{ emb_base_url|default('', true)|tojson|forceescape }},
-    embTopK: {{ emb_top_k|default('12', true)|tojson|forceescape }},
-    embRecallTopK: {{ emb_recall_top_k|default('10', true)|tojson|forceescape }},
-    embResult: '', embOk: false,
-    embStatus: null, embBusy: false, embTestResult: '',
-    // Lifecycle (Tier 3/4)
-    defaultImportance: {{ default_importance|default('5.0', true)|tojson|forceescape }},
-    archiveAfterDays: {{ archive_after_days|default('90', true)|tojson|forceescape }},
-    archiveMaxImportance: {{ archive_max_importance|default('4.0', true)|tojson|forceescape }},
-    archiveMinIdleDays: {{ archive_min_idle_days|default('45', true)|tojson|forceescape }},
-    hygieneEnabled: {{ hygiene_enabled|default('true', true)|tojson|forceescape }} === 'true',
-    hygieneThreshold: {{ hygiene_threshold|default('0.45', true)|tojson|forceescape }},
-    lifeResult: '', lifeOk: false,
-    get isLocal() { return this.embProvider === 'local' || this.embProvider === 'fastembed'; },
-    _hdrs() {
-      return {
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
-      };
-    },
-    saveCfg(vals, okMsg, okField, resField) {
-      return fetch('/config', { method: 'PATCH', headers: this._hdrs(), body: JSON.stringify({values: vals}) })
-        .then(r => { this[okField] = r.ok; return r.json(); })
-        .then(d => {
-          this[resField] = this[okField] ? okMsg : (d.detail || 'Error');
-          if (this[okField] && window.showToast) { window.showToast(okMsg); }
-        })
-        .catch(e => { this[okField] = false; this[resField] = e.message; });
-    },
-    loadEmbStatus() {
-      fetch('/memory/embedding/status', { headers: this._hdrs() })
-        .then(r => r.json()).then(d => { this.embStatus = d; }).catch(() => {});
-    },
-    downloadModel() {
-      this.embBusy = true; this.embTestResult = 'Downloading model… (first time may take a minute)';
-      fetch('/memory/embedding/prefetch', { method: 'POST', headers: this._hdrs() })
-        .then(r => r.json().then(d => ({ok: r.ok, d})))
-        .then(({ok, d}) => {
-          this.embTestResult = ok ? ('Model ready (dim ' + d.dimensions + ')') : ('Error: ' + (d.detail || 'failed'));
-          this.loadEmbStatus();
-        })
-        .catch(e => { this.embTestResult = 'Error: ' + e.message; })
-        .finally(() => { this.embBusy = false; });
-    },
-    testEmb() {
-      this.embBusy = true; this.embTestResult = 'Testing…';
-      fetch('/memory/embedding/test', { method: 'POST', headers: this._hdrs() })
-        .then(r => r.json().then(d => ({ok: r.ok, d})))
-        .then(({ok, d}) => {
-          this.embTestResult = ok
-            ? ('OK · dim ' + d.dimensions + ' · related=' + d.similar_pair + ' vs unrelated=' + d.unrelated_pair)
-            : ('Error: ' + (d.detail || 'failed'));
-        })
-        .catch(e => { this.embTestResult = 'Error: ' + e.message; })
-        .finally(() => { this.embBusy = false; });
-    }
-  }" x-init="loadEmbStatus()">
+{# Memory tab partial with sub-tabs: Settings | Long-term | Short-term #}
+{% set categories = ['preference','relationship','fact','routine','work','health','travel'] %}
+{% set page_sizes = [25, 50, 100] %}
+{% set v = memory_view|default('settings') %}
+{% set off = memory_offset|default(0)|int %}
+{% set lim = memory_limit|default(25)|int %}
+{% set q = memory_q|default('') %}
+
+{%- macro nav(view) %}
+<div class="flex border-b border-border mb-4 overflow-x-auto">
+  <button type="button" class="tab-link{% if view == 'settings' %} tab-link-active{% endif %}"
+          hx-get="/partials/memory?view=settings" hx-target="#tab-content" hx-swap="innerHTML">Settings</button>
+  <button type="button" class="tab-link{% if view == 'long-term' %} tab-link-active{% endif %}"
+          hx-get="/partials/memory?view=long-term&offset=0&limit={{ lim }}" hx-target="#tab-content" hx-swap="innerHTML">Long-term</button>
+  <button type="button" class="tab-link{% if view == 'short-term' %} tab-link-active{% endif %}"
+          hx-get="/partials/memory?view=short-term&offset=0&limit={{ lim }}" hx-target="#tab-content" hx-swap="innerHTML">Short-term</button>
+</div>
+{%- endmacro %}
+
+{%- macro pag(view, total) %}
+{% set total = total|default(0)|int %}
+{% set cp = (off // lim) + 1 if total > 0 else 1 %}
+{% set tp = ((total + lim - 1) // lim) if total > 0 else 1 %}
+{% set ss = off + 1 if total > 0 else 0 %}
+{% set se = (off + lim)|min(total) if total > 0 else 0 %}
+{% set qs = ('&q=' + q|urlencode) if q else '' %}
+<div class="flex items-center justify-between gap-2 mb-3 flex-wrap">
+  <div class="flex items-center gap-2">
+    <span class="text-xs text-muted">
+      {%- if total > 0 %}Showing {{ ss }}&ndash;{{ se }} of {{ total }}{% else %}No entries{% endif -%}
+    </span>
+    <label class="label mb-0 text-xs" for="ps-{{ view }}">Per page</label>
+    <select class="input-sm" style="max-width:80px" id="ps-{{ view }}"
+            onchange="htmx.ajax('GET','/partials/memory?view={{ view }}&offset=0&limit='+this.value+'{{ qs }}',{target:'#tab-content',swap:'innerHTML'})">
+      {% for ps in page_sizes %}<option value="{{ ps }}"{% if lim == ps %} selected{% endif %}>{{ ps }}</option>{% endfor %}
+    </select>
+  </div>
+  <div class="flex items-center gap-1">
+    <button class="btn btn-sm"{% if cp <= 1 %} disabled{% endif %}
+            hx-get="/partials/memory?view={{ view }}&offset=0&limit={{ lim }}{{ qs }}" hx-target="#tab-content" hx-swap="innerHTML">&laquo;</button>
+    <button class="btn btn-sm"{% if cp <= 1 %} disabled{% endif %}
+            hx-get="/partials/memory?view={{ view }}&offset={{ [off - lim, 0]|max }}&limit={{ lim }}{{ qs }}" hx-target="#tab-content" hx-swap="innerHTML">&lsaquo;</button>
+    <span class="text-xs text-muted px-1">Page {{ cp }} / {{ tp }}</span>
+    <button class="btn btn-sm"{% if cp >= tp %} disabled{% endif %}
+            hx-get="/partials/memory?view={{ view }}&offset={{ off + lim }}&limit={{ lim }}{{ qs }}" hx-target="#tab-content" hx-swap="innerHTML">&rsaquo;</button>
+    <button class="btn btn-sm"{% if cp >= tp %} disabled{% endif %}
+            hx-get="/partials/memory?view={{ view }}&offset={{ (tp - 1) * lim }}&limit={{ lim }}{{ qs }}" hx-target="#tab-content" hx-swap="innerHTML">&raquo;</button>
+  </div>
+</div>
+{%- endmacro %}
+
+{%- macro search(view) %}
+<div class="flex items-center gap-2 mb-3">
+  <input type="text" class="input-sm flex-1" style="max-width:300px" placeholder="Search memories..."
+         value="{{ q }}" id="search-{{ view }}"
+         onkeydown="if(event.key==='Enter'){const v=this.value;htmx.ajax('GET','/partials/memory?view={{ view }}&offset=0&limit={{ lim }}'+(v?'&q='+encodeURIComponent(v):''),{target:'#tab-content',swap:'innerHTML'});}">
+  <button class="btn btn-sm"
+          hx-get="/partials/memory?view={{ view }}&offset=0&limit={{ lim }}" hx-target="#tab-content" hx-swap="innerHTML"
+          title="Refresh">&#x21bb;</button>
+</div>
+{%- endmacro %}
+
+{% if v == 'settings' %}
+{{ nav('settings') }}
+<div x-data="{
+  longTermLimit: {{ memory_long_term_limit|default('50', true)|tojson|forceescape }},
+  cfgResult: '', cfgOk: false,
+  // Embeddings (Tier 2)
+  embEnabled: {{ emb_enabled|default('true', true)|tojson|forceescape }} === 'true',
+  embProvider: {{ emb_provider|default('sidecar', true)|tojson|forceescape }},
+  embModel: {{ emb_model|default('intfloat/multilingual-e5-small', true)|tojson|forceescape }},
+  embBaseUrl: {{ emb_base_url|default('', true)|tojson|forceescape }},
+  embTopK: {{ emb_top_k|default('12', true)|tojson|forceescape }},
+  embRecallTopK: {{ emb_recall_top_k|default('10', true)|tojson|forceescape }},
+  embResult: '', embOk: false,
+  embStatus: null, embBusy: false, embTestResult: '',
+  // Lifecycle (Tier 3/4)
+  defaultImportance: {{ default_importance|default('5.0', true)|tojson|forceescape }},
+  archiveAfterDays: {{ archive_after_days|default('90', true)|tojson|forceescape }},
+  archiveMaxImportance: {{ archive_max_importance|default('4.0', true)|tojson|forceescape }},
+  archiveMinIdleDays: {{ archive_min_idle_days|default('45', true)|tojson|forceescape }},
+  hygieneEnabled: {{ hygiene_enabled|default('true', true)|tojson|forceescape }} === 'true',
+  hygieneThreshold: {{ hygiene_threshold|default('0.45', true)|tojson|forceescape }},
+  lifeResult: '', lifeOk: false,
+  get isLocal() { return this.embProvider === 'local' || this.embProvider === 'fastembed'; },
+  _hdrs() {
+    return {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + (localStorage.getItem('admin_api_key') || '')
+    };
+  },
+  saveCfg(vals, okMsg, okField, resField) {
+    return fetch('/config', { method: 'PATCH', headers: this._hdrs(), body: JSON.stringify({values: vals}) })
+      .then(r => { this[okField] = r.ok; return r.json(); })
+      .then(d => {
+        this[resField] = this[okField] ? okMsg : (d.detail || 'Error');
+        if (this[okField] && window.showToast) { window.showToast(okMsg); }
+      })
+      .catch(e => { this[okField] = false; this[resField] = e.message; });
+  },
+  loadEmbStatus() {
+    fetch('/memory/embedding/status', { headers: this._hdrs() })
+      .then(r => r.json()).then(d => { this.embStatus = d; }).catch(() => {});
+  },
+  downloadModel() {
+    this.embBusy = true; this.embTestResult = 'Downloading model\u2026 (first time may take a minute)';
+    fetch('/memory/embedding/prefetch', { method: 'POST', headers: this._hdrs() })
+      .then(r => r.json().then(d => ({ok: r.ok, d})))
+      .then(({ok, d}) => {
+        this.embTestResult = ok ? ('Model ready (dim ' + d.dimensions + ')') : ('Error: ' + (d.detail || 'failed'));
+        this.loadEmbStatus();
+      })
+      .catch(e => { this.embTestResult = 'Error: ' + e.message; })
+      .finally(() => { this.embBusy = false; });
+  },
+  testEmb() {
+    this.embBusy = true; this.embTestResult = 'Testing\u2026';
+    fetch('/memory/embedding/test', { method: 'POST', headers: this._hdrs() })
+      .then(r => r.json().then(d => ({ok: r.ok, d})))
+      .then(({ok, d}) => {
+        this.embTestResult = ok
+          ? ('OK \u00b7 dim ' + d.dimensions + ' \u00b7 related=' + d.similar_pair + ' vs unrelated=' + d.unrelated_pair)
+          : ('Error: ' + (d.detail || 'failed'));
+      })
+      .catch(e => { this.embTestResult = 'Error: ' + e.message; })
+      .finally(() => { this.embBusy = false; });
+  }
+}" x-init="loadEmbStatus()">
+
   {# Memory config section #}
   <div class="card mb-6">
     <h2 class="text-base mb-1">Memory Settings</h2>
     <p class="text-muted text-xs mb-3">Configure memory storage behaviour.</p>
-
     <div class="space-y-3">
       <div>
         <label class="label" for="mem-long-term-limit">Long-term limit</label>
@@ -77,7 +139,6 @@
         <p class="text-muted text-xs mt-1">Maximum number of long-term memories before consolidation triggers cleanup.</p>
       </div>
     </div>
-
     <div class="flex justify-end mt-3">
       <button class="btn-primary btn-sm"
               @click="withLoading($el, () => saveCfg({'memory.long_term_limit': String(longTermLimit)}, 'Memory settings saved', 'cfgOk', 'cfgResult'))">
@@ -87,37 +148,34 @@
     <template x-if="cfgResult">
       <div :class="cfgOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="cfgResult"></div>
     </template>
-
     <p class="text-muted text-xs mt-4">
       The models used for memory extraction and consolidation can be configured in the
       <a href="#" class="text-link" @click.prevent="$dispatch('switch-tab', 'llm')">LLM tab</a>.
     </p>
   </div>
 
-  {# Semantic memory (embeddings) — Tier 2 #}
+  {# Semantic memory (embeddings) #}
   <div class="card mb-6">
     <h2 class="text-base mb-1">Semantic memory (embeddings)</h2>
     <p class="text-muted text-xs mb-3">
-      Match memories by <em>meaning</em>, not just words — so “allergic to shellfish” surfaces when you ask about eating prawns.
+      Match memories by <em>meaning</em>, not just words
+      &mdash; so &ldquo;allergic to shellfish&rdquo; surfaces when you ask about eating prawns.
     </p>
-
     <details class="mb-4 rounded border border-border p-2">
       <summary class="text-xs cursor-pointer">How it works (the science)</summary>
       <div class="text-muted text-xs mt-2 space-y-2">
-        <p>An <strong>embedding model</strong> turns each memory and your current message into a vector — a list of numbers positioning the text in a “meaning space”. Texts with similar meaning land close together, even with no shared words.</p>
-        <p>Closeness is measured by <strong>cosine similarity</strong> (1.0 = same direction/meaning, 0 = unrelated). On every message we embed it, compare against stored memory vectors, and inject only the most relevant ones — ranked by <em>relevance + importance + recency</em> (a Generative-Agents-style score) instead of dumping everything.</p>
+        <p>An <strong>embedding model</strong> turns each memory and your current message into a vector &mdash; a list of numbers positioning the text in a &ldquo;meaning space&rdquo;. Texts with similar meaning land close together, even with no shared words.</p>
+        <p>Closeness is measured by <strong>cosine similarity</strong> (1.0 = same direction/meaning, 0 = unrelated). On every message we embed it, compare against stored memory vectors, and inject only the most relevant ones &mdash; ranked by <em>relevance + importance + recency</em> (a Generative-Agents-style score) instead of dumping everything.</p>
         <p>The same similarity drives dedup (does this new fact match an existing one?) and the hygiene pass (cluster &amp; merge near-duplicates).</p>
-        <p><strong>Local</strong> runs the model on this machine (private, free, no key; the model file is bundled in the Docker image). <strong>API</strong> providers call a remote endpoint (needs a key; a few cents/year at most, but your memory text is sent to them). When disabled, memory falls back to fast word-overlap matching — still works, just less “fuzzy”.</p>
+        <p><strong>Local</strong> runs the model on this machine (private, free, no key; the model file is bundled in the Docker image). <strong>API</strong> providers call a remote endpoint (needs a key; a few cents/year at most, but your memory text is sent to them). When disabled, memory falls back to fast word-overlap matching &mdash; still works, just less &ldquo;fuzzy&rdquo;.</p>
       </div>
     </details>
-
     <div class="space-y-3">
       <div class="flex items-center gap-2">
         <label class="label mb-0" for="mem-emb-enabled">Enabled</label>
         <input type="checkbox" x-model="embEnabled" class="rounded border-border" id="mem-emb-enabled">
-        <span class="text-muted text-xs">Off → lexical (word-overlap) retrieval, no model needed.</span>
+        <span class="text-muted text-xs">Off &rarr; lexical (word-overlap) retrieval, no model needed.</span>
       </div>
-
       <div>
         <label class="label" for="mem-emb-backend">Backend</label>
         <select class="input-sm" style="max-width:360px" x-model="embProvider" :disabled="!embEnabled" id="mem-emb-backend">
@@ -132,7 +190,6 @@
           (Note: DeepSeek has no embeddings endpoint.)
         </p>
       </div>
-
       <div>
         <label class="label" for="mem-emb-model">Model</label>
         <input type="text" class="input-sm" style="max-width:420px" x-model="embModel" :disabled="!embEnabled"
@@ -140,32 +197,27 @@
         <p class="text-muted text-xs mt-1" x-show="isLocal">Multilingual CPU model (384-dim, ~470MB).</p>
         <p class="text-muted text-xs mt-1" x-show="!isLocal">e.g. <code>text-embedding-3-small</code> (OpenAI) or <code>text-embedding-004</code> (Google).</p>
       </div>
-
       <div x-show="!isLocal">
         <label class="label" for="mem-emb-base-url">Base URL (optional)</label>
         <input type="text" class="input-sm" style="max-width:420px" x-model="embBaseUrl" :disabled="!embEnabled"
-               placeholder="https://… (OpenAI-compatible /embeddings)" id="mem-emb-base-url">
+               placeholder="https://&hellip; (OpenAI-compatible /embeddings)" id="mem-emb-base-url">
       </div>
-
       <div>
         <label class="label" for="mem-emb-top-k">Injected memories per turn (top-k)</label>
         <input type="number" class="input-sm" style="max-width:120px" x-model="embTopK" :disabled="!embEnabled" min="1" max="100" id="mem-emb-top-k">
         <p class="text-muted text-xs mt-1">How many of the most relevant long-term memories to put in the prompt each message.</p>
       </div>
-
       <div>
         <label class="label" for="mem-emb-recall-top-k">Recall results (recall_memory tool)</label>
         <input type="number" class="input-sm" style="max-width:120px" x-model="embRecallTopK" :disabled="!embEnabled" min="1" max="25" id="mem-emb-recall-top-k">
         <p class="text-muted text-xs mt-1">Default number of memories the recall_memory tool returns when the agent searches its full long-term store on demand (the agent may request fewer/more per call, capped at 25).</p>
       </div>
-
       <div class="text-xs" x-show="isLocal && embStatus">
         Model on disk:
-        <span x-show="embStatus && embStatus.model_ready" class="text-success">yes ✓</span>
+        <span x-show="embStatus && embStatus.model_ready" class="text-success">yes &#x2713;</span>
         <span x-show="embStatus && embStatus.model_ready === false" class="text-error">not downloaded yet</span>
       </div>
     </div>
-
     <div class="flex items-center gap-2 mt-4 flex-wrap">
       <button class="btn-primary btn-sm"
               @click="withLoading($el, () => saveCfg({
@@ -180,7 +232,7 @@
       </button>
       <button class="btn btn-sm" type="button" x-show="isLocal" :disabled="embBusy" @click="downloadModel()">
         <span x-show="!embBusy">Download model</span>
-        <span x-show="embBusy">Working…</span>
+        <span x-show="embBusy">Working&hellip;</span>
       </button>
       <button class="btn btn-sm" type="button" :disabled="embBusy || !embEnabled" @click="testEmb()">Test</button>
     </div>
@@ -193,23 +245,21 @@
     <p class="text-muted text-xs mt-3">Changes apply live to the running agent (the local model loads on first use).</p>
   </div>
 
-  {# Memory lifecycle (forgetting + hygiene) — Tier 3/4 #}
+  {# Memory lifecycle (forgetting + hygiene) #}
   <div class="card mb-6">
     <h2 class="text-base mb-1">Memory lifecycle (forgetting &amp; hygiene)</h2>
     <p class="text-muted text-xs mb-3">Keep long-term memory from growing forever: reinforce what matters, forget cold trivia, merge duplicates.</p>
-
     <details class="mb-4 rounded border border-border p-2">
       <summary class="text-xs cursor-pointer">How it works (the science)</summary>
       <div class="text-muted text-xs mt-2 space-y-2">
-        <p>Each memory has an <strong>importance</strong> (1–10). Recall <strong>reinforces</strong> it (access count + recency), and re-stating a fact bumps its importance — mirroring how human memory strengthens with use.</p>
-        <p><strong>Forgetting:</strong> during consolidation, memories that are old, low-importance, and not accessed for a while are <em>archived</em> (soft-deleted, recoverable) rather than injected forever. This is decay, like the “use it or lose it” curve.</p>
-        <p><strong>Hygiene:</strong> the same run clusters near-duplicate memories (by similarity) and asks the model to merge them and drop contradictions, keeping the most recent — so the store stays compact and consistent.</p>
+        <p>Each memory has an <strong>importance</strong> (1&ndash;10). Recall <strong>reinforces</strong> it (access count + recency), and re-stating a fact bumps its importance &mdash; mirroring how human memory strengthens with use.</p>
+        <p><strong>Forgetting:</strong> during consolidation, memories that are old, low-importance, and not accessed for a while are <em>archived</em> (soft-deleted, recoverable) rather than injected forever. This is decay, like the &ldquo;use it or lose it&rdquo; curve.</p>
+        <p><strong>Hygiene:</strong> the same run clusters near-duplicate memories (by similarity) and asks the model to merge them and drop contradictions, keeping the most recent &mdash; so the store stays compact and consistent.</p>
       </div>
     </details>
-
     <div class="space-y-3">
       <div>
-        <label class="label" for="mem-default-importance">Default importance (1–10)</label>
+        <label class="label" for="mem-default-importance">Default importance (1&ndash;10)</label>
         <input type="number" step="0.5" class="input-sm" style="max-width:120px" x-model="defaultImportance" min="1" max="10" id="mem-default-importance">
         <p class="text-muted text-xs mt-1">Starting importance for a new memory.</p>
       </div>
@@ -219,7 +269,7 @@
         <p class="text-muted text-xs mt-1">A memory must be at least this old before it can be archived.</p>
       </div>
       <div>
-        <label class="label" for="mem-archive-max-imp">Archive only if importance ≤</label>
+        <label class="label" for="mem-archive-max-imp">Archive only if importance &le;</label>
         <input type="number" step="0.5" class="input-sm" style="max-width:120px" x-model="archiveMaxImportance" min="1" max="10" id="mem-archive-max-imp">
         <p class="text-muted text-xs mt-1">Important memories are never auto-archived.</p>
       </div>
@@ -240,8 +290,7 @@
         <p class="text-muted text-xs mt-1">Higher = stricter (only very-similar memories merge). 0.45 is a sensible default.</p>
       </div>
     </div>
-
-    <div class="flex justify-end mt-4">
+    <div class="flex items-center gap-2 mt-4">
       <button class="btn-primary btn-sm"
               @click="withLoading($el, () => saveCfg({
                 'memory.default_importance': String(defaultImportance),
@@ -253,142 +302,144 @@
               }, 'Lifecycle settings saved', 'lifeOk', 'lifeResult'))">
         Save lifecycle settings
       </button>
+      <button class="btn btn-sm" hx-post="/memory/consolidate" hx-target="#consolidation-result" hx-swap="innerHTML">
+        Run consolidation
+      </button>
+      <span id="consolidation-result" class="text-xs"></span>
     </div>
     <template x-if="lifeResult">
       <div :class="lifeOk ? 'alert-success' : 'alert-error'" class="mt-2" x-text="lifeResult"></div>
     </template>
   </div>
-
-  {# Memory data #}
-  <div class="flex items-center gap-2 mb-4">
-    <button class="btn btn-sm" hx-get="/partials/memory" hx-target="#tab-content" hx-swap="innerHTML">
-      Refresh
-    </button>
-    <button class="btn btn-sm" hx-post="/memory/consolidate" hx-target="#consolidation-result" hx-swap="innerHTML">
-      Run consolidation
-    </button>
-    <span id="consolidation-result" class="text-xs"></span>
-  </div>
-
-  {# Long-term memories #}
-  <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Long-term</h3>
-  <div class="overflow-x-auto mb-6">
-    <table class="table">
-      <thead>
-        <tr>
-          <th class="w-10">ID</th>
-          <th class="w-20">Category</th>
-          <th class="w-24">Subject</th>
-          <th>Content</th>
-          <th class="w-24">Scope</th>
-          <th class="w-10"></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% set categories = ['preference','relationship','fact','routine','work','health','travel'] %}
-        {% for m in long_term %}
-        <tr x-data="{editing:false}">
-          <td class="text-xs">{{ m.id }}</td>
-          <td class="text-xs">
-            <span x-show="!editing">{{ m.category }}</span>
-            <select name="category" class="input-sm" x-show="editing" aria-label="Category">
-              {% if m.category not in categories %}<option value="{{ m.category }}" selected>{{ m.category }}</option>{% endif %}
-              {% for c in categories %}<option value="{{ c }}" {% if m.category == c %}selected{% endif %}>{{ c }}</option>{% endfor %}
-            </select>
-          </td>
-          <td class="text-xs">
-            <span x-show="!editing">{{ m.subject }}</span>
-            <input name="subject" class="input-sm" value="{{ m.subject }}" x-show="editing" aria-label="Subject">
-          </td>
-          <td class="text-xs break-all">
-            <span x-show="!editing">{{ m.content }}</span>
-            <textarea name="content" class="input-sm w-full" rows="2" x-show="editing" aria-label="Content">{{ m.content }}</textarea>
-          </td>
-          <td class="text-xs">
-            <span x-show="!editing">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</span>
-            <select name="scope" class="input-sm" x-show="editing" aria-label="Scope">
-              <option value="" {% if not m.scope %}selected{% endif %}>shared</option>
-              {% if m.scope and m.scope not in agent_slugs %}<option value="{{ m.scope }}" selected>{{ m.scope }} (no agent)</option>{% endif %}
-              {% for s in agent_slugs %}<option value="{{ s }}" {% if m.scope == s %}selected{% endif %}>{{ s }}</option>{% endfor %}
-            </select>
-          </td>
-          <td class="whitespace-nowrap">
-            <button class="btn btn-sm" x-show="!editing" @click="editing=true">edit</button>
-            <button class="btn-primary btn-sm" x-show="editing"
-                    hx-post="/memory/update" hx-target="#tab-content" hx-swap="innerHTML"
-                    hx-include="closest tr"
-                    hx-vals='{"tier": "long-term", "memory_id": "{{ m.id }}"}'>save</button>
-            <button class="btn btn-sm" x-show="editing" @click="editing=false">cancel</button>
-            <button class="btn-danger btn-sm" x-show="!editing"
-                    hx-post="/memory/delete" hx-target="#tab-content" hx-swap="innerHTML"
-                    hx-vals='{"tier": "long-term", "memory_id": "{{ m.id }}"}'
-                    hx-confirm="Delete this memory?">
-              x
-            </button>
-          </td>
-        </tr>
-        {% endfor %}
-        {% if not long_term %}
-        <tr><td colspan="6" class="text-muted text-xs text-center py-4">No long-term memories</td></tr>
-        {% endif %}
-      </tbody>
-    </table>
-  </div>
-
-  {# Short-term memories #}
-  <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Short-term (active)</h3>
-  <div class="overflow-x-auto">
-    <table class="table">
-      <thead>
-        <tr>
-          <th class="w-10">ID</th>
-          <th>Content</th>
-          <th class="w-24">Scope</th>
-          <th class="w-32">Expires</th>
-          <th class="w-10"></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for m in short_term %}
-        <tr x-data="{editing:false}">
-          <td class="text-xs">{{ m.id }}</td>
-          <td class="text-xs break-all">
-            <span x-show="!editing">{{ m.content }}</span>
-            <input name="content" class="input-sm w-full" value="{{ m.content }}" x-show="editing" aria-label="Content">
-          </td>
-          <td class="text-xs">
-            <span x-show="!editing">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</span>
-            <select name="scope" class="input-sm" x-show="editing" aria-label="Scope">
-              <option value="" {% if not m.scope %}selected{% endif %}>shared</option>
-              {% if m.scope and m.scope not in agent_slugs %}<option value="{{ m.scope }}" selected>{{ m.scope }} (no agent)</option>{% endif %}
-              {% for s in agent_slugs %}<option value="{{ s }}" {% if m.scope == s %}selected{% endif %}>{{ s }}</option>{% endfor %}
-            </select>
-          </td>
-          <td class="text-xs">
-            <span x-show="!editing">{{ m.expires_at }}</span>
-            <input type="datetime-local" name="expires_at" step="1" class="input-sm"
-                   value="{{ m.expires_at[:19]|replace(' ','T') }}" x-show="editing" aria-label="Expires at">
-          </td>
-          <td class="whitespace-nowrap">
-            <button class="btn btn-sm" x-show="!editing" @click="editing=true">edit</button>
-            <button class="btn-primary btn-sm" x-show="editing"
-                    hx-post="/memory/update" hx-target="#tab-content" hx-swap="innerHTML"
-                    hx-include="closest tr"
-                    hx-vals='{"tier": "short-term", "memory_id": "{{ m.id }}"}'>save</button>
-            <button class="btn btn-sm" x-show="editing" @click="editing=false">cancel</button>
-            <button class="btn-danger btn-sm" x-show="!editing"
-                    hx-post="/memory/delete" hx-target="#tab-content" hx-swap="innerHTML"
-                    hx-vals='{"tier": "short-term", "memory_id": "{{ m.id }}"}'
-                    hx-confirm="Delete this memory?">
-              x
-            </button>
-          </td>
-        </tr>
-        {% endfor %}
-        {% if not short_term %}
-        <tr><td colspan="5" class="text-muted text-xs text-center py-4">No active short-term memories</td></tr>
-        {% endif %}
-      </tbody>
-    </table>
-  </div>
 </div>
+
+{% elif v == 'long-term' %}
+{{ nav('long-term') }}
+{% set lt = long_term|default([]) %}
+{% set lt_total = long_term_total|default(0) %}
+
+{{ search('long-term') }}
+{{ pag('long-term', lt_total) }}
+
+<div class="overflow-x-auto mb-6">
+  <table class="table">
+    <thead>
+      <tr>
+        <th class="w-10">ID</th>
+        <th class="w-20">Category</th>
+        <th class="w-24">Subject</th>
+        <th>Content</th>
+        <th class="w-24">Scope</th>
+        <th class="w-10"></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for m in lt %}
+      <tr x-data="{editing:false}">
+        <td class="text-xs">{{ m.id }}</td>
+        <td class="text-xs">
+          <span x-show="!editing">{{ m.category }}</span>
+          <select name="category" class="input-sm" x-show="editing" aria-label="Category">
+            {% if m.category not in categories %}<option value="{{ m.category }}" selected>{{ m.category }}</option>{% endif %}
+            {% for c in categories %}<option value="{{ c }}" {% if m.category == c %}selected{% endif %}>{{ c }}</option>{% endfor %}
+          </select>
+        </td>
+        <td class="text-xs">
+          <span x-show="!editing">{{ m.subject }}</span>
+          <input name="subject" class="input-sm" value="{{ m.subject }}" x-show="editing" aria-label="Subject">
+        </td>
+        <td class="text-xs break-all">
+          <span x-show="!editing">{{ m.content }}</span>
+          <textarea name="content" class="input-sm w-full" rows="2" x-show="editing" aria-label="Content">{{ m.content }}</textarea>
+        </td>
+        <td class="text-xs">
+          <span x-show="!editing">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</span>
+          <select name="scope" class="input-sm" x-show="editing" aria-label="Scope">
+            <option value="" {% if not m.scope %}selected{% endif %}>shared</option>
+            {% if m.scope and m.scope not in agent_slugs %}<option value="{{ m.scope }}" selected>{{ m.scope }} (no agent)</option>{% endif %}
+            {% for s in agent_slugs %}<option value="{{ s }}" {% if m.scope == s %}selected{% endif %}>{{ s }}</option>{% endfor %}
+          </select>
+        </td>
+        <td class="whitespace-nowrap">
+          <button class="btn btn-sm" x-show="!editing" @click="editing=true">edit</button>
+          <button class="btn-primary btn-sm" x-show="editing"
+                  hx-post="/memory/update" hx-target="#tab-content" hx-swap="innerHTML"
+                  hx-include="closest tr"
+                  hx-vals='{"tier": "long-term", "memory_id": "{{ m.id }}"}'>&#x2713;</button>
+          <button class="btn btn-sm" x-show="editing" @click="editing=false">cancel</button>
+          <button class="btn-danger btn-sm" x-show="!editing"
+                  hx-post="/memory/delete" hx-target="#tab-content" hx-swap="innerHTML"
+                  hx-vals='{"tier": "long-term", "memory_id": "{{ m.id }}"}' hx-confirm="Delete this memory?">x</button>
+        </td>
+      </tr>
+      {% endfor %}
+      {% if not lt %}
+      <tr><td colspan="6" class="text-muted text-xs text-center py-4">No long-term memories</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+</div>
+{{ pag('long-term', lt_total) }}
+
+{% elif v == 'short-term' %}
+{{ nav('short-term') }}
+{% set st = short_term|default([]) %}
+{% set st_total = short_term_total|default(0) %}
+
+{{ search('short-term') }}
+{{ pag('short-term', st_total) }}
+
+<div class="overflow-x-auto">
+  <table class="table">
+    <thead>
+      <tr>
+        <th class="w-10">ID</th>
+        <th>Content</th>
+        <th class="w-24">Scope</th>
+        <th class="w-32">Expires</th>
+        <th class="w-10"></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for m in st %}
+      <tr x-data="{editing:false}">
+        <td class="text-xs">{{ m.id }}</td>
+        <td class="text-xs break-all">
+          <span x-show="!editing">{{ m.content }}</span>
+          <input name="content" class="input-sm w-full" value="{{ m.content }}" x-show="editing" aria-label="Content">
+        </td>
+        <td class="text-xs">
+          <span x-show="!editing">{% if m.scope %}{{ m.scope }}{% else %}<span class="text-muted">shared</span>{% endif %}</span>
+          <select name="scope" class="input-sm" x-show="editing" aria-label="Scope">
+            <option value="" {% if not m.scope %}selected{% endif %}>shared</option>
+            {% if m.scope and m.scope not in agent_slugs %}<option value="{{ m.scope }}" selected>{{ m.scope }} (no agent)</option>{% endif %}
+            {% for s in agent_slugs %}<option value="{{ s }}" {% if m.scope == s %}selected{% endif %}>{{ s }}</option>{% endfor %}
+          </select>
+        </td>
+        <td class="text-xs">
+          <span x-show="!editing">{{ m.expires_at }}</span>
+          <input type="datetime-local" name="expires_at" step="1" class="input-sm"
+                 value="{{ m.expires_at[:19]|replace(' ','T') }}" x-show="editing" aria-label="Expires at">
+        </td>
+        <td class="whitespace-nowrap">
+          <button class="btn btn-sm" x-show="!editing" @click="editing=true">edit</button>
+          <button class="btn-primary btn-sm" x-show="editing"
+                  hx-post="/memory/update" hx-target="#tab-content" hx-swap="innerHTML"
+                  hx-include="closest tr"
+                  hx-vals='{"tier": "short-term", "memory_id": "{{ m.id }}"}'>&#x2713;</button>
+          <button class="btn btn-sm" x-show="editing" @click="editing=false">cancel</button>
+          <button class="btn-danger btn-sm" x-show="!editing"
+                  hx-post="/memory/delete" hx-target="#tab-content" hx-swap="innerHTML"
+                  hx-vals='{"tier": "short-term", "memory_id": "{{ m.id }}"}' hx-confirm="Delete this memory?">x</button>
+        </td>
+      </tr>
+      {% endfor %}
+      {% if not st %}
+      <tr><td colspan="5" class="text-muted text-xs text-center py-4">No active short-term memories</td></tr>
+      {% endif %}
+    </tbody>
+  </table>
+</div>
+{{ pag('short-term', st_total) }}
+
+{% endif %}

--- a/humux/tests/test_memory_subtabs.py
+++ b/humux/tests/test_memory_subtabs.py
@@ -1,0 +1,148 @@
+"""Tests for the Memory sub-tabs (Settings, Long-term, Short-term) with pagination and search."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from fastapi.testclient import TestClient
+
+from api.admin import AgentState, create_admin_app
+from core.config import Config
+from core.config_store import ConfigStore
+
+HEADERS = {"Authorization": "Bearer secret"}
+
+
+class _StoreStub:
+    """Minimal config store: auth + export_to_config(Config defaults)."""
+
+    def __init__(self, overrides: dict | None = None):
+        self._overrides = overrides or {}
+
+    async def is_setup_complete(self) -> bool:
+        return True
+
+    async def get(self, key: str):
+        if key == "admin.password_hash":
+            return "hash"
+        if key == "admin.password_salt":
+            return "salt"
+        return self._overrides.get(key)
+
+    async def verify_admin_password(self, password: str) -> bool:
+        return password == "secret"
+
+    async def export_to_config(self) -> Config:
+        cfg = Config()
+        emb = cfg.memory.embedding
+        for key, val in self._overrides.items():
+            if key == "memory.embedding.provider":
+                emb.provider = val
+            elif key == "memory.embedding.model":
+                emb.model = val
+        return cfg
+
+
+def _client(overrides: dict | None = None) -> TestClient:
+    agent_state = AgentState(agent=None)
+    app, _auth = create_admin_app(agent_state, cast(ConfigStore, _StoreStub(overrides)))
+    return TestClient(app)
+
+
+def test_memory_partial_renders_settings_by_default() -> None:
+    """GET /partials/memory renders the Settings view by default."""
+    resp = _client().get("/partials/memory", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.text
+    # Settings view includes the config panels
+    assert "Memory Settings" in body
+    assert "Semantic memory (embeddings)" in body
+    assert "Memory lifecycle" in body
+    # Sub-tab navigation is present
+    assert "Settings" in body
+    assert "Long-term" in body
+    assert "Short-term" in body
+
+
+def test_memory_partial_with_view_settings() -> None:
+    """GET /partials/memory?view=settings renders the Settings sub-tab."""
+    resp = _client().get("/partials/memory?view=settings", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Memory Settings" in body
+    assert "Semantic memory (embeddings)" in body
+    assert "Settings" in body
+
+
+def test_memory_partial_with_view_long_term_shows_table() -> None:
+    """GET /partials/memory?view=long-term renders the long-term table."""
+    resp = _client().get("/partials/memory?view=long-term", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.text
+    # Long-term table headers are present
+    assert "Category" in body or "Subject" in body or "Content" in body
+    # Pagination controls present
+    assert "page_size" in body or "Per page" in body or "Showing" in body
+    assert "href=" in body or "hx-get" in body or "hx-target" in body
+
+
+def test_memory_partial_with_view_short_term_shows_table() -> None:
+    """GET /partials/memory?view=short-term renders the short-term table."""
+    resp = _client().get("/partials/memory?view=short-term", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.text
+    # Short-term table headers are present
+    assert "Expires" in body or "Content" in body or "Scope" in body
+    # Pagination controls present
+    assert "page_size" in body or "Per page" in body or "Showing" in body
+
+
+def test_memory_partial_invalid_view_falls_back_to_settings() -> None:
+    """An unknown view value falls back to Settings."""
+    resp = _client().get("/partials/memory?view=nonexistent", headers=HEADERS)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Memory Settings" in body
+
+
+def test_memory_partial_long_term_pagination_params_accepted() -> None:
+    """Query params offset, limit, q are accepted on long-term view."""
+    resp = _client().get(
+        "/partials/memory?view=long-term&offset=10&limit=25&q=test",
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200
+
+
+def test_memory_partial_short_term_pagination_params_accepted() -> None:
+    """Query params offset, limit, q are accepted on short-term view."""
+    resp = _client().get(
+        "/partials/memory?view=short-term&offset=0&limit=50&q=search",
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200
+
+
+def test_memory_partial_with_legacy_tab_param() -> None:
+    """Legacy URL with ?tab=memory still works (defaults to Settings view)."""
+    # The admin dashboard passes ?tab=memory which loads /partials/memory
+    resp = _client().get("/partials/memory", headers=HEADERS)
+    assert resp.status_code == 200
+
+
+def test_sub_tab_nav_buttons_link_correctly() -> None:
+    """Sub-tab buttons have correct HTMX attributes."""
+    resp = _client().get("/partials/memory?view=settings", headers=HEADERS)
+    body = resp.text
+    # Each nav button should target #tab-content via hx-get
+    assert 'hx-get="/partials/memory?view=settings"' in body
+    assert 'hx-get="/partials/memory?view=long-term"' in body or 'hx-get="/partials/memory?view=long-term' in body
+    assert 'hx-get="/partials/memory?view=short-term"' in body or 'hx-get="/partials/memory?view=short-term' in body
+
+
+def test_endpoints_require_auth() -> None:
+    """Memory partial endpoint requires authentication."""
+    assert _client().get("/partials/memory").status_code in (401, 403)
+    assert _client().get("/partials/memory?view=settings").status_code in (401, 403)
+    assert _client().get("/partials/memory?view=long-term").status_code in (401, 403)
+    assert _client().get("/partials/memory?view=short-term").status_code in (401, 403)

--- a/humux/tests/test_memory_subtabs.py
+++ b/humux/tests/test_memory_subtabs.py
@@ -136,8 +136,10 @@ def test_sub_tab_nav_buttons_link_correctly() -> None:
     body = resp.text
     # Each nav button should target #tab-content via hx-get
     assert 'hx-get="/partials/memory?view=settings"' in body
-    assert 'hx-get="/partials/memory?view=long-term"' in body or 'hx-get="/partials/memory?view=long-term' in body
-    assert 'hx-get="/partials/memory?view=short-term"' in body or 'hx-get="/partials/memory?view=short-term' in body
+    long_hx = 'hx-get="/partials/memory?view=long-term'
+    assert long_hx in body
+    short_hx = 'hx-get="/partials/memory?view=short-term'
+    assert short_hx in body
 
 
 def test_endpoints_require_auth() -> None:


### PR DESCRIPTION
Closes #275.

## What changed

**Backend** — `_render_memory_partial()` now accepts `view`, `offset`, `limit`, `q` params. New `_fetch_memories_paginated()` helper performs paginated SQL queries with LIKE search and COUNT. The `/partials/memory` route accepts `?view=settings|long-term|short-term&offset=N&limit=N&q=...`. Delete/update handlers return the matching sub-view instead of the full old page.

**Template** — Rewritten `memory.html` as three sub-views each with their own sub-tab navigation bar:

- **Settings** — keeps all existing config cards (Memory Settings, Embeddings, Lifecycle) plus the Run consolidation button. Unchanged Alpine.js state and save handlers.
- **Long-term** — paginated table with search. Page nav (first/prev/next/last), per-page selector (25/50/100), "Showing X–Y of Z" counter. Inline edit/delete preserved.
- **Short-term** — same pagination + search pattern. Inline edit with expires_at field preserved.

**Sub-tab navigation** — Uses HTMX `hx-get="/partials/memory?view=..." hx-target="#tab-content"` for instant server-side switching. Active tab is highlighted. Default view is Settings (backward compatible with `?tab=memory`).

**Search** — Enter-to-search on the input field, with LIKE matching on content/subject/category for long-term and content for short-term. Refresh button clears the search.

## Tests
- 10 new tests covering all views, pagination params, search query params, auth enforcement, and nav button correctness.
- All 6 existing memory admin tests still pass.
