### PR TITLE
fix: agent GitHub identity leaks owner credentials

### DIFF
--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -2599,6 +2599,15 @@ class AgentCore:
                 if not resolved.is_dir():
                     return {"error": f"Not a directory: {workdir}"}
                 cwd = str(resolved)
+            # Per-agent tool identity (#93): resolve BEFORE the unlisted-bash
+            # fork so compound workspace commands (`cd repo && gh pr create`)
+            # authenticate as the agent, not the container's ambient identity.
+            agent = request_state.get("agent_obj")
+            agent_env = None
+            if agent is not None or _gh_app_configured(self.config):
+                store = self.secret_store
+                resolve = store.infra_resolve if store else (lambda _n: None)
+                agent_env = effective_tool_env(self.config, agent, resolve)
             if unlisted_bash:
                 # Outside the prefix allowlist: runs ONLY workspace-confined, under
                 # the per-call approval that already happened above (the old
@@ -2607,7 +2616,7 @@ class AgentCore:
                 if workspace is None:
                     # No workspace → surface the executor's allowlist guidance.
                     return await self.executor.run_command(command)
-                return await self.executor.run_in_dir(command, cwd)
+                return await self.executor.run_in_dir(command, cwd, tool_env=agent_env)
             # Secret substitution boundary (issue #19): {{secret:NAME}} is resolved
             # ONLY here, for the model's generic command tool, after an ACL check.
             # Structured tools (send_email/send_message/…) build their commands
@@ -2618,10 +2627,6 @@ class AgentCore:
                 command, serr = await self.secret_store.resolve_command_secrets(command, allowed)
                 if serr:
                     return {"error": serr}
-            # Per-agent tool identity (#93): an agent runs `gh`/`browser` with its
-            # own credentials/profile, never the owner's. No agent → the shared
-            # default env (unchanged path).
-            agent = request_state.get("agent_obj")
             # Per-agent GitHub repo allowlist (#111) — block before running.
             bad_repo = github_repo_violation(agent, command)
             if bad_repo:
@@ -2632,16 +2637,6 @@ class AgentCore:
                         "GitHub tool identity."
                     )
                 }
-            agent_env = None
-            # Build the per-turn tool env when an agent is active OR a GitHub App
-            # is configured — the latter so its rotating installation token (#111)
-            # is minted fresh per command instead of the stale one cached at
-            # construction. A static PAT doesn't rotate, so the no-agent/PAT case
-            # keeps using the executor's shared default (unchanged).
-            if agent is not None or _gh_app_configured(self.config):
-                store = self.secret_store
-                resolve = store.infra_resolve if store else (lambda _n: None)
-                agent_env = effective_tool_env(self.config, agent, resolve)
             return await self.executor.run_command(command, tool_env=agent_env, cwd=cwd)
 
         if name == "send_email":

--- a/humux/core/executor.py
+++ b/humux/core/executor.py
@@ -234,13 +234,24 @@ class ToolExecutor:
         """
         return await self._exec(self._resolve_command(command), timeout)
 
-    async def run_in_dir(self, command: str, cwd: str, timeout: int = 120) -> dict:
+    async def run_in_dir(
+        self,
+        command: str,
+        cwd: str,
+        timeout: int = 120,
+        tool_env: dict[str, str] | None = None,
+    ) -> dict:
         """Run a shell command in ``cwd`` (no prefix whitelist) for the coding
         harness (#76). Confinement of ``cwd`` to the workspace and per-call ASK
         approval are enforced by the caller (core/coding.py + the agent); this
         only adds the working directory. Builds/tests get a longer default
-        timeout than the 30s interactive default."""
-        return await self._exec(command, timeout, cwd=cwd)
+        timeout than the 30s interactive default.
+
+        ``tool_env`` injects the active agent's identity (GH_TOKEN, git author
+        env vars) so compound workspace commands (``cd repo && gh pr create``)
+        authenticate as the agent, not the container's ambient identity.
+        """
+        return await self._exec(command, timeout, cwd=cwd, tool_env=tool_env)
 
     async def _exec(
         self,

--- a/humux/core/tools.py
+++ b/humux/core/tools.py
@@ -485,11 +485,11 @@ def effective_tool_env(
                     agent.name,
                 )
                 env["GH_TOKEN"] = GH_NO_IDENTITY
-            # Commits authored as the bot (#263): env beats any `git config
+            # Commits authored as the agent (#263): env beats any `git config
             # user.*` the model sets in a shared workspace, so bot work can't
-            # carry the owner's name. The app slug rides webhook_mention; the
-            # plain noreply form displays the bot name (no avatar link — that
-            # would need the bot USER id, which isn't known offline).
+            # carry the owner's name.  webhook_mention gives the GitHub App
+            # slug (best: links to the bot profile); without it, the agent's
+            # own name prevents the owner's ~/.gitconfig from leaking through.
             slug = (
                 str(gh.get("webhook_mention") or "")
                 .strip()
@@ -497,12 +497,17 @@ def effective_tool_env(
                 .lower()
                 .removesuffix("[bot]")
             )
-            if slug and _agent_has_own_app(gh):
+            if slug:
                 bot = f"{slug}[bot]"
                 env["GIT_AUTHOR_NAME"] = bot
                 env["GIT_COMMITTER_NAME"] = bot
                 env["GIT_AUTHOR_EMAIL"] = f"{bot}@users.noreply.github.com"
                 env["GIT_COMMITTER_EMAIL"] = f"{bot}@users.noreply.github.com"
+            else:
+                env["GIT_AUTHOR_NAME"] = agent.name
+                env["GIT_COMMITTER_NAME"] = agent.name
+                env["GIT_AUTHOR_EMAIL"] = f"{agent.name}@users.noreply.github.com"
+                env["GIT_COMMITTER_EMAIL"] = f"{agent.name}@users.noreply.github.com"
 
     browser = agent.tool_setting("browser")
     if browser is not None and browser.get("enabled") and config.tools.browser.enabled:
@@ -544,10 +549,22 @@ if __name__ == "__main__":
     env = effective_tool_env(cfg, hopper, resolve)
     assert env["GH_TOKEN"] == "hopper-token", env.get("GH_TOKEN")
     assert env["BROWSER_PROFILE"] == "hop"
+    # No webhook_mention → git identity falls back to agent name.
+    assert env["GIT_AUTHOR_NAME"] == "hopper", env.get("GIT_AUTHOR_NAME")
+    assert env["GIT_AUTHOR_EMAIL"] == "hopper@users.noreply.github.com"
 
-    # gh enabled but no own token stored → no token (never borrows the owner's).
+    # Agent with webhook_mention → git identity uses the slug[bot] form.
+    mentioned = Agent(
+        name="coder",
+        tool_config={"gh": {"enabled": True, "webhook_mention": "@mybot[bot]"}},
+    )
+    menv = effective_tool_env(cfg, mentioned, resolve)
+    assert menv["GIT_AUTHOR_NAME"] == "mybot[bot]", menv.get("GIT_AUTHOR_NAME")
+    assert menv["GIT_AUTHOR_EMAIL"] == "mybot[bot]@users.noreply.github.com"
+
+    # gh enabled but no own token stored → fails closed (#263).
     atlas = Agent(name="atlas", tool_config={"gh": {"enabled": True}})
-    assert "GH_TOKEN" not in effective_tool_env(cfg, atlas, resolve)
+    assert effective_tool_env(cfg, atlas, resolve)["GH_TOKEN"] == GH_NO_IDENTITY
 
     # token_secret reuses an existing vault secret instead of the namespaced one.
     ref = Agent(name="atlas", tool_config={"gh": {"enabled": True, "token_secret": "SHARED_PAT"}})
@@ -578,7 +595,7 @@ if __name__ == "__main__":
         )
         assert effective_tool_env(app_cfg, pat_only, resolve)["GH_TOKEN"] == "hopper-token"
         pat_none = Agent(name="none", tool_config={"gh": {"enabled": True, "auth": "pat"}})
-        assert "GH_TOKEN" not in effective_tool_env(app_cfg, pat_none, resolve)
+        assert effective_tool_env(app_cfg, pat_none, resolve)["GH_TOKEN"] == GH_NO_IDENTITY
 
         # Agent's OWN GitHub App (multiple apps) → its own bot (app 500), not 42.
         own_app = Agent(
@@ -607,7 +624,7 @@ if __name__ == "__main__":
         pat_sys.tools.gh.app_id = "42"
         pat_sys.tools.gh.installation_id = "7"
         pat_sys.tools.gh.private_key = "PEM"
-        assert "GH_TOKEN" not in effective_tool_env(pat_sys, atlas, resolve)
+        assert effective_tool_env(pat_sys, atlas, resolve)["GH_TOKEN"] == GH_NO_IDENTITY
     finally:
         _ga.installation_token = _real_it
 

--- a/humux/tests/test_agent_tool_identity.py
+++ b/humux/tests/test_agent_tool_identity.py
@@ -101,10 +101,11 @@ async def test_agent_app_identity_sets_bot_git_authorship(agent: AgentCore, monk
     assert env["GH_TOKEN"] == "app-token"
     assert env["GIT_AUTHOR_NAME"] == "kindralai[bot]"
     assert env["GIT_COMMITTER_EMAIL"] == "kindralai[bot]@users.noreply.github.com"
-    # A PAT agent (no own app) gets no forced git identity.
+    # A PAT agent (no webhook_mention) gets git identity from agent name.
     pat = Agent(name="hopper", tool_config={"gh": {"enabled": True}})
     cap2 = await _run(agent, pat, monkeypatch)
-    assert "GIT_AUTHOR_NAME" not in cap2["tool_env"]
+    assert cap2["tool_env"]["GIT_AUTHOR_NAME"] == "hopper"
+    assert cap2["tool_env"]["GIT_AUTHOR_EMAIL"] == "hopper@users.noreply.github.com"
 
 
 async def test_agent_gh_disabled_strips_owner_token(agent: AgentCore, monkeypatch) -> None:

--- a/humux/tests/test_coding.py
+++ b/humux/tests/test_coding.py
@@ -305,6 +305,9 @@ def _yolo_gate_agent(tmp_path):
     from core.executor import ToolExecutor
 
     agent = object.__new__(AgentCore)
+    agent.config = MagicMock()
+    agent.config.tools.gh.enabled = False
+    agent.secret_store = None
     agent.permissions = PermissionEngine(db_path=str(tmp_path / "config.db"))
     agent.executor = ToolExecutor()
     agent.executor.run_in_dir = AsyncMock(return_value={"exit_code": 0})
@@ -369,7 +372,7 @@ async def test_unlisted_bash_runs_workspace_confined(tmp_path):
     )
     assert result == {"exit_code": 0}
     agent._request_approval.assert_awaited_once()
-    agent.executor.run_in_dir.assert_awaited_once_with("make test", str(tmp_path))
+    agent.executor.run_in_dir.assert_awaited_once_with("make test", str(tmp_path), tool_env=None)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Two bugs cause agents to act as the repo owner on GitHub instead of their own App bot identity:

**1. Compound workspace commands bypass per-agent env** — commands like `cd repo && gh pr create` are classified as "unlisted" (`cd` is not in `ALLOWED_PREFIXES`), routing through `run_in_dir` which did not forward `tool_env`. The subprocess inherited the executor's default env or the container's ambient `hosts.yml`, so `gh`/`git` ran as the owner.

**2. Git commit identity gated on `webhook_mention`** — `GIT_AUTHOR_NAME`/`EMAIL` env vars were only set when both `webhook_mention` (App slug) and `_agent_has_own_app()` were true. Agents without `webhook_mention` got no env override, so commits carried the owner's `~/.gitconfig` identity or whatever the LLM fabricated via `git config`.

## Fix

- `executor.run_in_dir` now accepts an optional `tool_env` and forwards it to `_exec` (agent-scoped managed-key stripping kicks in).
- `agent._execute_tool` computes `agent_env` **before** the unlisted-bash fork so both paths use the same per-agent identity.
- Git author/committer env vars are now always set when the agent has an explicit `gh` policy: `webhook_mention` → `slug[bot]` (unchanged); no mention → `agent.name` fallback. The env var always wins over git-config.
- Pre-existing self-check failures fixed: `GH_NO_IDENTITY` sentinel (#263) was added after assertions were written.

## Test plan

- [x] `test_agent_tool_identity` — webhook_mention → `slug[bot]`; no mention → `agent.name`
- [x] `test_coding` — workspace-confined commands pass `tool_env` through
- [x] `test_executor` + `test_tools` — existing checks still pass
- [x] `tools.py` self-check (`python -m core.tools`) passes