### PR TITLE
fix(research): deliver the deep-research artifact link deterministically

### DIFF
--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -4325,10 +4325,19 @@ class AgentCore:
                 target = Path(ws).expanduser() / ARTIFACTS_SUBDIR / slug / "index.html"
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_text(page, encoding="utf-8")
-                result["artifact_url"] = f"{self._base_url()}/artifacts/{slug}/"
+                url = f"{self._base_url()}/artifacts/{slug}/"
+                result["artifact_url"] = url
+                # Deliver the link deterministically, like the progress updates
+                # — the user must get it even if the model's reply drops it.
+                try:
+                    await progress(f"📄 Full report: {url}")
+                except Exception:
+                    log.exception("Failed to deliver deep-research artifact link")
                 result["note"] = (
-                    "Report published as a web artifact. Reply briefly: the key "
-                    "takeaways plus the artifact_url link — do not paste the report."
+                    "Report published as a web artifact; its link was already "
+                    "posted to the chat. Reply briefly: the key takeaways, plus "
+                    "the artifact_url repeated verbatim as a plain URL — do not "
+                    "paste the report."
                 )
             except OSError:
                 log.exception("Failed to write deep-research artifact %s", slug)


### PR DESCRIPTION
Follow-up to #294 (issue #293), from a live run: the chat reply relied on the model echoing `artifact_url`, and it dropped the links — the user had to ask for them.

The handler now posts `📄 Full report: <url>` straight to the originating chat through the same delivery path as the progress updates, so the link always arrives regardless of what the model writes. The result note also asks the model to repeat the URL verbatim.

Suite: 1080 passed, ruff clean.