### PR TITLE
www: update for v0.34–v0.36 features

### DIFF
--- a/www/comparison.html
+++ b/www/comparison.html
@@ -122,7 +122,7 @@
         <div class="feature-card" style="border-color: var(--color-accent-dim); background: var(--color-accent-glow);">
           <h3 class="mb-1 text-sm font-semibold" style="color: var(--color-accent);">humux</h3>
           <p class="text-xs" style="color: var(--color-secondary);">Merola Software & Services</p>
-          <p class="mt-1 text-xs leading-relaxed" style="color: var(--color-secondary);">Python agent with built-in email, calendar, contacts, Telegram, voice, vault, skills, subagents, and admin UI. Single Docker container.</p>
+          <p class="mt-1 text-xs leading-relaxed" style="color: var(--color-secondary);">Python agent with built-in email, calendar, contacts, Telegram, voice, vault, skills, subagents, deep research, and admin UI. Single Docker container.</p>
         </div>
       </div>
     </div>
@@ -280,6 +280,15 @@
               <td class="text-center check"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></td>
               <td class="text-center" style="color: var(--color-warn);">Via agent</td>
               <td class="text-center check"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></td>
+            </tr>
+            <tr>
+              <td class="font-medium" style="color: #ddd;">Deep research</td>
+              <td class="text-center check"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
+              <td class="text-center cross"><svg class="inline h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></td>
             </tr>
             <tr>
               <td class="font-medium" style="color: #ddd;">Browser automation</td>

--- a/www/features.html
+++ b/www/features.html
@@ -308,7 +308,7 @@
           </div>
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Scheduled jobs</h3>
-            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Cron-based scheduling for morning briefings, email checks, contact sync, and custom tasks. Filter by agent in the admin UI.</p>
+            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Cron-based scheduling for morning briefings, email checks, contact sync, and custom tasks. Pause and resume jobs. Filter by agent in the admin UI.</p>
           </div>
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Context usage meter</h3>
@@ -356,11 +356,11 @@
           </div>
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Memory inspection</h3>
-            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Browse and manage long-term and short-term memory entries. See what your agent remembers and edit or delete entries.</p>
+            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Settings, Long-term, and Short-term sub-tabs with pagination and search. Inline editing via detail modal. Mobile-friendly truncation.</p>
           </div>
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Job management</h3>
-            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">View, create, and cancel scheduled jobs. Monitor subagent runs. Filter jobs by agent.</p>
+            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">View, create, pause, resume, and cancel scheduled jobs. Monitor subagent runs. Filter jobs by agent.</p>
           </div>
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Secrets vault</h3>
@@ -427,6 +427,10 @@
             <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Optional headless Playwright browser. Read JS-heavy pages, act on websites with persistent logged-in profiles. Per-domain approval.</p>
           </div>
           <div class="feature-card">
+            <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Deep research</h3>
+            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Multi-step autonomous research pipeline: plan queries, fan-out web searches, fetch and read sources, verify claims, synthesize a cited report delivered as a shareable artifact.</p>
+          </div>
+          <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Web artifacts</h3>
             <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">The agent publishes pages and sites under /artifacts/ using workspace file tools. Sandbox CSP for security. Shareable links.</p>
           </div>
@@ -484,7 +488,7 @@
         <div class="grid gap-6 sm:grid-cols-2">
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Multi-provider support</h3>
-            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Choose from Anthropic Claude, OpenAI, Grok (xAI), Google Gemini, DeepSeek, or OpenRouter. Configure per-agent or globally. Image generation via OpenRouter, fal.ai, or OpenAI.</p>
+            <p class="text-xs leading-relaxed" style="color: var(--color-secondary);">Choose from Anthropic Claude, OpenAI, Grok (xAI), Google Gemini, DeepSeek, or OpenRouter. Configure per-agent or globally. Thinking levels up to 'max'. Image generation via OpenRouter, fal.ai, or OpenAI.</p>
           </div>
           <div class="feature-card">
             <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Provider sub-tabs</h3>

--- a/www/index.html
+++ b/www/index.html
@@ -126,7 +126,7 @@
       <div class="mb-4 inline-flex items-center gap-2 rounded-full border px-4 py-1 text-xs"
         style="border-color: var(--color-accent-dim); background: var(--color-accent-glow); color: var(--color-accent);">
         <span class="inline-block h-1.5 w-1.5 rounded-full" style="background: var(--color-accent);"></span>
-        <span id="version-tag">v0.33</span> &mdash; Self-hosted &bull; Open source &bull; MIT
+        <span id="version-tag">v0.36</span> &mdash; Self-hosted &bull; Open source &bull; MIT
       </div>
 
       <h1 class="mx-auto mb-6 max-w-3xl text-4xl font-bold leading-tight sm:text-5xl md:text-6xl" style="color: #eee;">
@@ -471,7 +471,7 @@
             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color: var(--color-accent);"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
           </div>
           <h3 class="mb-1 text-sm font-semibold" style="color: #eee;">Browser & search</h3>
-          <p class="text-xs" style="color: var(--color-secondary);">Headless Playwright, Tavily or self-hosted SearXNG. Web artifacts</p>
+          <p class="text-xs" style="color: var(--color-secondary);">Headless Playwright, Tavily or self-hosted SearXNG. Deep research with cited reports. Web artifacts</p>
         </div>
         <div class="feature-card text-center">
           <div class="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-md" style="background: var(--color-accent-glow);">

--- a/www/llm-full.txt
+++ b/www/llm-full.txt
@@ -177,6 +177,10 @@ faster-whisper (CTranslate2-based). On-device, offline, multilingual. Auto-selec
 
 Headless Chromium via Playwright. Self-driving explore mode (inner LLM loop navigates, fills forms, clicks). Persistent logged-in profiles. Per-domain action rules.
 
+## Deep research
+
+Multi-step autonomous research pipeline. The agent plans search queries, fans out web searches, fetches and reads full pages, cross-checks claims across sources, and synthesizes a cited report delivered as a shareable artifact. Configurable search/read models and token budget via the admin UI Tools tab.
+
 ## Web artifacts
 
 Agent writes files to `artifacts/<slug>/`, served as shareable links with sandboxed CSP. Multi-file sites, PDFs, images.
@@ -193,7 +197,7 @@ Cron-based job scheduler. Job types:
 - memory_consolidation: T4 hygiene job
 - subagent: scoped sub-task
 
-One-shot tasks via Telegram or admin UI. Filter by agent. Show/hide completed jobs.
+Pause and resume jobs from the admin UI. One-shot tasks via Telegram or admin UI. Filter by agent. Show/hide completed jobs.
 
 ## Admin UI
 
@@ -202,8 +206,8 @@ Full web dashboard: FastAPI + HTMX + Alpine.js + Tailwind CSS v4.
 - Setup wizard for first-boot configuration
 - Agent editor (character, skills, tools, voice, accounts, LLM provider)
 - Skills editor with live preview
-- Memory inspector (browse, edit, delete entries)
-- Job management (create, cancel, monitor)
+- Memory inspector (Settings / Long-term / Short-term sub-tabs, pagination, search, inline editing via detail modal)
+- Job management (create, pause, resume, cancel, monitor)
 - Per-agent log streams (filterable by stream, level, time, text)
 - Prompt inspector (last-sent LLM payload per context)
 - Token usage dashboard (24h/7d/30d, per-provider breakdown)

--- a/www/llm.txt
+++ b/www/llm.txt
@@ -43,9 +43,10 @@ Admin UI at http://localhost:8000 — setup wizard guides through LLM API key, T
 - Memory: four-tier system with automatic extraction from conversations
 - Skills: markdown-based, installable from git repos via admin UI
 - Subagents: scoped sub-tasks with step/token/thinking budgets
+- Deep research: multi-step autonomous research pipeline — plan, search, fetch, verify, synthesize a cited report as a shareable artifact
 - Browser: headless Playwright with persistent profiles and per-domain rules, optional sidecar
 - Coding: read/write/edit/bash tools confined to workspace directory
-- Scheduling: cron-based jobs for briefings, email checks, custom tasks
+- Scheduling: cron-based jobs for briefings, email checks, custom tasks — pause and resume via admin UI
 - Security: ALWAYS/ASK/NEVER permission rules, Telegram inline approval buttons, YOLO mode default
 - Admin UI: PWA-installable, token usage dashboard (24h/7d/30d), per-agent LLM override, mid-turn steering
 - Artifacts: agent-generated web apps and pages served under /artifacts/ with shareable links

--- a/www/use-cases.html
+++ b/www/use-cases.html
@@ -121,11 +121,15 @@
               <span class="shrink-0 mt-0.5" style="color: var(--color-accent);">↳</span>
               <span style="color: var(--color-secondary);">"Run tests, check the results, and open an issue if any fail"</span>
             </div>
+            <div class="flex gap-3 rounded-md px-4 py-3 text-xs" style="background: var(--color-elevated);">
+              <span class="shrink-0 mt-0.5" style="color: var(--color-accent);">↳</span>
+              <span style="color: var(--color-secondary);">"Research the best Rust HTTP frameworks and give me a cited comparison"</span>
+            </div>
           </div>
 
           <div class="mt-6 flex flex-wrap gap-2">
             <span class="text-xs px-2 py-0.5 rounded" style="background: var(--color-accent-glow); color: var(--color-accent); border: 1px solid var(--color-accent-dim);">Coding harness</span>
-            <span class="text-xs px-2 py-0.5 rounded" style="background: var(--color-accent-glow); color: var(--color-accent); border: 1px solid var(--color-accent-dim);">Browser automation</span>
+            <span class="text-xs px-2 py-0.5 rounded" style="background: var(--color-accent-glow); color: var(--color-accent); border: 1px solid var(--color-accent-dim);">Deep research</span>
             <span class="text-xs px-2 py-0.5 rounded" style="background: var(--color-accent-glow); color: var(--color-accent); border: 1px solid var(--color-accent-dim);">Web search</span>
             <span class="text-xs px-2 py-0.5 rounded" style="background: var(--color-accent-glow); color: var(--color-accent); border: 1px solid var(--color-accent-dim);">GitHub integration</span>
           </div>


### PR DESCRIPTION
## Summary
- **Deep research**: new feature cards on features page, comparison table row, use-case example prompt, homepage mention, llm.txt/llm-full.txt sections
- **Job pause/resume** (v0.34): updated features page (scheduled jobs + job management cards) and llm texts
- **Thinking level 'max'** (v0.35): added to LLM providers card on features page
- **Memory sub-tabs** (v0.34): updated memory inspection card (sub-tabs, pagination, search, detail modal)
- **Version badge**: bumped fallback from v0.33 → v0.36 on homepage

## Test plan
- [ ] Run `make serve` in `www/` and verify all 4 pages render correctly
- [ ] Check deep research card appears in Browser & Web section on features page
- [ ] Check comparison table has deep research row
- [ ] Check version badge shows v0.36 on homepage