### PR TITLE
Fix sitemap to use canonical non-.html URLs

### DIFF
--- a/www/sitemap.xml
+++ b/www/sitemap.xml
@@ -6,17 +6,17 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://humux.dev/features.html</loc>
+    <loc>https://humux.dev/features</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://humux.dev/use-cases.html</loc>
+    <loc>https://humux.dev/use-cases</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://humux.dev/comparison.html</loc>
+    <loc>https://humux.dev/comparison</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -26,92 +26,92 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/multi-channel-agent-architecture.html</loc>
+    <loc>https://humux.dev/blog/multi-channel-agent-architecture</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/skills-over-code.html</loc>
+    <loc>https://humux.dev/blog/skills-over-code</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/memory-architecture-for-agents.html</loc>
+    <loc>https://humux.dev/blog/memory-architecture-for-agents</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/permission-engineering.html</loc>
+    <loc>https://humux.dev/blog/permission-engineering</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/single-container-agents.html</loc>
+    <loc>https://humux.dev/blog/single-container-agents</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/voice-pipelines-for-agents.html</loc>
+    <loc>https://humux.dev/blog/voice-pipelines-for-agents</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/why-multiple-agents.html</loc>
+    <loc>https://humux.dev/blog/why-multiple-agents</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/subagent-patterns.html</loc>
+    <loc>https://humux.dev/blog/subagent-patterns</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/secrets-management-agents.html</loc>
+    <loc>https://humux.dev/blog/secrets-management-agents</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/group-chat-engineering.html</loc>
+    <loc>https://humux.dev/blog/group-chat-engineering</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/replacing-cloud-ai.html</loc>
+    <loc>https://humux.dev/blog/replacing-cloud-ai</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/use-case-walkthroughs.html</loc>
+    <loc>https://humux.dev/blog/use-case-walkthroughs</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/release-notes-v032-v033.html</loc>
+    <loc>https://humux.dev/blog/release-notes-v032-v033</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/release-notes-v029-v031.html</loc>
+    <loc>https://humux.dev/blog/release-notes-v029-v031</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://humux.dev/blog/release-notes-v025-v028.html</loc>
+    <loc>https://humux.dev/blog/release-notes-v025-v028</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/comparison/humux-vs-hermes.html</loc>
+    <loc>https://humux.dev/comparison/humux-vs-hermes</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/comparison/humux-vs-openclaw.html</loc>
+    <loc>https://humux.dev/comparison/humux-vs-openclaw</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://humux.dev/comparison/humux-vs-zeroclaw.html</loc>
+    <loc>https://humux.dev/comparison/humux-vs-zeroclaw</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
## Summary

Remove `.html` extensions from all page URLs in the sitemap.xml. The Cloudflare reverse proxy redirects all `.html` URLs to their canonical non-.html forms (with 308 status), which wastes crawl budget and can dilute SEO signals. The sitemap should point directly to canonical URLs.

## Changes

Updated `www/sitemap.xml` to emit URLs without `.html` extensions:
- `https://humux.dev/features` (was `features.html`)
- `https://humux.dev/blog/voice-pipelines-for-agents` (was `...html`)
- All other page URLs similarly cleaned

Root paths (`https://humux.dev/`, `https://humux.dev/blog/`) remain unchanged.

## Post-deploy

After this is deployed, resubmit the sitemap to Google Search Console so Google crawls the canonical URLs directly without following redirects.

Fixes #303