### PR TITLE
Raise default max_tool_rounds from 50 to 100

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1530,7 +1530,7 @@ def create_admin_app(
                 "model": (await config_store.get("agent.model")) or "",
                 "thinking_level": (await config_store.get("agent.thinking_level")) or "",
                 "max_tokens": (await config_store.get("agent.max_tokens")) or "16384",
-                "max_tool_rounds": (await config_store.get("agent.max_tool_rounds")) or "50",
+                "max_tool_rounds": (await config_store.get("agent.max_tool_rounds")) or "100",
                 "temperature": (await config_store.get("agent.temperature")) or "0.5",
             },
         }
@@ -1917,7 +1917,7 @@ def create_admin_app(
         openrouter_vaulted = _is_vault_ref(openrouter_api_key)
         model = await config_store.get("agent.model") or "claude-4-6-sonnet"
         max_tokens = await config_store.get("agent.max_tokens") or "16384"
-        max_tool_rounds = await config_store.get("agent.max_tool_rounds") or "50"
+        max_tool_rounds = await config_store.get("agent.max_tool_rounds") or "100"
         thinking_level = await config_store.get("agent.thinking_level") or ""
         temperature = await config_store.get("agent.temperature") or "0.5"
         extraction_provider = await config_store.get("memory.extraction_provider") or "deepseek"

--- a/humux/api/templates/partials/llm.html
+++ b/humux/api/templates/partials/llm.html
@@ -46,7 +46,7 @@
   {{ rd_max_replies|default('6', true)|tojson|forceescape }},
   {{ rd_window_seconds|default('120', true)|tojson|forceescape }},
   {{ max_tokens|default('16384', true)|tojson|forceescape }},
-  {{ max_tool_rounds|default('50', true)|tojson|forceescape }},
+  {{ max_tool_rounds|default('100', true)|tojson|forceescape }},
   {{ temperature|default('0.5', true)|tojson|forceescape }},
   {{ tr_max_reflections|default('12', true)|tojson|forceescape }}
 )">

--- a/humux/api/templates/partials/llm_inference.html
+++ b/humux/api/templates/partials/llm_inference.html
@@ -51,7 +51,7 @@
         <div>
           <label class="label" for="llm-max-rounds">Max tool rounds</label>
           <input type="number" min="1" class="input-sm" style="max-width:160px" x-model="maxToolRounds" id="llm-max-rounds">
-          <p class="text-muted text-xs mt-1">Hard backstop on LLM round-trips in a single user turn. Default 50; raise if a legitimate workflow needs more rounds.</p>
+          <p class="text-muted text-xs mt-1">Hard backstop on LLM round-trips in a single user turn. Default 100; raise if a legitimate workflow needs more rounds.</p>
         </div>
       </div>
 

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -104,7 +104,7 @@ class AgentConfig(BaseModel):
     # several tool calls), so even a model that ignores every error signal can't loop
     # forever. Normal turns use a handful; raise it if a legitimate workflow needs more.
     # Exposed on the LLM admin tab.
-    max_tool_rounds: int = 50
+    max_tool_rounds: int = 100
     # Sampling temperature for the main agent loop. Lower = steadier tool calls;
     # higher = more varied prose. Skipped automatically for reasoning calls. Tune
     # on the LLM admin tab. (#12)


### PR DESCRIPTION
Models now sustain longer multi-step work. The 50-round ceiling was set conservatively and cuts legitimate workflows short. Raise the default to 100 so users don't hit the backstop unnecessarily.

Existing installs with explicit custom values are unaffected (they win over defaults).

**Changes:**
- config.py: AgentConfig.max_tool_rounds default
- admin.py: default fallback values in two places
- llm.html: template default render value  
- llm_inference.html: helper text

Fixes #305