### PR TITLE
fix: dedupe voice-marked parts that fall back to text

### DIFF
--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -2426,13 +2426,37 @@ class AgentCore:
         note, or a mix. No marker → a single message (unchanged behaviour).
         Returns the message list and the combined marker-free text (for history,
         logging, and the backward-compat ``AgentResponse.text``).
+
+        A voice-marked part whose synthesis fails (or whose pipeline isn't
+        loaded) must never silently degrade into a duplicate text bubble
+        (#304): if the same marker-free content was already going out as plain
+        text elsewhere in the turn, the failed part is dropped instead of
+        repeated; otherwise it falls back to text with a warning logged.
         """
         voice_name = (agent.voice or None) if agent else None
         parts = [p for p in (seg.strip() for seg in _SPLIT_MARKER_RE.split(final_text)) if p]
-        messages: list[OutputMessage] = []
+        items: list[tuple[str, bool, bytes | None]] = []
         for part in parts:
+            marked = bool(_VOICE_MARKER_RE.search(part))
             voice_bytes = await self._maybe_synthesize_voice(part, voice=voice_name)
-            messages.append(OutputMessage(text=strip_voice_marker(part), voice=voice_bytes))
+            items.append((strip_voice_marker(part), marked, voice_bytes))
+        delivered_as_text = {clean for clean, marked, _ in items if not marked}
+
+        messages: list[OutputMessage] = []
+        for clean, marked, voice_bytes in items:
+            if marked and voice_bytes is None:
+                if clean in delivered_as_text:
+                    log.warning(
+                        "Voice synthesis unavailable for part already delivered as text; "
+                        "dropping duplicate: %r",
+                        clean[:80],
+                    )
+                    continue
+                log.warning(
+                    "Voice synthesis unavailable/failed; falling back to text: %r", clean[:80]
+                )
+                delivered_as_text.add(clean)
+            messages.append(OutputMessage(text=clean, voice=voice_bytes))
         combined = "\n".join(m.text for m in messages if m.text)
         return messages, combined
 

--- a/humux/tests/test_multi_message.py
+++ b/humux/tests/test_multi_message.py
@@ -111,3 +111,42 @@ async def test_voice_marker_stripped_per_part(agent):
     )
     assert [m.text for m in messages] == ["spoken bit", "typed bit"]
     assert "[respond_with_voice" not in combined
+
+
+# --- voice fallback on failed/unavailable synthesis (#304) ------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_voice_part_dropped_when_already_sent_as_text(agent):
+    # No TTS pipeline → synthesis never succeeds. The voice-marked part repeats
+    # a plain-text part's content, so it must be dropped, not resent as text.
+    messages, combined = await agent._split_reply(
+        "Here's the summary[[split]]Here's the summary[respond_with_voice]", None
+    )
+    assert [m.text for m in messages] == ["Here's the summary"]
+    assert [m.voice for m in messages] == [None]
+    assert combined == "Here's the summary"
+
+
+@pytest.mark.asyncio
+async def test_failed_voice_only_part_falls_back_to_text(agent):
+    # A voice-only part (no matching text part) still needs to reach the user.
+    messages, combined = await agent._split_reply("solo voice line[respond_with_voice]", None)
+    assert [m.text for m in messages] == ["solo voice line"]
+    assert [m.voice for m in messages] == [None]
+    assert combined == "solo voice line"
+
+
+@pytest.mark.asyncio
+async def test_successful_voice_synthesis_unchanged(agent, monkeypatch):
+    class FakeVoice:
+        async def synthesize(self, text, voice=None, lang=None):
+            return b"audio-bytes"
+
+    monkeypatch.setattr(agent, "voice", FakeVoice())
+    messages, combined = await agent._split_reply(
+        "Here's the summary[[split]]Here's the summary[respond_with_voice]", None
+    )
+    assert [m.text for m in messages] == ["Here's the summary", "Here's the summary"]
+    assert [m.voice for m in messages] == [None, b"audio-bytes"]
+    assert combined == "Here's the summary\nHere's the summary"


### PR DESCRIPTION
## Root cause

In a multi-message turn, `_split_reply()` (`humux/core/agent.py`) built each `OutputMessage` independently: for every part it called `_maybe_synthesize_voice()` and always kept the part's full text regardless of the outcome. When TTS synthesis failed, or the voice pipeline wasn't loaded (`self.voice is None`), `voice_bytes` came back `None`, but the text was kept as-is. The Telegram delivery loop then sent that `OutputMessage` as a plain text bubble.

So a turn like:

- Part 1 (no marker): "Here's the summary"
- Part 2 (`[respond_with_voice]`): "Here's the summary"

degraded to two identical text bubbles and no audio whenever synthesis failed, instead of one text message + one voice note (or an explicit fallback).

## Fix

`_split_reply()` now tracks, per part, whether it carried the voice marker and computes the set of content that's guaranteed to go out as plain text (the unmarked parts). When a voice-marked part's synthesis comes back empty:

- if its content is already in that guaranteed-text set (or was already added as a fallback by an earlier failed voice part), the part is dropped and a warning is logged — no duplicate bubble.
- otherwise it falls back to a text bubble, with a warning logged so the failure isn't silent.

Unmarked parts and parts with successful synthesis are untouched.

## Testing

Added three cases to `humux/tests/test_multi_message.py`, alongside the existing `_split_reply` tests:

- text + voice part with the same content, TTS unavailable → single text message, no duplicate
- voice-only part, TTS unavailable → text fallback (not dropped)
- successful synthesis → unchanged (text bubble + voice bubble)

`uv run pytest humux/tests/test_multi_message.py` — 14 passed. Also ran `test_telegram_channel.py`, `test_voice_clean.py`, and `test_agents.py` to check nothing else in the delivery path regressed — all green.

Fixes #304