### PR TITLE
Add Test STT button to Voice tab

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1142,6 +1142,15 @@ class VoicePreviewIn(BaseModel):
     lang: str = Field("", max_length=16)  # Kokoro pronunciation override; "" = derive from voice
 
 
+class STTTestIn(BaseModel):
+    mode: str = Field("local", max_length=16)  # "local" or "remote"; anything else → local
+
+
+# Fixed phrase for the STT round-trip test (#297) — same text every run so
+# results (accuracy, timing) are comparable across local/remote and over time.
+_STT_TEST_PHRASE = "The quick brown fox jumps over the lazy dog"
+
+
 # ---------------------------------------------------------------------------
 # Auth dependency
 # ---------------------------------------------------------------------------
@@ -3196,6 +3205,63 @@ def create_admin_app(
         except Exception as exc:
             raise HTTPException(503, f"Preview failed: {exc}") from exc
         return Response(content=audio, media_type=mime)
+
+    @app.post("/voice/test-stt", dependencies=[Depends(auth)])
+    async def voice_test_stt(body: STTTestIn) -> dict:
+        """Round-trip STT test (#297): synthesize a fixed phrase via edge-tts,
+        then transcribe it through the same VoicePipeline methods that process
+        real voice messages, forced to the requested mode — so a misconfigured
+        remote STT (bad URL, unreachable sidecar, format mismatch) surfaces here
+        instead of at the next real voice message."""
+        agent = agent_state.agent
+        pipeline = getattr(agent, "voice", None) if agent else None
+        if pipeline is None:
+            raise HTTPException(
+                503, "Voice pipeline not loaded — enable TTS and restart the agent."
+            )
+        mode = "remote" if body.mode == "remote" else "local"
+
+        try:
+            audio = await pipeline._synthesize_edge(_STT_TEST_PHRASE, None)
+        except Exception as exc:
+            raise HTTPException(
+                503, f"Couldn't generate test audio (edge-tts unavailable): {exc}"
+            ) from exc
+
+        start = time.monotonic()
+        try:
+            if mode == "remote":
+                if not pipeline.stt_api_base_url:
+                    raise HTTPException(
+                        400, "Remote STT URL isn't configured — set it above and save first."
+                    )
+                text = await pipeline._transcribe_remote(audio)
+            else:
+                if pipeline._whisper is None:
+                    raise HTTPException(
+                        400,
+                        "Local STT (Whisper) isn't loaded — install faster-whisper or switch "
+                        "to remote.",
+                    )
+                loop = asyncio.get_running_loop()
+                text = await loop.run_in_executor(None, pipeline._transcribe_sync, audio)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            return {
+                "ok": False,
+                "mode": mode,
+                "error": str(exc),
+                "duration_ms": int((time.monotonic() - start) * 1000),
+            }
+
+        return {
+            "ok": True,
+            "mode": mode,
+            "text": text,
+            "duration_ms": int((time.monotonic() - start) * 1000),
+            "model": pipeline.stt_model if mode == "local" else None,
+        }
 
     @app.post("/debug/system-prompt/preview", dependencies=[Depends(auth)])
     async def system_prompt_preview(body: PromptPreviewIn) -> dict:

--- a/humux/api/templates/partials/identity.html
+++ b/humux/api/templates/partials/identity.html
@@ -20,7 +20,26 @@
   get sttMode() { return this._sttMode; },
   set sttMode(val) { this._sttMode = val; },
   get ttsMode() { return this._ttsMode; },
-  set ttsMode(val) { this._ttsMode = val; }
+  set ttsMode(val) { this._ttsMode = val; },
+  sttTestResult: '',
+  sttTestOk: false,
+  testStt() {
+    const key = localStorage.getItem('admin_api_key') || '';
+    return fetch('/voice/test-stt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + key },
+      body: JSON.stringify({ mode: this.sttMode })
+    })
+      .then(async r => {
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) throw new Error(d.detail || 'STT test failed');
+        this.sttTestOk = d.ok;
+        this.sttTestResult = d.ok
+          ? `✓ ${d.mode} STT: \"${d.text}\" (${(d.duration_ms / 1000).toFixed(1)}s)`
+          : `✗ ${d.mode} STT: ${d.error || 'failed'}`;
+      })
+      .catch(e => { this.sttTestOk = false; this.sttTestResult = e.message; });
+  }
 }">
   <h2 class="text-base mb-1">Voice</h2>
   <p class="text-muted text-xs mb-3">Configure speech-to-text (STT) and text-to-speech (TTS) used for voice messages.</p>
@@ -61,6 +80,14 @@
       <input type="text" class="input-sm" style="max-width:360px" x-model="sttApiBaseUrl"
              placeholder="http://whisper:8000/v1" id="voice-stt-url">
       <p class="text-muted text-xs mt-1">OpenAI-compatible STT endpoint (e.g. whisper sidecar, OpenAI, Groq). The model is chosen by the remote service.</p>
+    </div>
+
+    <div>
+      <button type="button" class="btn btn-sm" @click="withLoading($event.currentTarget, () => testStt())">Test STT</button>
+      <p class="text-muted text-xs mt-1">Speaks a fixed test phrase with edge-tts, then transcribes it with the selected STT engine above — no need to send a real voice message.</p>
+      <template x-if="sttTestResult">
+        <div :class="sttTestOk ? 'alert-success' : 'alert-error'" class="mt-2 text-xs" x-text="sttTestResult"></div>
+      </template>
     </div>
 
     {# ── TTS ── #}

--- a/humux/tests/test_admin_ui.py
+++ b/humux/tests/test_admin_ui.py
@@ -475,6 +475,38 @@ class TestVoicePreview:
             assert resp.status_code == 401, f"{path} should require auth"
 
 
+class TestVoiceTestStt:
+    def test_test_stt_local_round_trip(self):
+        # #297: the endpoint synthesizes the fixed test phrase via edge-tts,
+        # then feeds it through the pipeline's local transcription method —
+        # the same one real voice messages use.
+        class _VoiceStub:
+            stt_api_base_url = ""
+            stt_model = "base"
+            _whisper = object()  # non-None stand-in: "local STT is loaded"
+
+            async def _synthesize_edge(self, text, voice):
+                assert "quick brown fox" in text.lower()
+                return b"FAKE-MP3"
+
+            def _transcribe_sync(self, audio_bytes):
+                assert audio_bytes == b"FAKE-MP3"
+                return "the quick brown fox jumps over the lazy dog"
+
+        client = _client(agent=cast(Any, SimpleNamespace(voice=_VoiceStub())))
+        resp = client.post("/voice/test-stt", json={"mode": "local"}, headers=AUTH)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {
+            "ok": True,
+            "mode": "local",
+            "text": "the quick brown fox jumps over the lazy dog",
+            "duration_ms": data["duration_ms"],
+            "model": "base",
+        }
+        assert isinstance(data["duration_ms"], int)
+
+
 # ---------------------------------------------------------------------------
 # Setup wizard
 # ---------------------------------------------------------------------------

--- a/humux/voice/pipeline.py
+++ b/humux/voice/pipeline.py
@@ -230,6 +230,7 @@ class VoicePipeline:
         self.tts_voice = tts_voice
         self.tts_enabled = tts_enabled
         self.backend = backend
+        self.stt_model = stt_model
         self.kokoro_default_voice = kokoro_default_voice
         self.tts_api_base_url = tts_api_base_url.rstrip("/") if tts_api_base_url else ""
         self.stt_api_base_url = stt_api_base_url.rstrip("/") if stt_api_base_url else ""


### PR DESCRIPTION
## Summary

- New `POST /voice/test-stt` endpoint: synthesizes the fixed phrase "The quick brown fox jumps over the lazy dog" via edge-tts, then transcribes it through the same `VoicePipeline` methods (`_transcribe_remote` / `_transcribe_sync`) that process real Telegram voice messages, forced to whichever mode (local Whisper / remote sidecar) the request asks for. Returns `{ok, mode, text, duration_ms, model, error}`.
- "Test STT" button on the Voice tab, next to the STT config, matching the style of the existing TTS "Preview" button (spinner while running, inline green/red result with the transcribed text and timing).
- Errors from the underlying pipeline (connection refused, timeout, bad format, unconfigured remote URL, missing local model) are surfaced as-is rather than swallowed.

## Test plan

- [x] `uv run pytest tests/test_admin_ui.py tests/test_voice_clean.py tests/test_voice_kokoro.py` — 110 passed
- [x] New test `TestVoiceTestStt::test_test_stt_local_round_trip` mocks the pipeline and asserts the endpoint drives it through the same synth → transcribe path

Fixes #297