### PR TITLE
Subagents can run on a different model than their parent

### DIFF
--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -46,6 +46,8 @@ The agent decides to delegate and calls the tool. Two modes:
   "max_steps": 6,                // optional — caller-chosen, capped at the configured max
   "token_budget": 40000,         // optional — caller-chosen, min 1000, capped at the configured max
   "thinking_effort": "high",     // optional — off | low | medium | high; omit to inherit yours
+  "model": "deepseek-v4-flash",  // optional — must be an allowed model; omit to inherit yours
+  "provider": "deepseek",        // optional — only to disambiguate; follows from "model"
   "background": false            // true → run async, report back when done
 }
 ```
@@ -60,6 +62,15 @@ configured ceiling, `thinking_effort` to inherit the caller's level — and the
 numeric caps are clamped to the [Guardrails](#guardrails) maxima, which the
 agent can dial *down* but never past. Omitting `agent` runs the subagent as
 the caller itself, with the same identity and scope.
+
+**A subagent can run on a different model.** With `allowed_models` configured
+(see [Guardrails](#guardrails)), a spawn may name a `model` — a coordinator on a
+big model then farms the legwork out to cheap, fast workers and keeps the
+synthesis for itself. The model must be one of the allowed `provider:model`
+entries, which the tool description lists for the agent; anything else is
+refused. `provider` is only needed to disambiguate a model name that appears
+under two providers, and each provider uses the API key already configured for
+it. Omit both and the subagent inherits the caller's model, as it always has.
 
 **Files hand back automatically.** The subagent shares the agent's filesystem,
 so any file it writes is already on disk where the caller can reach it — it just
@@ -118,6 +129,7 @@ limit, applied live without a restart), or under `subagents` in `config.yml`:
 | `max_steps` | `12` | Ceiling on tool-call rounds per run — a hard stop; the agent may request fewer per spawn, never more |
 | `token_budget` | `100000` | Ceiling on tokens per run (best-effort); the agent may request fewer per spawn, never more |
 | `max_concurrent` | `3` | Max background runs at once |
+| `allowed_models` | *(empty)* | `provider:model` entries a spawn may pick instead of inheriting the caller's model — one per line in the admin card. Empty means overrides are off entirely |
 
 When disabled, the tool is hidden from the assistant and from the Agents tool
 scope. Assign it per agent in the **Agents** editor. A run that hits its step

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -2127,6 +2127,14 @@ def create_admin_app(
         sub_steps = await config_store.get("subagents.max_steps") or "12"
         sub_tokens = await config_store.get("subagents.token_budget") or "100000"
         sub_concurrent = await config_store.get("subagents.max_concurrent") or "3"
+        # Allowed "provider:model" overrides (#299) — stored as a JSON list,
+        # edited as one entry per line.
+        try:
+            sub_allowed = "\n".join(
+                json.loads(await config_store.get("subagents.allowed_models") or "[]")
+            )
+        except json.JSONDecodeError, TypeError:
+            sub_allowed = ""
         # Result-summary inference (notification + context digest) for finished
         # background batches — fast/cheap model by default.
         ss_enabled = await config_store.get("subagent_summary.enabled")
@@ -2192,6 +2200,7 @@ def create_admin_app(
             subagents_max_steps=sub_steps,
             subagents_token_budget=sub_tokens,
             subagents_max_concurrent=sub_concurrent,
+            subagents_allowed_models=sub_allowed,
             summary_enabled=ss_enabled,
             summary_provider=ss_provider,
             summary_model=ss_model,

--- a/humux/api/templates/partials/tools.html
+++ b/humux/api/templates/partials/tools.html
@@ -68,6 +68,7 @@
     steps: {{ subagents_max_steps|default('12', true)|tojson|forceescape }},
     tokens: {{ subagents_token_budget|default('100000', true)|tojson|forceescape }},
     concurrent: {{ subagents_max_concurrent|default('3', true)|tojson|forceescape }},
+    allowedModels: {{ subagents_allowed_models|default('', true)|tojson|forceescape }},
     summaryEnabled: {{ summary_enabled|default('true', true)|tojson|forceescape }},
     summaryProvider: {{ summary_provider|default('deepseek', true)|tojson|forceescape }},
     summaryModel: {{ summary_model|default('deepseek-v4-flash', true)|tojson|forceescape }},
@@ -80,6 +81,7 @@
         'subagents.max_steps': String(parseInt(this.steps) || 1),
         'subagents.token_budget': String(parseInt(this.tokens) || 1),
         'subagents.max_concurrent': String(parseInt(this.concurrent) || 1),
+        'subagents.allowed_models': JSON.stringify(String(this.allowedModels || '').split('\n').map(s => s.trim()).filter(Boolean)),
         'subagent_summary.enabled': String(this.summaryEnabled === true || this.summaryEnabled === 'true'),
         'subagent_summary.provider': String(this.summaryProvider || 'deepseek').trim(),
         'subagent_summary.model': String(this.summaryModel || 'deepseek-v4-flash').trim(),
@@ -135,6 +137,18 @@
         <input type="number" min="1" class="input-sm" style="max-width:200px" x-model="concurrent" id="tools-sub-concurrent">
         <p class="text-muted text-xs mt-1">Background runs allowed at once.</p>
       </div>
+    </div>
+    <div class="mt-3" x-show="enabled === 'true' || enabled === true">
+      <label class="label" for="tools-sub-allowed-models">Allowed models for subagents</label>
+      <textarea class="input-sm" x-model="allowedModels" id="tools-sub-allowed-models"
+                style="max-width:420px; min-height:80px; font-family:monospace; font-size:0.75rem"
+                placeholder="deepseek:deepseek-v4-flash&#10;anthropic:claude-sonnet-4-5"></textarea>
+      <p class="text-muted text-xs mt-1">
+        One <code>provider:model</code> per line. Lets the assistant send a subagent to a
+        cheaper or faster model than its own — it may only pick from this list, and a
+        spawn asking for anything else is refused. Blank = subagents always inherit the
+        caller's model. Each provider uses its API key from the <strong>Assistant</strong> tab.
+      </p>
     </div>
     <div class="border-t border-border mt-4 pt-4" x-show="enabled === 'true' || enabled === true">
       <div class="flex items-center justify-between gap-3 mb-1">

--- a/humux/config.yml.example
+++ b/humux/config.yml.example
@@ -218,6 +218,9 @@ subagents:
   max_steps: 12        # max tool-call rounds per run (hard stop)
   token_budget: 100000 # approx token ceiling per run (best-effort)
   max_concurrent: 3    # max background runs at once
+  # "provider:model" a spawn may pick instead of inheriting the caller's LLM
+  # (e.g. a cheap worker under an expensive coordinator). Empty = inherit only.
+  allowed_models: []   # e.g. ["deepseek:deepseek-v4-flash"]
 
 # When a background subagent batch finishes, distil it into a one-line chat
 # notification + a concise context digest (instead of dumping the raw output).

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -53,11 +53,13 @@ from core.subagents import (
     RESULT_FOR_AGENT_INSTRUCTION,
     SubagentRegistry,
     SubagentRun,
+    allowed_models_hint,
     fallback_summary,
     narrow_accounts,
     narrow_scope,
     normalize_effort,
     resolve_cap,
+    resolve_model_override,
     short_summary,
     summarize_batch,
 )
@@ -810,6 +812,21 @@ TOOLS = [
                         "How hard the subagent reasons each step. Omit to inherit "
                         "your own level. Use 'high' for tricky reasoning, 'off'/'low' "
                         "for simple mechanical work."
+                    ),
+                },
+                "model": {
+                    "type": "string",
+                    "description": (
+                        "Model the subagent should run on. Omit to inherit yours — "
+                        "only the models named in this tool's description may be "
+                        "picked, and if none are named, omit it."
+                    ),
+                },
+                "provider": {
+                    "type": "string",
+                    "description": (
+                        "Provider for 'model' (e.g. 'deepseek', 'anthropic'). Only "
+                        "needed to disambiguate; omit and it follows from 'model'."
                     ),
                 },
                 "background": {
@@ -1682,6 +1699,16 @@ class AgentCore:
         # scope withholds web_search (#293); the handler refuses too.
         if agent and agent.tools and not agent.allows_tool("web_search"):
             tools = [t for t in tools if t["name"] != "deep_research"]
+        # Name the models a spawn may pick (#299), else the agent can't know them.
+        # Copy the schema — the module-level list is shared across turns.
+        hint = allowed_models_hint(self.config.subagents.allowed_models)
+        if hint:
+            tools = [
+                {**t, "description": f"{t['description']}\nSubagent models — {hint}."}
+                if t["name"] == "spawn_subagent"
+                else t
+                for t in tools
+            ]
         return tools
 
     async def _turn_preamble(
@@ -3648,6 +3675,8 @@ class AgentCore:
             max_steps=params.get("max_steps"),
             token_budget=params.get("token_budget"),
             thinking_effort=params.get("thinking_effort"),
+            model=str(params.get("model", "")),
+            provider=str(params.get("provider", "")),
         )
 
     async def run_subagent(
@@ -3663,6 +3692,8 @@ class AgentCore:
         max_steps: object = None,
         token_budget: object = None,
         thinking_effort: str | None = None,
+        model: str = "",
+        provider: str = "",
     ) -> dict:
         """Run a subagent — the one primitive behind both the tool and scheduled
         ``subagent`` jobs. Scope is narrowed from the caller (inherit-never-widen);
@@ -3671,6 +3702,11 @@ class AgentCore:
         ``max_steps`` / ``token_budget`` / ``thinking_effort`` let the caller size
         the run; each defaults to the configured value and is clamped to it as a
         ceiling (``thinking_effort`` defaults to inheriting the caller's level).
+
+        ``model`` / ``provider`` send the run to a *different* LLM than the caller's
+        (#299) — a cheap worker under an expensive coordinator. Both omitted (the
+        default) inherits, exactly as before; anything else must be on the
+        ``subagents.allowed_models`` allowlist or the spawn is refused.
         """
         cfg = self.config.subagents
         if not cfg.enabled:
@@ -3684,6 +3720,14 @@ class AgentCore:
                     "do this work directly instead of spawning another subagent."
                 )
             }
+
+        # LLM override, allowlisted (#299). Refused as a normal tool error the
+        # calling model can read and retry, never an exception.
+        ov_provider, ov_model, ov_error = resolve_model_override(
+            provider, model, cfg.allowed_models
+        )
+        if ov_error:
+            return {"error": ov_error}
 
         # Resolve + narrow the agent. A name must exist; with no name the child
         # inherits the caller's identity and scope.
@@ -3726,6 +3770,8 @@ class AgentCore:
             max_steps=resolve_cap(max_steps, cfg.max_steps),
             token_budget=resolve_cap(token_budget, cfg.token_budget, floor=1000),
             effort=normalize_effort(thinking_effort),
+            provider=ov_provider,
+            model=ov_model,
             origin_channel=origin_channel,
             origin_user_id=origin_user_id,
             origin_chat_id=origin_chat_id,
@@ -3874,7 +3920,14 @@ class AgentCore:
         # "senior" subagent gets its bigger model); an explicit spawn effort
         # still wins over the inherited/overridden thinking level.
         llm, model, max_tokens = self._agent_llm(child_agent)
-        if run.effort is not None:
+        if run.provider or run.model:
+            # A per-spawn model (#299) — same key/base-URL resolution every other
+            # off-provider inference uses, so a foreign provider gets its own
+            # configured credentials. Effort defaults to the level we'd inherit.
+            level = run.effort if run.effort is not None else llm.thinking_level
+            llm = self._background_llm(run.provider or llm.provider, level)
+            model = run.model or model
+        elif run.effort is not None:
             clone = copy.copy(llm)
             clone.thinking_level = run.effort
             llm = clone

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -525,6 +525,9 @@ class SubagentsConfig(BaseModel):
     max_steps: int = 12  # max tool-call rounds per run (hard stop)
     token_budget: int = 100_000  # approx token ceiling per run (best-effort)
     max_concurrent: int = 3  # max background runs at once
+    # "provider:model" entries a spawn may pick instead of inheriting the
+    # caller's LLM (#299). Empty = no overrides; a subagent always inherits.
+    allowed_models: list[str] = []
 
 
 class SubagentSummaryConfig(BaseModel):

--- a/humux/core/subagents.py
+++ b/humux/core/subagents.py
@@ -64,6 +64,68 @@ def normalize_effort(value: str | None) -> str | None:
     return _EFFORT_LEVELS.get(str(value).strip().lower())
 
 
+def _parse_allowed(allowed: list[str] | None) -> list[tuple[str, str]]:
+    """Split configured ``provider:model`` entries into pairs, dropping junk."""
+    out: list[tuple[str, str]] = []
+    for entry in allowed or []:
+        provider, _, model = str(entry).strip().partition(":")
+        if provider.strip() and model.strip():
+            out.append((provider.strip(), model.strip()))
+    return out
+
+
+def allowed_models_hint(allowed: list[str] | None) -> str:
+    """One line naming the models a spawn may pick, or "" when none are configured."""
+    pairs = _parse_allowed(allowed)
+    if not pairs:
+        return ""
+    return "Available: " + ", ".join(f"{p}:{m}" for p, m in pairs)
+
+
+def resolve_model_override(
+    provider: str, model: str, allowed: list[str] | None
+) -> tuple[str, str, str]:
+    """Resolve a spawn's requested model/provider against ``subagents.allowed_models``.
+
+    Returns ``(provider, model, error)``. ``("", "", "")`` means *inherit the
+    caller's LLM* — the default and the only outcome when the caller asked for
+    nothing, so existing spawns are unchanged (#299).
+
+    Entries are ``provider:model``; a request matches an entry when every field
+    it *did* name matches, so ``model`` alone resolves its provider from the list
+    (and ``provider`` alone picks that provider's first listed model). An empty
+    list means overrides are off entirely. A miss returns a message for the
+    calling model, never an exception.
+    """
+    provider, model = (provider or "").strip(), (model or "").strip()
+    if not provider and not model:
+        return "", "", ""
+    pairs = _parse_allowed(allowed)
+    if not pairs:
+        return (
+            "",
+            "",
+            (
+                "Subagent model/provider overrides are not enabled "
+                "(no allowed models configured). Omit 'model' and 'provider' to "
+                "inherit the current model."
+            ),
+        )
+    for p, m in pairs:
+        if (not provider or p == provider) and (not model or m == model):
+            return p, m, ""
+    asked = ":".join(x for x in (provider, model) if x)
+    return (
+        "",
+        "",
+        (
+            f"Model '{asked}' is not allowed for subagents. "
+            f"{allowed_models_hint(allowed)}. Omit 'model' and 'provider' to inherit "
+            "the current model."
+        ),
+    )
+
+
 def resolve_cap(value: object, ceiling: int, floor: int = 1) -> int:
     """Clamp a caller-requested run cap (steps / token budget) into bounds.
 
@@ -149,6 +211,9 @@ class SubagentRun:
     max_steps: int = 0
     token_budget: int = 0
     effort: str | None = None
+    # LLM override resolved from subagents.allowed_models (#299); "" = inherit.
+    provider: str = ""
+    model: str = ""
     status: str = "running"  # running | done | cancelled | error
     progress: str = ""
     result: str = ""
@@ -335,6 +400,16 @@ def _selfcheck() -> None:
     assert narrow_accounts([{"account": "y", "access_level": "read_write"}], [rw]) == []
     # Both read_write → preserved.
     assert narrow_accounts([rw], [rw]) == [rw]
+
+    # Model overrides (#299): nothing asked → inherit, whatever the config says.
+    assert resolve_model_override("", "", []) == ("", "", "")
+    assert resolve_model_override("", "", ["a:b"]) == ("", "", "")
+    # Asked with no allowlist → refused, not raised.
+    assert resolve_model_override("", "b", [])[2]
+    # Model alone resolves its provider from the list.
+    assert resolve_model_override("", "b", ["a:b"]) == ("a", "b", "")
+    assert resolve_model_override("a", "b", ["a:b", "c:d"]) == ("a", "b", "")
+    assert resolve_model_override("a", "d", ["a:b", "c:d"])[2]  # wrong pairing → refused
     print("subagents.py self-check OK")
 
 

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -120,6 +120,7 @@ class _ScriptedLLM:
     def __init__(self, responses: list[LLMResponse]) -> None:
         self._responses = list(responses)
         self.provider = "deepseek"
+        self.thinking_level = ""
 
     async def generate(self, **_kw) -> LLMResponse:
         if self._responses:
@@ -591,6 +592,62 @@ async def test_run_subagent_effort_uses_scoped_client(agent, monkeypatch) -> Non
     assert captured["level"] == "high"
     assert agent.llm.thinking_level == ""  # main client untouched
     assert agent.subagents.get(result["run_id"]).effort == "high"
+
+
+# ---------------------------------------------------------------------------
+# Per-spawn model/provider override, gated by subagents.allowed_models (#299)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_subagent_model_override(agent, monkeypatch) -> None:
+    agent.config.subagents.allowed_models = ["anthropic:claude-sonnet-4-5"]
+    agent.llm = _ScriptedLLM([LLMResponse(text="ok", tool_calls=[])])
+    built: dict = {}
+
+    def _fake_background_llm(provider, thinking_level=""):
+        built["provider"] = provider
+        return agent.llm
+
+    monkeypatch.setattr(agent, "_background_llm", _fake_background_llm)
+
+    # Allowed: the model alone resolves its provider off the allowlist.
+    result = await agent.run_subagent(task="x", model="claude-sonnet-4-5")
+    assert result["ok"] is True
+    assert built["provider"] == "anthropic"
+    run = agent.subagents.get(result["run_id"])
+    assert (run.provider, run.model) == ("anthropic", "claude-sonnet-4-5")
+
+    # Not on the list: refused with a readable error, no run started.
+    built.clear()
+    refused = await agent.run_subagent(task="x", model="gpt-9")
+    assert "not allowed" in refused["error"]
+    assert "anthropic:claude-sonnet-4-5" in refused["error"]
+    assert built == {}
+
+    # Omitted: inherits the caller's client exactly as before (#299 back-compat).
+    result = await agent.run_subagent(task="x")
+    assert result["ok"] is True
+    assert built == {}
+    run = agent.subagents.get(result["run_id"])
+    assert (run.provider, run.model) == ("", "")
+
+
+@pytest.mark.asyncio
+async def test_run_subagent_model_override_needs_an_allowlist(agent) -> None:
+    agent.llm = _ScriptedLLM([LLMResponse(text="ok", tool_calls=[])])
+    refused = await agent.run_subagent(task="x", model="anything")  # allowed_models empty
+    assert "not enabled" in refused["error"]
+
+
+def test_spawn_subagent_description_names_allowed_models(agent) -> None:
+    agent.config.subagents.allowed_models = ["deepseek:deepseek-v4-flash"]
+    spawn = next(t for t in agent._tools_for_turn(None) if t["name"] == "spawn_subagent")
+    assert "deepseek:deepseek-v4-flash" in spawn["description"]
+    # The shared module-level schema is untouched by the per-turn copy.
+    agent.config.subagents.allowed_models = []
+    spawn = next(t for t in agent._tools_for_turn(None) if t["name"] == "spawn_subagent")
+    assert "deepseek:deepseek-v4-flash" not in spawn["description"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Lead-coordinator pattern: an agent on an expensive model delegates the legwork to
subagents on a cheap, fast one and keeps the synthesis for itself.

## What changed

`spawn_subagent` takes two new optional params, `model` and `provider`, alongside
the existing `thinking_effort`. The resolved override rides on `SubagentRun` and is
applied where the child's client is built (`_run_subagent_loop_inner`).

## Design decisions

**Key resolution.** The override routes through `_background_llm(provider, level)` —
the same helper `_agent_llm` (the per-agent LLM override) and every background
inference already use. It clones the main client when the provider matches, and
otherwise builds one from `config.agent.<provider>_api_key` / `_base_url`, so vault
refs and env vars resolve exactly as they do everywhere else. No parallel credential
path, and a subagent still carries no key of its own — it picks *which* configured
provider it runs on.

**Guardrail semantics.** The model is in full control of the tool call, so the
override is allowlisted rather than free-form: `subagents.allowed_models` holds
`provider:model` entries.

- Empty/unset → overrides are off; a spawn that asks for one is refused and told to
  omit the field.
- Non-empty → the request must match an entry. A request matches when every field it
  *named* matches, so `model` alone resolves its provider off the list (that is the
  common case) and `provider` alone picks that provider's first listed model.
- A miss returns `{"error": ...}` naming the allowed entries, so the model can retry
  or fall back — never an exception.
- Validation happens at spawn time only; saving the config stays a plain string write.
- When the list is non-empty its entries are appended to the `spawn_subagent`
  description for that turn (a per-turn copy — the module-level schema is shared),
  so the model knows what it may pick without guessing.

**Backward compatibility.** Both params omitted returns the inherit path untouched:
same client, same model, same `thinking_effort` clone as before. The `elif` keeps the
existing effort-only branch on its original code path, and `allowed_models` defaults
to empty, so an existing install behaves identically until someone fills the field in.

**Thinking level.** An explicit `thinking_effort` still wins; without one the run
keeps the level it would have inherited, so switching model doesn't silently switch
reasoning off.

## Admin UI

An "Allowed models for subagents" textarea in the Tools tab's subagent card, one
`provider:model` per line. It follows the card's existing pattern (Alpine `x-data`
+ `PATCH /config`); the lines are `JSON.stringify`d on save because the config store's
list convention is JSON, and joined back to lines when the partial renders.

## Tests

`uv run pytest tests/test_subagents.py` — 45 passed. New coverage: override honored
and provider resolved off the list, off-list request refused with the entries named
and no run started, omitted → inherits with no client rebuilt, and the tool
description carrying the allowlist without mutating the shared schema. Plus asserts
in the `core/subagents.py` self-check for the resolver itself.

Fixes #299