### PR TITLE
fix: block the Telegram Bot API from the shell (#300)

### DIFF
--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -114,6 +114,12 @@ REACTION_EMOJI: dict[str, str] = {
     "target": "🏆",  # no native 🎯 reaction — 🏆 "on target / achieved"
 }
 
+# The same set keyed by the character, so a caller may pass the emoji itself
+# ("👀") instead of its name ("eyes") — models off providers that don't enforce
+# the tool enum do, and so does the steering ack (#145). Rejecting those raised
+# a tool error that invited the model to improvise a raw Bot API call (#300).
+REACTION_CHARS: frozenset[str] = frozenset(REACTION_EMOJI.values())
+
 
 def _chunk(text: str, limit: int = TELEGRAM_LIMIT) -> list[str]:
     """Split ``text`` into pieces no longer than ``limit``, breaking on newlines.
@@ -764,7 +770,12 @@ class TelegramChannel:
         emoji; both surface as BadRequest, which is swallowed (a cosmetic ack must
         never fail a turn — issue #70 edge cases).
         """
+        # A name from REACTION_EMOJI, or the emoji character itself (VS16 stripped:
+        # "❤️" and "❤" are the same reaction to Telegram).
         char = REACTION_EMOJI.get(emoji)
+        if char is None:
+            raw = emoji.replace("\ufe0f", "")
+            char = raw if raw in REACTION_CHARS else None
         if char is None:
             raise ValueError(f"Unsupported reaction: {emoji!r}")
         cid, _ = self._route(chat_id)

--- a/humux/core/executor.py
+++ b/humux/core/executor.py
@@ -5,12 +5,29 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import shlex
 import shutil
 import sys
 from pathlib import Path
 
 from core.email_config import himalaya_env
+
+# The Telegram Bot API is off limits to the shell (#300). `curl` is allowlisted
+# and the bot token is readable from config, so a model that wants to react but
+# improvises "the Telegram API" can call ANY method — pinChatMessage instead of
+# setMessageReaction, deleteMessage, sendMessage as the bot — bypassing every
+# guard the real tools enforce (permissions, per-chat settings, group gates).
+# Matches the host and a bare `/bot<id>:<token>` path so a proxy/mirror is caught
+# too. Structured tools (set_reaction, send_message) are the only way in.
+_TELEGRAM_API_RE = re.compile(r"api\.telegram\.org|/bot\d{5,}:[A-Za-z0-9_-]{20,}", re.I)
+_TELEGRAM_API_ERROR = {
+    "error": (
+        "Blocked: the Telegram Bot API cannot be called from the shell. "
+        "Use the built-in tools instead — `set_reaction` to react to a message, "
+        "`send_message` to send one."
+    )
+}
 
 
 def _find_wacli_bin() -> str:
@@ -209,6 +226,8 @@ class ToolExecutor:
         root here so `git clone`/`git` operate in the SAME tree the file tools
         resolve under (#151); ``None`` keeps the process cwd (unchanged default).
         """
+        if _TELEGRAM_API_RE.search(command):
+            return _TELEGRAM_API_ERROR
         # Security: validate against whitelist
         if not self._command_allowed(command):
             return {
@@ -250,7 +269,12 @@ class ToolExecutor:
         ``tool_env`` injects the active agent's identity (GH_TOKEN, git author
         env vars) so compound workspace commands (``cd repo && gh pr create``)
         authenticate as the agent, not the container's ambient identity.
+
+        The Telegram Bot API block applies here too: this rail has no prefix
+        allowlist, so it is the other way an LLM-issued command could reach it.
         """
+        if _TELEGRAM_API_RE.search(command):
+            return _TELEGRAM_API_ERROR
         return await self._exec(command, timeout, cwd=cwd, tool_env=tool_env)
 
     async def _exec(

--- a/humux/tests/test_executor.py
+++ b/humux/tests/test_executor.py
@@ -47,6 +47,32 @@ async def test_run_command_allows_cp(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "command",
+    [
+        # curl is allowlisted, so the Bot API was one hop away: the model could
+        # call any method — pinChatMessage instead of a reaction (#300).
+        "curl -s https://api.telegram.org/bot123456:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw/"
+        "pinChatMessage -d chat_id=1 -d message_id=2",
+        # A mirror/proxy still carries the token path.
+        "curl -s https://tg-proxy.example/bot123456:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw/sendMessage",
+    ],
+)
+async def test_run_command_blocks_telegram_bot_api(monkeypatch, command: str) -> None:
+    executor = ToolExecutor()
+    mock_exec = AsyncMock(return_value={"stdout": "", "stderr": "", "exit_code": 0})
+    monkeypatch.setattr(executor, "_exec", mock_exec)
+
+    result = await executor.run_command(command)
+    # The workspace rail (unlisted bash) must refuse it too — it has no allowlist.
+    in_dir = await executor.run_in_dir(command, cwd="/data/ws")
+
+    assert "set_reaction" in result["error"]
+    assert "set_reaction" in in_dir["error"]
+    mock_exec.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_run_command_forwards_cwd(monkeypatch) -> None:
     # #151: the harness passes the workspace root so git operates in the same
     # tree the file tools resolve under.

--- a/humux/tests/test_reactions.py
+++ b/humux/tests/test_reactions.py
@@ -44,6 +44,17 @@ async def test_react_swallows_badrequest_on_old_message() -> None:
 
 
 @pytest.mark.asyncio
+async def test_react_accepts_the_emoji_character_itself() -> None:
+    # The steering ack passes "👀", and models off providers that don't enforce the
+    # tool enum send the character too — both used to raise (#300).
+    ch = _channel_with_mock_bot()
+    await ch.react(5, 1, "👀")
+    await ch.react(5, 2, "❤️")  # with VS16 — same reaction to Telegram
+    emojis = [k["reaction"][0].emoji for _, k in ch.app.bot.set_message_reaction.call_args_list]
+    assert emojis == ["👀", "❤"]
+
+
+@pytest.mark.asyncio
 async def test_react_unknown_emoji_raises() -> None:
     ch = _channel_with_mock_bot()
     with pytest.raises(ValueError):


### PR DESCRIPTION
## What I found

Grepping the whole repo for `pin`, `pinChatMessage`, `pin_chat_message`, `unpin` returns **nothing** — no code path in humux pins a message, and python-telegram-bot never pins as a side effect of `set_message_reaction`. So the pin cannot have originated inside our own Telegram code; it has to be an out-of-band Bot API call.

That call is reachable today:

- `curl` is in `ToolExecutor.ALLOWED_PREFIXES`, so `curl https://api.telegram.org/bot<token>/pinChatMessage …` passes the prefix allowlist and runs on the pre-approved rail.
- The bot token is easy for the agent to obtain: `rg` is both allowlisted *and* `ALWAYS` in the default permission rules, so `rg bot_token /app/data/config.yml` prints it with no prompt.
- The curl itself is `ASK` by default, but that gate is routinely open in practice: a YOLO chat auto-approves it, and users tap Approve on a long URL without reading the method name at the end of it.
- Once the shell can reach the Bot API, the model is no longer constrained by our tool surface — it can invent *any* method it remembers (`pinChatMessage`, `deleteMessage`, `sendMessage` as the bot), bypassing permissions, per-chat settings and the group reply gates. Pinning instead of reacting is one symptom of that, not the whole hole.

Contributing factor on the reaction side: `react()` only accepted a **name** from `REACTION_EMOJI`. Anything else raised `ValueError`. Two live consequences:

- `AgentCore._ack_steer` has been calling `react(chat_id, message_id, "👀")` — the character, not `"eyes"` — since #145. On the real Telegram channel that raised every single time and was swallowed by the ack's `except`, so the steering 👀 has never actually appeared. The steer tests only exercise a fake channel that accepts anything, which is why it went unnoticed.
- A model that passes `"👀"` instead of `"eyes"` (providers enforce tool enums unevenly) got back `{"error": "Unsupported reaction: '👀'"}` — precisely the dead end that pushes a model to improvise "I'll just call the Telegram API directly".

### Ruled out

- **Emoji mapping (hypothesis 3).** `REACTION_EMOJI` is complete and every value is in Telegram's default reaction set; `test_every_enum_name_maps_to_an_emoji` already guards enum/map drift. A bad emoji yields a `BadRequest` that `react()` swallows — it cannot pin.
- **Tool routing (hypothesis 4).** `_execute_tool` dispatches on exact `name ==` comparisons with no fuzzy matching; an unknown tool name falls through to the explicit unknown-tool error. There is nothing for `set_reaction` to be misrouted *to* — no pin handler exists.
- **CoT 👀 / unreact path.** Both call `set_message_reaction` only, and `react()` already de-registers the CoT mark so a deliberate reaction is not cleared.

## The fix

1. **Executor: the Bot API is off limits to the shell.** One regex (`api.telegram.org` or a bare `/bot<id>:<token>` path, so a proxy/mirror is caught too) rejected in `run_command` *and* `run_in_dir`. Both LLM rails are covered — note that guarding only the prefix allowlist would have made such a command "unlisted" and simply routed it to the workspace rail, which has no allowlist at all. `run_command_trusted` is untouched: internal commands never call the Bot API (the admin `getMe` check uses httpx directly). The error names the tools to use instead, so the model has somewhere to go.
2. **`react()` accepts the emoji character** as well as its name (VS16 stripped, so `❤️` and `❤` are the same reaction). This fixes the steering ack, which has been silently failing since #145, and removes the tool error that invites improvisation.

The token remains *readable* via allowlisted read commands — that is a separate secret-exposure question (the vault covers it only when the token is stored as `${vault:…}`). This change blocks the *use*, which is what causes damage.

## Tests

`test_run_command_blocks_telegram_bot_api` (parametrised over a direct call and a proxy path, asserting both rails refuse and `_exec` is never reached) and `test_react_accepts_the_emoji_character_itself`. Full suite: 1083 passed.

Fixes #300