### PR TITLE
feat: subagent fan-out & orchestration

### DIFF
--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -66,11 +66,11 @@ Manage every agent on one tab (#115). Each is a card with its own character, ski
 
 ### Inspect
 
-The last tab — a developer view of every active context, laid out **master/detail**. The left pane lists each conversation by `channel · user · chat`, **most recently used first**, with a relative "last active" time; the one you just messaged floats to the top. Filter the list by channel, user, or chat. Selecting a context loads its detail on the right (the most recent context is selected automatically).
+The last tab — a developer view of every active context, laid out **master/detail**. The left pane lists each conversation by `channel · user · chat`, **most recently used first**, with a relative "last active" time; the one you just messaged floats to the top. [Subagent](/docs/subagents) runs are listed too, by run id, alongside the main chats. Filter the list by channel, user, or chat. Selecting a context loads its detail on the right (the most recent context is selected automatically).
 
 The detail pane shows the **exact payload the agent last sent to the model** for that context — the assembled system prompt/identity, the full tool definitions, and the history window rendered as a transcript (user / assistant / tool-use / tool-result blocks), plus the model and `max_tokens`. A **Context usage** meter shows the real prompt size the provider reported for that request against the model's context window — e.g. `12,480 / 200,000 tokens — 6.2% of context window` — so you can see how close a conversation is to its limit at a glance (the bar turns amber past 70% and red past 90%). The window comes from the same per-model map that drives compaction; unknown models fall back to the compaction context-window setting. A **Raw JSON** section gives the verbatim serialized request for power users (base64 image bytes are elided so the view stays light).
 
-This is the real inference payload, captured in memory at send time, so it shows exactly what ran — no guessing. It is empty until a context has had a turn since the agent started, and reselecting a context refreshes to the latest. Subagent turns are not captured here, only the conversation's own requests. The view is admin-only and shows the payload verbatim; the assembled prompt references secrets by name, not value. The page is responsive at phone width.
+This is the real inference payload, captured in memory at send time, so it shows exactly what ran — no guessing. It is empty until a context has had a turn since the agent started, and reselecting a context refreshes to the latest. Subagent runs are captured too — each run's last-sent payload is inspectable per run id, the same way a chat's is. The view is admin-only and shows the payload verbatim; the assembled prompt references secrets by name, not value. The page is responsive at phone width.
 
 ### Memory
 
@@ -100,6 +100,14 @@ Manage scheduled tasks:
 - Delete jobs
 - View job execution history
 
+Live [subagent](/docs/subagents) runs get a card each (agent, status, elapsed
+time, current step) with a cancel button, in a badge colour that distinguishes
+running from finished. Every card carries its run id, label, tokens used, and
+steps taken, plus — once it finishes — the stopped reason. The runs from one
+`spawn_subagents` fan-out are grouped under that batch, and a run's
+parent/children links let you walk the session tree (subagents spawning
+subagents). The tab shows a live count badge for jobs currently running.
+
 ### History
 
 A sub-tab of the **LLM** tab (LLM → History). Configure conversation history and browse stored turns:
@@ -124,12 +132,14 @@ tagged with the **stream** it belongs to — the active agent's slug, or
 `default` for the base identity — shown as a colour-coded `[stream]` badge so
 concurrent agents are easy to tell apart. A [subagent](/docs/subagents)'s lines
 (its reasoning and tool calls) flow into the **same stream as the agent that
-spawned it**, prefixed `[subagent:<id>]`, so one stream is a full logical session
-regardless of how many subagents were involved.
+spawned it**, tagged with a structured subagent label unique per run — e.g.
+`pricing#a1b2` — so one stream is a full logical session regardless of how
+many subagents were involved.
 
 The filter bar narrows the view:
 
 - **Stream** — pick a name from the live list, or type a **regex** to match several
+- **Subagent** — filter to one run's label to isolate a single fan-out subtask from the rest of its stream
 - **Level** — minimum severity (`DEBUG` → `ERROR`)
 - **Search** — free-text match within the line
 - **From / To** — a timestamp range

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -72,6 +72,19 @@ The detail pane shows the **exact payload the agent last sent to the model** for
 
 This is the real inference payload, captured in memory at send time, so it shows exactly what ran — no guessing. It is empty until a context has had a turn since the agent started, and reselecting a context refreshes to the latest. Subagent runs are captured too — each run's last-sent payload is inspectable per run id, the same way a chat's is. The view is admin-only and shows the payload verbatim; the assembled prompt references secrets by name, not value. The page is responsive at phone width.
 
+Above the context list sits the **live subagent runs** panel, refreshed every
+three seconds. Live [subagent](/docs/subagents) runs get a card each (agent,
+status, elapsed time, current step) with a cancel button, in a badge colour that
+distinguishes running from finished. Every card carries its run id, label, tokens
+used, and steps taken, plus — once it finishes — the stopped reason. The runs
+from one `spawn_subagents` fan-out are grouped under that batch, and a run's
+parent/children links let you walk the session tree (subagents spawning
+subagents). The panel header shows a live count of currently running subagents.
+Each main context row in the list on the left has a small **runs** button that
+filters the panel to that conversation's runs (a **show all** button in the
+header clears it); the filter survives the poll. The synthetic `⚙ subagent` rows
+stay payload-only — the panel and the payload view are complementary.
+
 ### Memory
 
 Inspect and manage the agent's memories, and tune the memory engine live:
@@ -100,13 +113,9 @@ Manage scheduled tasks:
 - Delete jobs
 - View job execution history
 
-Live [subagent](/docs/subagents) runs get a card each (agent, status, elapsed
-time, current step) with a cancel button, in a badge colour that distinguishes
-running from finished. Every card carries its run id, label, tokens used, and
-steps taken, plus — once it finishes — the stopped reason. The runs from one
-`spawn_subagents` fan-out are grouped under that batch, and a run's
-parent/children links let you walk the session tree (subagents spawning
-subagents). The tab shows a live count badge for jobs currently running.
+Jobs of type `subagent` are scheduled jobs like any other and live here. Live
+[subagent](/docs/subagents) *runs* are monitored and cancelled from the
+[Inspect](#inspect) tab.
 
 ### History
 

--- a/docs/content/docs/agents.mdx
+++ b/docs/content/docs/agents.mdx
@@ -56,6 +56,7 @@ voice: en-US-GuyNeural
 skills: [scheduling, memory, weather]
 tools: [send_message, create_calendar_event, manage_jobs, web_search]
 secrets: []
+spawnable_agents: [research-analyst, writing-editor]   # delegation trust list — see below
 tool_config:
   gh: {enabled: true}            # uses this agent's own GitHub token
   browser: {enabled: true, profile: forge}
@@ -89,7 +90,8 @@ first. From there you can:
   routes); the flag moves atomically, applied live to new turns;
 - **Disable / Enable** — the kill-switch (see [below](#enabling--disabling-an-agent));
 - **edit** an agent in the editor — a **guided form** (identity, voice, skill + tool
-  checkboxes, secret scope) with a **raw markdown** toggle for power users;
+  checkboxes, secret scope, delegation trust list) with a **raw markdown** toggle for
+  power users;
 - **rename** an agent's slug in the editor — the new slug is cascaded to everything that
   references it (per-chat bindings, private memories, scheduled jobs, and the `telegram:<slug>`
   bot channel), so no association is lost. The `is_default` flag rides with the row, so a
@@ -184,6 +186,25 @@ and base URLs are **always** the global ones (LLM → Providers): the override p
 configured provider and model the agent runs on, it never carries its own credentials.
 The override applies to the agent's whole agentic loop, including the subagent runs it
 spawns; background inferences (memory, compaction, reflection, …) keep their own models.
+
+## Delegation trust list
+
+`spawnable_agents` is the list of agent slugs this agent may delegate to when it spawns a
+[subagent](/docs/subagents). Leave it **empty** (the default) and nothing changes: any
+agent may be named, and the child's tools, skills, secrets and account bindings are
+narrowed to the intersection with the caller's — inherit, never widen.
+
+Fill it in and the agent gets a **team**. Only the listed agents may be named (anything
+else is refused with a message listing the team), the `<agents>` roster the agent sees each
+turn is filtered to them, and a listed specialist runs with its **own** tools, skills,
+secrets and accounts instead of the narrowed intersection — the list itself is your grant
+of trust, so delegation becomes a capability handoff. Omitting the agent (or naming
+itself) still runs the subtask as the caller.
+
+Edit it in the **Agents** editor, or as `spawnable_agents:` in the markdown frontmatter.
+Because subagents run without per-action approval prompts, keep the list short on agents
+exposed to untrusted input — see [Delegation trust
+list](/docs/subagents#delegation-trust-list) for the full semantics.
 
 ## Tool identities
 

--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -130,6 +130,10 @@ done (42s, 23k tokens)`, or the failed/cancelled variant). Like the progress
 note these are notifications only: they never start a turn and never enter the
 conversation history. A singular synchronous spawn only posts one if it ran for
 at least ten seconds — a quick one's result is already in the very next reply.
+Every spawn announces itself the same way (`🧬 Spawned subagent pricing`, or
+`🧬 pricing spawned subagent stock-check` for a nested one — fan-out children are
+covered by the group note instead), so the run tree is visible in the chat as it
+grows and any run in it can be cancelled from `/subagents` or the Jobs tab.
 
 All spawns, singular or plural, draw from the same [per-turn budget
 pool](#guardrails) — a big fan-out can exhaust it and leave less room for

--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -133,7 +133,7 @@ at least ten seconds — a quick one's result is already in the very next reply.
 Every spawn announces itself the same way (`🧬 Spawned subagent pricing`, or
 `🧬 pricing spawned subagent stock-check` for a nested one — fan-out children are
 covered by the group note instead), so the run tree is visible in the chat as it
-grows and any run in it can be cancelled from `/subagents` or the Jobs tab.
+grows and any run in it can be cancelled from `/subagents` or the Inspect tab.
 
 All spawns, singular or plural, draw from the same [per-turn budget
 pool](#guardrails) — a big fan-out can exhaust it and leave less room for
@@ -258,9 +258,10 @@ Background subagents are first-class runs you can watch and stop:
 
 - **Telegram** — send `/jobs` to list active runs, each with an inline **Cancel**
   button. Monitoring and cancelling a long task from your phone needs no web UI.
-- **Admin UI** — the **Jobs** tab shows a live card per run (agent, status,
-  elapsed time, current step) with a cancel button; the layout collapses to a
-  single column at phone width.
+- **Admin UI** — the **Inspect** tab shows a live card per run (agent, status,
+  elapsed time, current step) with a cancel button, above the context list; the
+  layout collapses to a single column at phone width. Each context row has a
+  **runs** button that filters the panel to that conversation's runs.
 
 Cancelling stops the run; if it was a background run, a cancellation notice is
 posted back to the originating chat. `/stop` cancels in-flight subagents too —

--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -125,6 +125,12 @@ When a fan-out starts, the agent posts a one-line progress note to the chat
 you send meanwhile is picked up once the fan-out completes — the 👀 steering
 ack still just means "the model has seen it", not "the fan-out is done".
 
+As each run ends it posts its own one-line status note (`✅ Subagent pricing —
+done (42s, 23k tokens)`, or the failed/cancelled variant). Like the progress
+note these are notifications only: they never start a turn and never enter the
+conversation history. A singular synchronous spawn only posts one if it ran for
+at least ten seconds — a quick one's result is already in the very next reply.
+
 All spawns, singular or plural, draw from the same [per-turn budget
 pool](#guardrails) — a big fan-out can exhaust it and leave less room for
 further delegation later in the turn. The bundled `subagent-orchestration`

--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -75,7 +75,9 @@ it. Omit both and the subagent inherits the caller's model, as it always has.
 **Files hand back automatically.** The subagent shares the agent's filesystem,
 so any file it writes is already on disk where the caller can reach it — it just
 reports the absolute paths in its result, which the spawning agent then reads,
-sends, or attaches.
+sends, or attaches. This is also how generated media travels: a subagent that
+calls `generate_image` hands back the saved image's path, and the spawning agent
+delivers it.
 
 ## Fan-out & orchestration
 
@@ -156,6 +158,31 @@ and a scoped caller delegating to an open agent keeps its own limits.
 [Permission rules](/docs/permissions) (`NEVER` in particular) still apply inside
 the subagent, so a blocked action stays blocked at any depth.
 
+### Delegation trust list
+
+Narrowing is the default because the caller has vouched for nobody. The
+`spawnable_agents` field on an [agent](/docs/agents) — a list of agent slugs —
+is how you vouch:
+
+- **Empty** (the default) — legacy behaviour: any agent may be named in
+  `spawn_subagent`/`spawn_subagents`, and the child is narrowed to the
+  intersection described above.
+- **Non-empty** — a curated **team**. Only the listed agents may be named;
+  anything else is refused with a message listing the team, so the model can
+  self-correct. A listed specialist runs with its **own** tools, skills, secrets,
+  and account bindings — the list *is* the owner's trust grant, which makes
+  delegation a deliberate capability handoff rather than a leak.
+
+Naming yourself, or omitting `agent` entirely, still runs the subtask as the
+caller, narrowed exactly as before.
+
+> **Keep the list short on exposed agents.** A subagent runs with system
+> semantics — no per-action approval — so the spawn approval (which names the
+> target agent and the task) is the one human gate on the whole run. On agents
+> reachable by untrusted input, such as group chats or [GitHub
+> webhooks](/docs/channels), every entry in `spawnable_agents` is a capability
+> that input can reach for.
+
 ## Choosing an agent
 
 Selection stays **user-led**: omitting `agent` runs the subagent as the caller
@@ -164,6 +191,11 @@ already chose. To make the *specialist* case an informed choice rather than a
 guess, each turn the agent sees a compact roster of available agents
 (`name — role`) and only names one when the subtask clearly fits it. A wrong
 name is rejected with the list of valid names, so the agent can self-correct.
+
+With a **team** configured, the roster is filtered to that team and the guidance
+flips: instead of "only when the user asked for a specialist", the agent is told
+to pick the best-equipped teammate for the subtask, because you have already
+approved each of them.
 
 ## Guardrails
 

--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -75,9 +75,11 @@ it. Omit both and the subagent inherits the caller's model, as it always has.
 **Files hand back automatically.** The subagent shares the agent's filesystem,
 so any file it writes is already on disk where the caller can reach it — it just
 reports the absolute paths in its result, which the spawning agent then reads,
-sends, or attaches. This is also how generated media travels: a subagent that
-calls `generate_image` hands back the saved image's path, and the spawning agent
-delivers it.
+sends, or attaches. Generated media travels differently depending on mode: a
+**synchronous** spawn's `generate_image` rides out natively with the spawning
+turn's reply (it shares the parent turn's attachment queue), while a
+**background** run has no live turn to deliver through, so it hands back the
+saved image's absolute path via the `Files:` convention instead.
 
 ## Fan-out & orchestration
 
@@ -110,7 +112,7 @@ notification per subtask.
 **Failure is per-subtask, never all-or-nothing.** Results come back in request
 order, one entry per task, each with `status` (`done` / `error` / `cancelled`),
 `steps`, `tokens_used`, `stopped_reason` (`complete` / `max_steps` /
-`token_budget` / `truncated` / `aborted`), a `summary`, and the full `result`.
+`token_budget` / `turn_budget` / `truncated` / `aborted`), a `summary`, and the full `result`.
 One subtask failing or being cancelled doesn't stop the others from completing.
 
 **Fan-out doesn't nest.** `spawn_subagents` is only offered to the top-level
@@ -212,14 +214,15 @@ limit, applied live without a restart), or under `subagents` in `config.yml`:
 | `max_concurrent` | `4` | Per-chat concurrency gate covering **every** subagent run, sync or background. Extra spawns queue instead of failing; each chat has its own pool, so one chat's fan-out can't starve another chat's spawn. A background `spawn_subagent` still refuses outright when the chat is already at the cap |
 | `max_fanout` | `6` | Max tasks in one `spawn_subagents` call |
 | `max_spawns_per_turn` | `12` | Max subagent spawns across the whole subagent tree, per turn |
-| `turn_token_budget` | `400000` | Max subagent tokens across the whole tree, per turn. Reserve-then-refund: each run reserves its `token_budget` up front and refunds the unspent part when it finishes. The pool is never smaller than one default run (`token_budget`), and fan-out tasks that don't set a budget split the pool across the width |
+| `turn_token_budget` | `400000` | Max subagent tokens across the whole tree, per turn. Charged as spent, one LLM round at a time — never reserved up front, so a spawn is never refused for tokens before it starts. Once the pool drains, runs stop gracefully between rounds with `stopped_reason: "turn_budget"`; concurrent runs can overshoot by at most one round each, a bounded tradeoff for the simplicity |
 | `allowed_models` | *(empty)* | `provider:model` entries a spawn may pick instead of inheriting the caller's model — one per line in the admin card. Empty means overrides are off entirely |
 
 When disabled, the tool is hidden from the assistant and from the Agents tool
 scope. Assign it per agent in the **Agents** editor. A run that hits its step
 or token budget stops and returns what it has, with a note that the budget was
-reached. A turn that would exceed `max_spawns_per_turn` or `turn_token_budget`
-gets a budget-refusal the model can read, instead of spawning without limit.
+reached. A spawn is refused only once `max_spawns_per_turn` is used up or
+`turn_token_budget` is already fully drained — never pre-emptively for
+tokens — with a message the model can read instead of spawning without limit.
 
 ## Result summary
 

--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -212,7 +212,7 @@ limit, applied live without a restart), or under `subagents` in `config.yml`:
 | `max_concurrent` | `4` | Per-chat concurrency gate covering **every** subagent run, sync or background. Extra spawns queue instead of failing; each chat has its own pool, so one chat's fan-out can't starve another chat's spawn. A background `spawn_subagent` still refuses outright when the chat is already at the cap |
 | `max_fanout` | `6` | Max tasks in one `spawn_subagents` call |
 | `max_spawns_per_turn` | `12` | Max subagent spawns across the whole subagent tree, per turn |
-| `turn_token_budget` | `400000` | Max subagent tokens across the whole tree, per turn. Reserve-then-refund: each run reserves its `token_budget` up front and refunds the unspent part when it finishes |
+| `turn_token_budget` | `400000` | Max subagent tokens across the whole tree, per turn. Reserve-then-refund: each run reserves its `token_budget` up front and refunds the unspent part when it finishes. The pool is never smaller than one default run (`token_budget`), and fan-out tasks that don't set a budget split the pool across the width |
 | `allowed_models` | *(empty)* | `provider:model` entries a spawn may pick instead of inheriting the caller's model — one per line in the admin card. Empty means overrides are off entirely |
 
 When disabled, the tool is hidden from the assistant and from the Agents tool

--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -44,7 +44,7 @@ The agent decides to delegate and calls the tool. Two modes:
   "task": "Research the top 3 Python HTTP clients and summarise trade-offs",
   "agent": "coding-helper",   // optional — omit to run as yourself (same identity & scope)
   "max_steps": 6,                // optional — caller-chosen, capped at the configured max
-  "token_budget": 40000,         // optional — caller-chosen, min 1000, capped at the configured max
+  "token_budget": 120000,        // optional — caller-chosen, min 50000, capped at the configured max
   "thinking_effort": "high",     // optional — off | low | medium | high; omit to inherit yours
   "model": "deepseek-v4-flash",  // optional — must be an allowed model; omit to inherit yours
   "provider": "deepseek",        // optional — only to disambiguate; follows from "model"
@@ -220,17 +220,19 @@ limit, applied live without a restart), or under `subagents` in `config.yml`:
 | `enabled` | `true` | Master switch; off hides the `spawn_subagent` tool everywhere |
 | `recursion_depth` | `3` | Max nesting (a top-level spawn is depth 1) |
 | `max_steps` | `12` | Ceiling on tool-call rounds per run — a hard stop; the agent may request fewer per spawn, never more |
-| `token_budget` | `100000` | Ceiling on tokens per run (best-effort); the agent may request fewer per spawn, never more |
+| `token_budget` | `300000` | Ceiling on tokens per run (best-effort); the agent may request fewer per spawn, never more. A round re-sends the whole prompt, so it costs 15–35k and each round costs more than the last — sized so `max_steps`, not tokens, is what stops a run |
 | `max_concurrent` | `4` | Per-chat concurrency gate covering **every** subagent run, sync or background. Extra spawns queue instead of failing; each chat has its own pool, so one chat's fan-out can't starve another chat's spawn. A background `spawn_subagent` still refuses outright when the chat is already at the cap |
 | `max_fanout` | `6` | Max tasks in one `spawn_subagents` call |
 | `max_spawns_per_turn` | `12` | Max subagent spawns across the whole subagent tree, per turn |
-| `turn_token_budget` | `400000` | Max subagent tokens across the whole tree, per turn. Charged as spent, one LLM round at a time — never reserved up front, so a spawn is never refused for tokens before it starts. Once the pool drains, runs stop gracefully between rounds with `stopped_reason: "turn_budget"`; concurrent runs can overshoot by at most one round each, a bounded tradeoff for the simplicity |
+| `turn_token_budget` | `1200000` | Max subagent tokens across the whole tree, per turn. Charged as spent, one LLM round at a time — never reserved up front, so a spawn is never refused for tokens before it starts. Once the pool drains, runs stop gracefully between rounds with `stopped_reason: "turn_budget"`; concurrent runs can overshoot by at most one round each, a bounded tradeoff for the simplicity |
 | `allowed_models` | *(empty)* | `provider:model` entries a spawn may pick instead of inheriting the caller's model — one per line in the admin card. Empty means overrides are off entirely |
 
 When disabled, the tool is hidden from the assistant and from the Agents tool
 scope. Assign it per agent in the **Agents** editor. A run that hits its step
 or token budget stops and returns what it has, with a note that the budget was
-reached. A spawn is refused only once `max_spawns_per_turn` is used up or
+reached — a stop always lands on a round that wanted to call another tool, so
+the run spends one final tool-less round writing up what it found rather than
+returning an empty result over the work it already paid for. A spawn is refused only once `max_spawns_per_turn` is used up or
 `turn_token_budget` is already fully drained — never pre-emptively for
 tokens — with a message the model can read instead of spawning without limit.
 

--- a/docs/content/docs/subagents.mdx
+++ b/docs/content/docs/subagents.mdx
@@ -77,6 +77,55 @@ so any file it writes is already on disk where the caller can reach it — it ju
 reports the absolute paths in its result, which the spawning agent then reads,
 sends, or attaches.
 
+## Fan-out & orchestration
+
+For work that splits into independent pieces, `spawn_subagents` (plural) runs
+several subtasks **in parallel** in one call instead of one `spawn_subagent`
+call per piece. Wall-clock is roughly that of the slowest subtask, not the sum
+of them.
+
+```jsonc
+// spawn_subagents tool input
+{
+  "tasks": [
+    { "task": "Summarise open PRs in repo A", "label": "repo-a", "agent": "coding-helper" },
+    { "task": "Summarise open PRs in repo B", "label": "repo-b", "agent": "coding-helper" }
+  ],
+  "background": false   // true → return run ids immediately, results posted when all finish
+}
+```
+
+Each entry in `tasks` takes the same fields as `spawn_subagent` (`task`, `agent`,
+`max_steps`, `token_budget`, `thinking_effort`, `model`, `provider`) plus a
+short `label` used in logs and the [admin UI](/docs/admin-ui) — the agent
+derives one from the task text when it's omitted. A call may name 2 up to
+`max_fanout` tasks (see [Guardrails](#guardrails)).
+
+`background: true` runs the whole batch off-turn: results are posted to the
+chat as **one grouped notification** once every subtask has finished, not one
+notification per subtask.
+
+**Failure is per-subtask, never all-or-nothing.** Results come back in request
+order, one entry per task, each with `status` (`done` / `error` / `cancelled`),
+`steps`, `tokens_used`, `stopped_reason` (`complete` / `max_steps` /
+`token_budget` / `truncated` / `aborted`), a `summary`, and the full `result`.
+One subtask failing or being cancelled doesn't stop the others from completing.
+
+**Fan-out doesn't nest.** `spawn_subagents` is only offered to the top-level
+agent; a subagent it spawns can still delegate further with the singular
+`spawn_subagent`, up to `recursion_depth` — it just can't start a fan-out of
+its own.
+
+When a fan-out starts, the agent posts a one-line progress note to the chat
+(`🧩 Delegating N subtasks…`) so a long parallel run doesn't look hung. Anything
+you send meanwhile is picked up once the fan-out completes — the 👀 steering
+ack still just means "the model has seen it", not "the fan-out is done".
+
+All spawns, singular or plural, draw from the same [per-turn budget
+pool](#guardrails) — a big fan-out can exhaust it and leave less room for
+further delegation later in the turn. The bundled `subagent-orchestration`
+skill covers when fanning out is worth it versus a single sequential spawn.
+
 ## Scheduled
 
 Run a subagent on a cron or one-shot schedule by giving a job `type: "subagent"`
@@ -128,13 +177,17 @@ limit, applied live without a restart), or under `subagents` in `config.yml`:
 | `recursion_depth` | `3` | Max nesting (a top-level spawn is depth 1) |
 | `max_steps` | `12` | Ceiling on tool-call rounds per run — a hard stop; the agent may request fewer per spawn, never more |
 | `token_budget` | `100000` | Ceiling on tokens per run (best-effort); the agent may request fewer per spawn, never more |
-| `max_concurrent` | `3` | Max background runs at once |
+| `max_concurrent` | `4` | Per-chat concurrency gate covering **every** subagent run, sync or background. Extra spawns queue instead of failing; each chat has its own pool, so one chat's fan-out can't starve another chat's spawn. A background `spawn_subagent` still refuses outright when the chat is already at the cap |
+| `max_fanout` | `6` | Max tasks in one `spawn_subagents` call |
+| `max_spawns_per_turn` | `12` | Max subagent spawns across the whole subagent tree, per turn |
+| `turn_token_budget` | `400000` | Max subagent tokens across the whole tree, per turn. Reserve-then-refund: each run reserves its `token_budget` up front and refunds the unspent part when it finishes |
 | `allowed_models` | *(empty)* | `provider:model` entries a spawn may pick instead of inheriting the caller's model — one per line in the admin card. Empty means overrides are off entirely |
 
 When disabled, the tool is hidden from the assistant and from the Agents tool
 scope. Assign it per agent in the **Agents** editor. A run that hits its step
 or token budget stops and returns what it has, with a note that the budget was
-reached.
+reached. A turn that would exceed `max_spawns_per_turn` or `turn_token_budget`
+gets a budget-refusal the model can read, instead of spawning without limit.
 
 ## Result summary
 
@@ -165,7 +218,9 @@ Background subagents are first-class runs you can watch and stop:
   single column at phone width.
 
 Cancelling stops the run; if it was a background run, a cancellation notice is
-posted back to the originating chat.
+posted back to the originating chat. `/stop` cancels in-flight subagents too —
+for a fan-out that means the whole batch, cascading to any children it spawned
+— instead of letting them run to completion after the main turn has aborted.
 
 > Runs live in memory, so a restart clears the registry (and stops any in-flight
 > background runs) — there is nothing to resume after a reboot.

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -41,7 +41,7 @@ from core.compaction import effective_window
 from core.config import CompactionConfig, search_ready
 from core.config_store import ConfigStore
 from core.goal_decomposition import classify_complexity, decompose_goal
-from core.llm import LLMClient, get_sent_payload
+from core.llm import LLMClient, get_sent_payload, list_captured
 from core.log_streams import current_stream, current_subagent
 from core.prompt_builder import (
     build_prompt_sections,
@@ -471,6 +471,7 @@ class _BufferHandler(logging.Handler):
                     "name": record.name,
                     "stream": stream,
                     "hue": _stream_hue(stream),
+                    "subagent": sub or "",
                     "message": message,
                     "is_reasoning": record.name == _REASONING_LOGGER,
                 }
@@ -487,17 +488,20 @@ def _filter_log_entries(
     q: str = "",
     since: str = "",
     until: str = "",
+    subagent: str = "",
 ) -> list[dict]:
     """Apply the Logs tab filters. ``stream`` is a regex over the stream name;
     ``level`` is a minimum severity; ``q`` is a case-insensitive substring over
-    the message; ``since``/``until`` are ``datetime-local`` bounds. Each empty
-    filter is a no-op, so the unfiltered case returns everything."""
+    the message; ``since``/``until`` are ``datetime-local`` bounds; ``subagent``
+    is a case-insensitive substring over the emitting subagent's label. Each
+    empty filter is a no-op, so the unfiltered case returns everything."""
     try:
         rx = re.compile(stream, re.IGNORECASE) if stream else None
     except re.error:
         rx = None  # a half-typed regex shouldn't blank the viewer
     minlevel = logging.getLevelName(level) if level in _LOG_LEVELS else 0
     ql = q.strip().lower()
+    subl = subagent.strip().lower()
     lo = _parse_local_dt(since)
     hi = _parse_local_dt(until)
     out = []
@@ -507,6 +511,8 @@ def _filter_log_entries(
         if minlevel and e["levelno"] < minlevel:
             continue
         if ql and ql not in e["message"].lower() and ql not in e["name"].lower():
+            continue
+        if subl and subl not in (e.get("subagent") or "").lower():
             continue
         if lo is not None and e["ts"] < lo:
             continue
@@ -2135,7 +2141,10 @@ def create_admin_app(
         sub_recursion = await config_store.get("subagents.recursion_depth") or "3"
         sub_steps = await config_store.get("subagents.max_steps") or "12"
         sub_tokens = await config_store.get("subagents.token_budget") or "100000"
-        sub_concurrent = await config_store.get("subagents.max_concurrent") or "3"
+        sub_concurrent = await config_store.get("subagents.max_concurrent") or "4"
+        sub_fanout = await config_store.get("subagents.max_fanout") or "6"
+        sub_spawns_turn = await config_store.get("subagents.max_spawns_per_turn") or "12"
+        sub_turn_tokens = await config_store.get("subagents.turn_token_budget") or "400000"
         # Allowed "provider:model" overrides (#299) — stored as a JSON list,
         # edited as one entry per line.
         try:
@@ -2209,6 +2218,9 @@ def create_admin_app(
             subagents_max_steps=sub_steps,
             subagents_token_budget=sub_tokens,
             subagents_max_concurrent=sub_concurrent,
+            subagents_max_fanout=sub_fanout,
+            subagents_max_spawns_per_turn=sub_spawns_turn,
+            subagents_turn_token_budget=sub_turn_tokens,
             subagents_allowed_models=sub_allowed,
             summary_enabled=ss_enabled,
             summary_provider=ss_provider,
@@ -2745,12 +2757,20 @@ def create_admin_app(
         q: str = "",
         since: str = "",
         until: str = "",
+        subagent: str = "",
     ) -> HTMLResponse:
         """Filtered log lines for HTMX swap (#75). Filters: stream (regex), level
-        (min severity), q (text), since/until (time range)."""
+        (min severity), q (text), since/until (time range), subagent (label
+        substring — lines emitted inside one subagent run)."""
         snapshot = list(_LOG_BUFFER)
         entries = _filter_log_entries(
-            snapshot, stream=stream, level=level, q=q, since=since, until=until
+            snapshot,
+            stream=stream,
+            level=level,
+            q=q,
+            since=since,
+            until=until,
+            subagent=subagent,
         )[-300:]
         # All stream names ever seen (not just the filtered slice) for the picker.
         streams = sorted({e["stream"] for e in snapshot})
@@ -3085,12 +3105,33 @@ def create_admin_app(
             return []
         return agent.subagents.list_runs()
 
+    def _subagent_groups(runs: list) -> list[dict]:
+        """Bucket runs by ``group_id`` (siblings of one fan-out), newest bucket
+        first; an ungrouped run is its own bucket. Order inside a bucket keeps
+        list_runs' newest-first order."""
+        groups: list[dict] = []
+        index: dict[str, dict] = {}
+        for r in runs:
+            gid = getattr(r, "group_id", "") or ""
+            key = gid or f"\0solo:{r.run_id}"
+            g = index.get(key)
+            if g is None:
+                g = {"group_id": gid, "runs": []}
+                index[key] = g
+                groups.append(g)
+            g["runs"].append(r)
+        return groups
+
     @app.get("/partials/subagent-runs", dependencies=[Depends(auth)])
     async def partial_subagent_runs() -> HTMLResponse:
         """Subagent runs card grid — polled by the Jobs tab for live status."""
+        runs = _subagent_runs()
         return _render_partial(
             "partials/subagent_runs.html",
-            runs=_subagent_runs(),
+            groups=_subagent_groups(runs),
+            # run_id → display label, so a child can name its parent.
+            labels={r.run_id: (r.label or r.agent or r.run_id) for r in runs},
+            running_count=sum(1 for r in runs if r.status == "running"),
             agent_running=agent_state.agent is not None,
         )
 
@@ -4207,7 +4248,23 @@ def create_admin_app(
         tz = await config_store.get("agent.timezone") or "UTC"
         now = datetime.now(UTC)
         for c in chats:
+            c["run_id"] = ""
             c["last_active_h"] = _humanize_ts(c.get("last_active", ""), now, tz)
+        # Subagent runs never write to ConversationHistory, so their captured
+        # payloads would be unreachable from the list. Append one synthetic row
+        # per captured key that carries a run id (newest first), leaving the
+        # main-chat rows above untouched.
+        for channel, user_id, chat_id, run_id in list_captured():
+            if run_id:
+                chats.append(
+                    {
+                        "channel": channel,
+                        "user_id": user_id,
+                        "chat_id": chat_id,
+                        "run_id": run_id,
+                        "last_active_h": "",
+                    }
+                )
         return _render_partial("partials/inspect.html", chats=chats)
 
     @app.get("/partials/inspect-tabs", dependencies=[Depends(auth)])
@@ -4227,14 +4284,15 @@ def create_admin_app(
 
     @app.get("/inspect/payload", dependencies=[Depends(auth)])
     async def inspect_payload(
-        channel: str = "", user_id: str = "", chat_id: str = ""
+        channel: str = "", user_id: str = "", chat_id: str = "", run_id: str = ""
     ) -> HTMLResponse:
         """Render the last-sent inference payload for one context (#99).
 
-        Reads the in-memory capture keyed by (channel, user_id, chat_id) — the
-        exact system/messages/tools/model that generate() last sent. Empty until
-        the context has had a turn since the agent started."""
-        payload = get_sent_payload((channel, user_id, chat_id))
+        Reads the in-memory capture keyed by (channel, user_id, chat_id, run_id)
+        — run_id "" for a main turn, a subagent run id otherwise — the exact
+        system/messages/tools/model that generate() last sent. Empty until the
+        context has had a turn since the agent started."""
+        payload = get_sent_payload((channel, user_id, chat_id, run_id))
         meta: dict[str, object] | None = None
         system = ""
         messages: list = []
@@ -5291,6 +5349,7 @@ GATEABLE_TOOLS = [
     "deep_research",
     "manage_jobs",
     "spawn_subagent",
+    "spawn_subagents",
     "generate_image",
     "read",
     "write",
@@ -5318,6 +5377,7 @@ TOOL_DESCRIPTIONS = {
     "deep_research": "Multi-step web research with a synthesized, cited report.",
     "manage_jobs": "Schedule, list and cancel the agent's own jobs.",
     "spawn_subagent": "Delegate a scoped subtask to a child agent.",
+    "spawn_subagents": "Fan out several subtasks to parallel subagents.",
     "generate_image": "Generate images and send them as photos.",
     "read": "Read a file inside the workspace.",
     "write": "Create or overwrite a file inside the workspace.",
@@ -5333,7 +5393,7 @@ def gateable_tools_for(
     """GATEABLE_TOOLS minus tools whose feature is globally disabled."""
     out = list(GATEABLE_TOOLS)
     if not subagents_enabled:
-        out = [t for t in out if t != "spawn_subagent"]
+        out = [t for t in out if t not in ("spawn_subagent", "spawn_subagents")]
     if not imagegen_enabled:
         out = [t for t in out if t != "generate_image"]
     if not workspace_enabled:

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -2861,11 +2861,6 @@ def create_admin_app(
             "partials/jobs_scheduled.html", **(await _jobs_context(show_completed))
         )
 
-    @app.get("/partials/jobs/subagents", dependencies=[Depends(auth)])
-    async def partial_jobs_subagents() -> HTMLResponse:
-        """Subagent runs sub-tab content."""
-        return _render_partial("partials/jobs_subagents.html")
-
     @app.post("/jobs", dependencies=[Depends(auth)])
     async def upsert_job(request: Request) -> HTMLResponse:
         """Add or update a scheduled job. Returns refreshed jobs partial."""
@@ -3128,21 +3123,43 @@ def create_admin_app(
         return groups
 
     @app.get("/partials/subagent-runs", dependencies=[Depends(auth)])
-    async def partial_subagent_runs() -> HTMLResponse:
-        """Subagent runs card grid — polled by the Jobs tab for live status."""
+    async def partial_subagent_runs(channel: str = "", chat_id: str = "") -> HTMLResponse:
+        """Subagent runs card grid — polled by the Inspect tab for live status.
+
+        ``channel``/``chat_id`` narrow the panel to the runs originating from one
+        conversation (the Inspect master list's per-context "runs" buttons); both
+        empty shows every run. The filter is echoed back as ``qs`` so the panel's
+        self-poll keeps it."""
         runs = _subagent_runs()
+        # Labels come from every run, so a filtered child can still name a parent.
+        labels = {r.run_id: (r.label or r.agent or r.run_id) for r in runs}
+        if channel or chat_id:
+            runs = [
+                r
+                for r in runs
+                if (not channel or r.origin_channel == channel)
+                and (not chat_id or r.origin_chat_id == chat_id)
+            ]
         return _render_partial(
             "partials/subagent_runs.html",
             groups=_subagent_groups(runs),
-            # run_id → display label, so a child can name its parent.
-            labels={r.run_id: (r.label or r.agent or r.run_id) for r in runs},
+            labels=labels,
             running_count=sum(1 for r in runs if r.status == "running"),
             agent_running=agent_state.agent is not None,
+            qs=(
+                "?" + urllib.parse.urlencode({"channel": channel, "chat_id": chat_id})
+                if (channel or chat_id)
+                else ""
+            ),
         )
 
     @app.post("/subagents/cancel", dependencies=[Depends(auth)])
-    async def cancel_subagent(request: Request) -> HTMLResponse:
-        """Cancel a running subagent. Returns the refreshed runs partial."""
+    async def cancel_subagent(
+        request: Request, channel: str = "", chat_id: str = ""
+    ) -> HTMLResponse:
+        """Cancel a running subagent. Returns the refreshed runs partial,
+        keeping any active per-context filter (the button posts to
+        ``/subagents/cancel{qs}``, so the panel doesn't jump back to all runs)."""
         agent = agent_state.agent
         if not agent:
             raise HTTPException(503, "Agent not running")
@@ -3156,9 +3173,7 @@ def create_admin_app(
             raise HTTPException(400, "Missing 'run_id' in request body")
         agent.subagents.cancel(run_id)
         log.info("Subagent %r cancelled via admin", run_id)
-        return _render_partial(
-            "partials/subagent_runs.html", runs=_subagent_runs(), agent_running=True
-        )
+        return await partial_subagent_runs(channel=channel, chat_id=chat_id)
 
     # ── Config API ─────────────────────────────────────────────────────
 

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -4269,21 +4269,28 @@ def create_admin_app(
         tz = await config_store.get("agent.timezone") or "UTC"
         now = datetime.now(UTC)
         for c in chats:
-            c["run_id"] = ""
+            c["run_id"] = c["label"] = c["task"] = c["status"] = ""
             c["last_active_h"] = _humanize_ts(c.get("last_active", ""), now, tz)
         # Subagent runs never write to ConversationHistory, so their captured
         # payloads would be unreachable from the list. Append one synthetic row
         # per captured key that carries a run id (newest first), leaving the
-        # main-chat rows above untouched.
+        # main-chat rows above untouched. The registry supplies the label/agent/
+        # task so the row is nameable instead of an opaque run id — it keeps
+        # fewer finished runs than the payload cache, hence the .get fallback.
+        runs = {r.run_id: r for r in _subagent_runs()}
         for channel, user_id, chat_id, run_id in list_captured():
             if run_id:
+                run = runs.get(run_id)
                 chats.append(
                     {
                         "channel": channel,
                         "user_id": user_id,
                         "chat_id": chat_id,
                         "run_id": run_id,
-                        "last_active_h": "",
+                        "label": (run.label or run.agent) if run else "",
+                        "task": (run.task or "")[:120] if run else "",
+                        "status": run.status if run else "",
+                        "last_active_h": run.elapsed_str if run else "",
                     }
                 )
         return _render_partial("partials/inspect.html", chats=chats)

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -1071,6 +1071,7 @@ class AgentUpsertIn(BaseModel):
     character: str = ""
     skills: list[str] = []
     tools: list[str] = []
+    spawnable_agents: list[str] = []  # delegation trust list; empty = any agent
     secrets: list[str] = []
     bot_token: str = ""  # per-agent Telegram bot (#29); empty = no own bot
     allowed_user_ids: str = ""  # comma/newline-separated; empty = inherit global
@@ -1519,6 +1520,10 @@ def create_admin_app(
                 {"key": s.key, "label": s.label, "summary": s.summary}
                 for s in tool_registry()
                 if (await config_store.get(f"tools.{s.key}.enabled")) == "true"
+            ],
+            # Agent slugs offerable as a delegation trust list (spawnable_agents).
+            "all_agents": [
+                a.name for a in await (await _agent_store_from_config(config_store)).list_agents()
             ],
             "infra_available": bool(secret_store and secret_store.infra.available),
             # Existing infra-vault secret names an agent can reuse as its gh token
@@ -4107,6 +4112,7 @@ def create_admin_app(
                 character=body.character,
                 skills=[s.strip() for s in body.skills if s.strip()],
                 tools=[t.strip() for t in body.tools if t.strip()],
+                spawnable_agents=[a.strip() for a in body.spawnable_agents if a.strip()],
                 secrets=[s.strip() for s in body.secrets if s.strip()],
                 bot_token=body.bot_token.strip(),
                 allowed_user_ids=_as_int_list(body.allowed_user_ids),

--- a/humux/api/templates/agent_editor.html
+++ b/humux/api/templates/agent_editor.html
@@ -376,6 +376,28 @@
         </div>
       </div>
 
+      {# ── Delegation trust list (spawnable_agents) ── #}
+      <div class="card">
+        <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Delegation</h3>
+        <p class="text-xs text-muted mb-3">
+          None ticked = any agent may be delegated to, scoped down to this agent's own
+          tools and accounts (never widened). Ticking agents means <strong>only</strong>
+          those may be delegated to, and they run with their <strong>own</strong> tools and
+          accounts — a trust grant, so keep this list short for agents exposed to group
+          chats or webhooks.
+        </p>
+        <div class="space-y-2 max-h-[32rem] overflow-y-auto">
+          {% for a in all_agents if a != agent.name %}
+          <label class="flex items-start gap-2 text-xs">
+            <input type="checkbox" value="{{ a }}" x-model="spawnableAgents" class="mt-0.5">
+            <span class="font-semibold break-all">{{ a }}</span>
+          </label>
+          {% else %}
+          <p class="text-xs text-muted">No other agents defined yet.</p>
+          {% endfor %}
+        </div>
+      </div>
+
       {# ── Tool identities (#93) ── #}
       <div class="card">
         <h3 class="text-xs text-muted uppercase tracking-wider mb-2">Tool identities</h3>
@@ -615,7 +637,7 @@
   <div x-show="mode === 'raw'" class="card">
     <label class="label" for="agent-raw">Markdown (YAML frontmatter)</label>
     <textarea class="textarea" x-model="raw" id="agent-raw" style="min-height:460px; font-size:0.8rem; line-height:1.5; tab-size:2"></textarea>
-    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, voice, bot_token, allowed_user_ids, group_chat, llm, skills, tools, secrets, email_accounts, calendar_accounts, contacts_accounts, chat_settings, character).</p>
+    <p class="hint">Saving in raw mode parses this document directly — frontmatter keys (role, voice, bot_token, allowed_user_ids, group_chat, llm, skills, tools, spawnable_agents, secrets, email_accounts, calendar_accounts, contacts_accounts, chat_settings, character).</p>
   </div>
 
   <div class="flex items-center gap-2 mt-3">
@@ -642,6 +664,7 @@
       character: {{ agent.character|tojson }},
       skills: {{ agent.skills|tojson }},
       tools: {{ agent.tools|tojson }},
+      spawnableAgents: {{ agent.spawnable_agents|tojson }},
       secretsText: {{ (agent.secrets|join('\n'))|tojson }},
       raw: {{ raw|tojson }},
       result: '',
@@ -974,6 +997,7 @@
           'allowed_user_ids: ' + list(userIds) + '\n' +
           'skills: ' + list(this.skills) + '\n' +
           'tools: ' + list(this.tools) + '\n' +
+          'spawnable_agents: ' + list(this.spawnableAgents) + '\n' +
           'secrets: ' + list(secrets) + '\n' +
           'tool_config: ' + JSON.stringify(this.buildToolConfig()) + '\n' +
           'email_accounts: ' + JSON.stringify(this.buildEmailAccounts()) + '\n' +
@@ -1003,6 +1027,7 @@
               voice: this.voice,
               character: this.character,
               skills: this.skills, tools: this.tools,
+              spawnable_agents: this.spawnableAgents,
               secrets: this.secretsText.split('\n').map(s => s.trim()).filter(Boolean),
               bot_token: this.bot_token, allowed_user_ids: this.allowedUserIds,
               tool_config: this.buildToolConfig(), gh_token: ghToken,

--- a/humux/api/templates/base.html
+++ b/humux/api/templates/base.html
@@ -1364,20 +1364,6 @@
     }
     window.memorySubtab = memorySubtab;
 
-    // Jobs tab: Scheduled | Subagents sub-tabs.
-    // Persisted via ?jobsub= URL param; each sub-tab lazy-loads its own
-    // partial via htmx with skeleton loading.
-    function jobsTabs() {
-      return subTabs({
-        subs: { scheduled: '/partials/jobs/scheduled', subagents: '/partials/jobs/subagents' },
-        param: 'jobsub',
-        storageKey: 'jobs_sub',
-        container: '#jobs-sub',
-        fallback: 'scheduled'
-      });
-    }
-    window.jobsTabs = jobsTabs;
-
     // Global: handle 401 by redirecting to auth gate
     document.body.addEventListener('htmx:responseError', function(e) {
       if (e.detail.xhr.status === 401) {

--- a/humux/api/templates/partials/inspect.html
+++ b/humux/api/templates/partials/inspect.html
@@ -12,6 +12,14 @@
     </p>
   </div>
 
+  {# Live subagent runs — self-polling every 3s (it re-renders its own wrapper,
+     so the channel/chat filter set by the "runs" buttons below survives). #}
+  <div id="subagent-runs" class="mb-4"
+       hx-get="/partials/subagent-runs" hx-trigger="load"
+       hx-target="this" hx-swap="outerHTML">
+    <div class="skeleton skeleton-row"></div>
+  </div>
+
   <div class="flex flex-col lg:flex-row gap-3">
     {# Master — context list, newest-active first #}
     <div class="lg:w-80 lg:shrink-0 flex flex-col gap-2">
@@ -19,15 +27,16 @@
       <span class="text-muted text-xs">{{ chats|length }} context{{ '' if chats|length == 1 else 's' }}</span>
       <div class="flex flex-col gap-1 overflow-y-auto" style="max-height: 32rem">
         {% for c in chats %}
+        <div class="flex items-center gap-1"
+             x-show="!filter
+                     || {{ c.channel|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                     || {{ c.user_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                     || {{ c.chat_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                     || {{ c.run_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())">
         <button type="button"
-                class="card text-left flex flex-col gap-0.5 py-2"
+                class="card text-left flex flex-col gap-0.5 py-2 flex-1 min-w-0"
                 :class="selected === {{ loop.index0 }} ? 'border-accent' : ''"
                 @click="selected = {{ loop.index0 }}"
-                x-show="!filter
-                        || {{ c.channel|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
-                        || {{ c.user_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
-                        || {{ c.chat_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
-                        || {{ c.run_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())"
                 hx-get="/inspect/payload?channel={{ c.channel|urlencode }}&user_id={{ c.user_id|urlencode }}&chat_id={{ c.chat_id|urlencode }}&run_id={{ c.run_id|urlencode }}"
                 hx-target="#inspect-detail" hx-swap="innerHTML"
                 hx-trigger="click{% if loop.first %}, load{% endif %}">
@@ -47,6 +56,14 @@
             {% endif %}
           </div>
         </button>
+        {% if not c.run_id %}
+        {# Narrow the runs panel above to this context's subagent runs. #}
+        <button type="button" class="btn btn-sm btn-ghost shrink-0"
+                title="Show this context's subagent runs"
+                hx-get="/partials/subagent-runs?channel={{ c.channel|urlencode }}&chat_id={{ c.chat_id|urlencode }}"
+                hx-target="#subagent-runs" hx-swap="outerHTML">runs</button>
+        {% endif %}
+        </div>
         {% endfor %}
         {% if not chats %}
         <div class="text-muted text-xs text-center py-6">

--- a/humux/api/templates/partials/inspect.html
+++ b/humux/api/templates/partials/inspect.html
@@ -32,7 +32,8 @@
                      || {{ c.channel|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
                      || {{ c.user_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
                      || {{ c.chat_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
-                     || {{ c.run_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())">
+                     || {{ c.run_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                     || {{ (c.label ~ ' ' ~ c.task)|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())">
         <button type="button"
                 class="card text-left flex flex-col gap-0.5 py-2 flex-1 min-w-0"
                 :class="selected === {{ loop.index0 }} ? 'border-accent' : ''"
@@ -43,11 +44,14 @@
           <div class="flex items-center gap-1.5 min-w-0">
             <span class="{{ 'badge-warn' if c.run_id else 'badge-ok' }} whitespace-nowrap">{{ c.channel }}</span>
             <span class="text-sm font-semibold break-all flex-1 min-w-0">
-              {%- if c.run_id %}⚙ subagent {{ c.run_id }}{% else %}{{ c.chat_id or '(default)' }}{% endif -%}
+              {%- if c.run_id %}⚙ {{ c.label or c.run_id }}{% else %}{{ c.chat_id or '(default)' }}{% endif -%}
             </span>
           </div>
           {% if c.run_id %}
-          <div class="text-muted text-xs break-all">chat {{ c.chat_id or '(default)' }}</div>
+          {% if c.task %}<div class="text-muted text-xs break-all">{{ c.task }}</div>{% endif %}
+          <div class="text-muted text-xs break-all">
+            {{ c.run_id }}{% if c.status %} · {{ c.status }}{% endif %} · chat {{ c.chat_id or '(default)' }}
+          </div>
           {% endif %}
           <div class="flex items-center justify-between gap-2">
             <span class="text-muted text-xs break-all">user {{ c.user_id }}</span>

--- a/humux/api/templates/partials/inspect.html
+++ b/humux/api/templates/partials/inspect.html
@@ -26,14 +26,20 @@
                 x-show="!filter
                         || {{ c.channel|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
                         || {{ c.user_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
-                        || {{ c.chat_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())"
-                hx-get="/inspect/payload?channel={{ c.channel|urlencode }}&user_id={{ c.user_id|urlencode }}&chat_id={{ c.chat_id|urlencode }}"
+                        || {{ c.chat_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())
+                        || {{ c.run_id|tojson|forceescape }}.toLowerCase().includes(filter.toLowerCase())"
+                hx-get="/inspect/payload?channel={{ c.channel|urlencode }}&user_id={{ c.user_id|urlencode }}&chat_id={{ c.chat_id|urlencode }}&run_id={{ c.run_id|urlencode }}"
                 hx-target="#inspect-detail" hx-swap="innerHTML"
                 hx-trigger="click{% if loop.first %}, load{% endif %}">
           <div class="flex items-center gap-1.5 min-w-0">
-            <span class="badge-ok whitespace-nowrap">{{ c.channel }}</span>
-            <span class="text-sm font-semibold break-all flex-1 min-w-0">{{ c.chat_id or '(default)' }}</span>
+            <span class="{{ 'badge-warn' if c.run_id else 'badge-ok' }} whitespace-nowrap">{{ c.channel }}</span>
+            <span class="text-sm font-semibold break-all flex-1 min-w-0">
+              {%- if c.run_id %}⚙ subagent {{ c.run_id }}{% else %}{{ c.chat_id or '(default)' }}{% endif -%}
+            </span>
           </div>
+          {% if c.run_id %}
+          <div class="text-muted text-xs break-all">chat {{ c.chat_id or '(default)' }}</div>
+          {% endif %}
           <div class="flex items-center justify-between gap-2">
             <span class="text-muted text-xs break-all">user {{ c.user_id }}</span>
             {% if c.last_active_h %}

--- a/humux/api/templates/partials/jobs.html
+++ b/humux/api/templates/partials/jobs.html
@@ -1,19 +1,7 @@
-{# Jobs tab wrapper: Scheduled | Subagents sub-tabs.
-   Each sub-tab lazy-loads its own partial via htmx. The active sub-tab
-   is mirrored in the URL as ?jobsub= for copy-pasteable links. #}
-<div x-data="jobsTabs()" x-init="init()">
-  <div class="flex border-b border-border mb-4 overflow-x-auto">
-    <button type="button" class="tab-link" :class="sub === 'scheduled' && 'tab-link-active'" @click="select('scheduled')">Scheduled</button>
-    <button type="button" class="tab-link" :class="sub === 'subagents' && 'tab-link-active'" @click="select('subagents')">
-      Subagents
-      {# Running-subagent count; filled out-of-band by partials/subagent_runs.html on every 3s poll. #}
-      <span id="subagent-badge"
-            class="inline-flex items-center justify-center ml-1 px-1.5 py-0.5 rounded-full text-[0.65rem] font-bold bg-accent text-black" style="min-width:1.25rem; line-height:1;display:none;"></span>
-    </button>
-  </div>
-  <div id="jobs-sub">
-    <div class="skeleton skeleton-row"></div>
-    <div class="skeleton skeleton-row"></div>
-    <div class="skeleton skeleton-row"></div>
-  </div>
+{# Jobs tab — scheduled jobs (including jobs of type "subagent").
+   Live subagent runs moved to the Inspect tab. #}
+<div id="jobs-sub" hx-get="/partials/jobs/scheduled" hx-trigger="load" hx-swap="innerHTML">
+  <div class="skeleton skeleton-row"></div>
+  <div class="skeleton skeleton-row"></div>
+  <div class="skeleton skeleton-row"></div>
 </div>

--- a/humux/api/templates/partials/jobs.html
+++ b/humux/api/templates/partials/jobs.html
@@ -6,6 +6,7 @@
     <button type="button" class="tab-link" :class="sub === 'scheduled' && 'tab-link-active'" @click="select('scheduled')">Scheduled</button>
     <button type="button" class="tab-link" :class="sub === 'subagents' && 'tab-link-active'" @click="select('subagents')">
       Subagents
+      {# Running-subagent count; filled out-of-band by partials/subagent_runs.html on every 3s poll. #}
       <span id="subagent-badge"
             class="inline-flex items-center justify-center ml-1 px-1.5 py-0.5 rounded-full text-[0.65rem] font-bold bg-accent text-black" style="min-width:1.25rem; line-height:1;display:none;"></span>
     </button>

--- a/humux/api/templates/partials/jobs_subagents.html
+++ b/humux/api/templates/partials/jobs_subagents.html
@@ -1,6 +1,0 @@
-<div id="subagent-runs"
-     hx-get="/partials/subagent-runs" hx-trigger="load, every 3s" hx-swap="innerHTML">
-  <div class="skeleton skeleton-row"></div>
-  <div class="skeleton skeleton-row"></div>
-  <div class="skeleton skeleton-row"></div>
-</div>

--- a/humux/api/templates/partials/logs.html
+++ b/humux/api/templates/partials/logs.html
@@ -24,10 +24,14 @@
 
   <form id="log-filters"
         hx-get="/partials/logs-content" hx-target="#log-content" hx-swap="innerHTML"
-        hx-trigger="load, change, keyup delay:400ms from:input[name='q']"
+        hx-trigger="load, change, keyup delay:400ms from:input[name='q'], keyup delay:400ms from:input[name='subagent']"
         class="flex flex-wrap items-end gap-3 mb-4">
     <label class="label">Stream
       <input type="text" name="stream" list="log-streams" placeholder="all (regex)"
+             class="block w-44 rounded border-border bg-surface text-sm px-2 py-1">
+    </label>
+    <label class="label">Subagent
+      <input type="text" name="subagent" placeholder="any (label)"
              class="block w-44 rounded border-border bg-surface text-sm px-2 py-1">
     </label>
     <label class="label">Level

--- a/humux/api/templates/partials/subagent_runs.html
+++ b/humux/api/templates/partials/subagent_runs.html
@@ -1,35 +1,71 @@
-{# Subagent runs — responsive card grid, polled live by the Jobs tab (#15) #}
-{% if runs %}
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-  {% for r in runs %}
-  <div class="card">
-    <div class="flex items-center justify-between gap-2">
-      <span class="font-medium text-xs break-all">{{ r.agent or 'default' }}</span>
-      <span class="{% if r.status in ('running', 'done') %}badge-ok{% elif r.status == 'error' %}badge-warn{% else %}badge-off{% endif %}">
-        {{ r.status }}
-      </span>
-    </div>
-    <div class="text-muted text-[0.7rem] mt-1 break-words">{{ r.task[:140] }}{{ '…' if r.task|length > 140 else '' }}</div>
-    <div class="flex items-center justify-between text-muted text-[0.65rem] mt-2 gap-2">
-      <span title="elapsed">⏱ {{ r.elapsed_str }}</span>
-      <span class="truncate" title="{{ r.progress }}">{{ r.progress or '—' }}</span>
-    </div>
-    {% if r.depth and r.depth > 1 %}
-    <div class="text-muted text-[0.6rem] mt-1">depth {{ r.depth }}</div>
-    {% endif %}
-    {% if r.status == 'running' %}
-    <button class="btn-danger btn-sm mt-2 w-full"
-            hx-post="/subagents/cancel" hx-target="#subagent-runs" hx-swap="innerHTML"
-            hx-vals='{"run_id": {{ r.run_id|tojson }} }'
-            hx-confirm="Cancel subagent {{ r.run_id }}?">
-      Cancel
-    </button>
-    {% endif %}
+{# Subagent runs — responsive card grid, polled live by the Jobs tab (#15).
+   Siblings of one spawn_subagents fan-out share a group_id and render under a
+   group header; a child run (parent_run_id set) is indented and names its
+   parent, so the run tree is visible. #}
+{% macro status_badge(status) -%}
+  {%- if status == 'running' -%}
+    <span class="badge-warn">running</span>
+  {%- elif status == 'done' -%}
+    <span class="badge-ok">done</span>
+  {%- elif status == 'error' -%}
+    <span class="badge-off" style="color:var(--color-danger); background-color:color-mix(in oklab, var(--color-danger-dim) 40%, transparent)">error</span>
+  {%- else -%}
+    <span class="badge-off">{{ status }}</span>
+  {%- endif -%}
+{%- endmacro %}
+
+{% macro run_card(r, labels) %}
+<div class="card{% if r.parent_run_id %} border-l-2 border-accent ml-2{% endif %}">
+  <div class="flex items-center justify-between gap-2">
+    <span class="font-medium text-xs break-all">{{ r.label or r.agent or r.run_id }}</span>
+    {{ status_badge(r.status) }}
   </div>
-  {% endfor %}
+  {% if r.parent_run_id %}
+  <div class="text-muted text-[0.6rem] mt-0.5 break-all">└ child of {{ labels.get(r.parent_run_id, r.parent_run_id) }}</div>
+  {% endif %}
+  <div class="text-muted text-[0.7rem] mt-1 break-words">{{ r.task[:140] }}{{ '…' if r.task|length > 140 else '' }}</div>
+  <div class="flex items-center justify-between text-muted text-[0.65rem] mt-2 gap-2">
+    <span title="elapsed">⏱ {{ r.elapsed_str }}</span>
+    <span class="truncate" title="{{ r.progress }}">{{ r.progress or '—' }}</span>
+  </div>
+  <div class="flex flex-wrap items-center gap-2 text-muted text-[0.6rem] mt-1">
+    {% if r.depth and r.depth > 1 %}<span>depth {{ r.depth }}</span>{% endif %}
+    {% if r.steps %}<span title="tool-call rounds">{{ r.steps }} steps</span>{% endif %}
+    {% if r.tokens_used %}<span title="approx tokens used">{{ '{:,}'.format(r.tokens_used) }} tok</span>{% endif %}
+    {% if r.children %}<span title="child runs">{{ r.children|length }} child{{ '' if r.children|length == 1 else 'ren' }}</span>{% endif %}
+    {% if r.stopped_reason and r.status != 'running' %}<span title="why it stopped">stopped: {{ r.stopped_reason }}</span>{% endif %}
+  </div>
+  {% if r.status == 'running' %}
+  <button class="btn-danger btn-sm mt-2 w-full"
+          hx-post="/subagents/cancel" hx-target="#subagent-runs" hx-swap="innerHTML"
+          hx-vals='{"run_id": {{ r.run_id|tojson }} }'
+          hx-confirm="Cancel subagent {{ r.run_id }}?">
+    Cancel
+  </button>
+  {% endif %}
 </div>
+{% endmacro %}
+
+{% if groups %}
+{% for g in groups %}
+  {% if g.group_id %}
+  <div class="flex items-center gap-2 mt-3 mb-1">
+    <span class="text-xs text-accent font-medium">fan-out {{ g.group_id }}</span>
+    <span class="text-muted text-[0.65rem]">{{ g.runs|length }} run{{ '' if g.runs|length == 1 else 's' }}</span>
+    <span class="flex-1 border-t border-border"></span>
+  </div>
+  {% endif %}
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3{% if not g.group_id %} mt-3{% endif %}">
+    {% for r in g.runs %}{{ run_card(r, labels) }}{% endfor %}
+  </div>
+{% endfor %}
 {% else %}
 <p class="text-muted text-xs">
   {% if agent_running %}No subagent runs yet.{% else %}Agent stopped — no subagent runs.{% endif %}
 </p>
 {% endif %}
+
+{# Live count for the Jobs sub-tab badge — swapped out-of-band on every poll. #}
+<span id="subagent-badge" hx-swap-oob="true"
+      class="inline-flex items-center justify-center ml-1 px-1.5 py-0.5 rounded-full text-[0.65rem] font-bold bg-accent text-black"
+      style="min-width:1.25rem; line-height:1;{% if not running_count %}display:none;{% endif %}">{{ running_count or '' }}</span>

--- a/humux/api/templates/partials/subagent_runs.html
+++ b/humux/api/templates/partials/subagent_runs.html
@@ -1,7 +1,9 @@
-{# Subagent runs — responsive card grid, polled live by the Jobs tab (#15).
+{# Subagent runs — responsive card grid, polled live by the Inspect tab (#15).
    Siblings of one spawn_subagents fan-out share a group_id and render under a
    group header; a child run (parent_run_id set) is indented and names its
-   parent, so the run tree is visible. #}
+   parent, so the run tree is visible. The panel replaces itself on every poll
+   (outerHTML), so an active channel/chat filter survives the refresh — the
+   filter lives in this element's own hx-get. #}
 {% macro status_badge(status) -%}
   {%- if status == 'running' -%}
     <span class="badge-warn">running</span>
@@ -37,7 +39,7 @@
   </div>
   {% if r.status == 'running' %}
   <button class="btn-danger btn-sm mt-2 w-full"
-          hx-post="/subagents/cancel" hx-target="#subagent-runs" hx-swap="innerHTML"
+          hx-post="/subagents/cancel{{ qs }}" hx-target="#subagent-runs" hx-swap="outerHTML"
           hx-vals='{"run_id": {{ r.run_id|tojson }} }'
           hx-confirm="Cancel subagent {{ r.run_id }}?">
     Cancel
@@ -46,26 +48,36 @@
 </div>
 {% endmacro %}
 
-{% if groups %}
-{% for g in groups %}
-  {% if g.group_id %}
-  <div class="flex items-center gap-2 mt-3 mb-1">
-    <span class="text-xs text-accent font-medium">fan-out {{ g.group_id }}</span>
-    <span class="text-muted text-[0.65rem]">{{ g.runs|length }} run{{ '' if g.runs|length == 1 else 's' }}</span>
-    <span class="flex-1 border-t border-border"></span>
+<div id="subagent-runs" class="mb-4"
+     hx-get="/partials/subagent-runs{{ qs }}" hx-trigger="every 3s"
+     hx-target="this" hx-swap="outerHTML">
+  <div class="flex flex-wrap items-center gap-2">
+    <span class="text-xs font-medium">Subagent runs</span>
+    {# Live running count — re-rendered with the panel on every poll. #}
+    {% if running_count %}<span class="badge-warn">{{ running_count }} running</span>{% endif %}
+    {% if qs %}
+    <span class="text-muted text-xs">filtered</span>
+    <button type="button" class="btn btn-sm btn-ghost"
+            hx-get="/partials/subagent-runs" hx-target="#subagent-runs" hx-swap="outerHTML">show all</button>
+    {% endif %}
   </div>
-  {% endif %}
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3{% if not g.group_id %} mt-3{% endif %}">
-    {% for r in g.runs %}{{ run_card(r, labels) }}{% endfor %}
-  </div>
-{% endfor %}
-{% else %}
-<p class="text-muted text-xs">
-  {% if agent_running %}No subagent runs yet.{% else %}Agent stopped — no subagent runs.{% endif %}
-</p>
-{% endif %}
 
-{# Live count for the Jobs sub-tab badge — swapped out-of-band on every poll. #}
-<span id="subagent-badge" hx-swap-oob="true"
-      class="inline-flex items-center justify-center ml-1 px-1.5 py-0.5 rounded-full text-[0.65rem] font-bold bg-accent text-black"
-      style="min-width:1.25rem; line-height:1;{% if not running_count %}display:none;{% endif %}">{{ running_count or '' }}</span>
+  {% if groups %}
+  {% for g in groups %}
+    {% if g.group_id %}
+    <div class="flex items-center gap-2 mt-3 mb-1">
+      <span class="text-xs text-accent font-medium">fan-out {{ g.group_id }}</span>
+      <span class="text-muted text-[0.65rem]">{{ g.runs|length }} run{{ '' if g.runs|length == 1 else 's' }}</span>
+      <span class="flex-1 border-t border-border"></span>
+    </div>
+    {% endif %}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3{% if not g.group_id %} mt-3{% endif %}">
+      {% for r in g.runs %}{{ run_card(r, labels) }}{% endfor %}
+    </div>
+  {% endfor %}
+  {% else %}
+  <p class="text-muted text-xs mt-1">
+    {% if not agent_running %}Agent stopped — no subagent runs.{% elif qs %}No subagent runs for this context.{% else %}No subagent runs yet.{% endif %}
+  </p>
+  {% endif %}
+</div>

--- a/humux/api/templates/partials/tools.html
+++ b/humux/api/templates/partials/tools.html
@@ -67,7 +67,10 @@
     recursion: {{ subagents_recursion_depth|default('3', true)|tojson|forceescape }},
     steps: {{ subagents_max_steps|default('12', true)|tojson|forceescape }},
     tokens: {{ subagents_token_budget|default('100000', true)|tojson|forceescape }},
-    concurrent: {{ subagents_max_concurrent|default('3', true)|tojson|forceescape }},
+    concurrent: {{ subagents_max_concurrent|default('4', true)|tojson|forceescape }},
+    fanout: {{ subagents_max_fanout|default('6', true)|tojson|forceescape }},
+    spawnsPerTurn: {{ subagents_max_spawns_per_turn|default('12', true)|tojson|forceescape }},
+    turnTokens: {{ subagents_turn_token_budget|default('400000', true)|tojson|forceescape }},
     allowedModels: {{ subagents_allowed_models|default('', true)|tojson|forceescape }},
     summaryEnabled: {{ summary_enabled|default('true', true)|tojson|forceescape }},
     summaryProvider: {{ summary_provider|default('deepseek', true)|tojson|forceescape }},
@@ -81,6 +84,9 @@
         'subagents.max_steps': String(parseInt(this.steps) || 1),
         'subagents.token_budget': String(parseInt(this.tokens) || 1),
         'subagents.max_concurrent': String(parseInt(this.concurrent) || 1),
+        'subagents.max_fanout': String(parseInt(this.fanout) || 1),
+        'subagents.max_spawns_per_turn': String(parseInt(this.spawnsPerTurn) || 1),
+        'subagents.turn_token_budget': String(parseInt(this.turnTokens) || 1),
         'subagents.allowed_models': JSON.stringify(String(this.allowedModels || '').split('\n').map(s => s.trim()).filter(Boolean)),
         'subagent_summary.enabled': String(this.summaryEnabled === true || this.summaryEnabled === 'true'),
         'subagent_summary.provider': String(this.summaryProvider || 'deepseek').trim(),
@@ -133,9 +139,24 @@
         <p class="text-muted text-xs mt-1">Approx token ceiling per run (best-effort).</p>
       </div>
       <div>
-        <label class="label" for="tools-sub-concurrent">Max concurrent</label>
+        <label class="label" for="tools-sub-concurrent">Max concurrent (per chat)</label>
         <input type="number" min="1" class="input-sm" style="max-width:200px" x-model="concurrent" id="tools-sub-concurrent">
-        <p class="text-muted text-xs mt-1">Background runs allowed at once.</p>
+        <p class="text-muted text-xs mt-1">Runs executing at once in one chat, all paths.</p>
+      </div>
+      <div>
+        <label class="label" for="tools-sub-fanout">Max fan-out</label>
+        <input type="number" min="1" class="input-sm" style="max-width:200px" x-model="fanout" id="tools-sub-fanout">
+        <p class="text-muted text-xs mt-1">Max tasks in one <code>spawn_subagents</code> call.</p>
+      </div>
+      <div>
+        <label class="label" for="tools-sub-spawns-turn">Max spawns per turn</label>
+        <input type="number" min="1" class="input-sm" style="max-width:200px" x-model="spawnsPerTurn" id="tools-sub-spawns-turn">
+        <p class="text-muted text-xs mt-1">Whole tree — parents and children combined.</p>
+      </div>
+      <div>
+        <label class="label" for="tools-sub-turn-tokens">Turn token budget</label>
+        <input type="number" min="1" class="input-sm" style="max-width:200px" x-model="turnTokens" id="tools-sub-turn-tokens">
+        <p class="text-muted text-xs mt-1">Subagent tokens one turn may spend, tree-wide.</p>
       </div>
     </div>
     <div class="mt-3" x-show="enabled === 'true' || enabled === true">

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -657,8 +657,9 @@ class TelegramChannel:
             await message.reply_text("No active subagent runs.")
             return
         for r in runs:
+            name = r.label or r.agent or "default"
             text = (
-                f"🤖 <b>{r.agent or 'default'}</b> · {r.status} · {r.elapsed_str}\n"
+                f"🤖 <b>{name}</b> · {r.status} · {r.elapsed_str}\n"
                 f"{(r.progress or '—')}\n"
                 f"<i>{r.task[:160]}</i>"
             )

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -656,10 +656,17 @@ class TelegramChannel:
         if not runs:
             await message.reply_text("No active subagent runs.")
             return
-        for r in runs:
+        # Oldest first so a parent reads above the children it spawned; the
+        # registry lists every run at any depth, so nested spawns are all here.
+        for r in sorted(runs, key=lambda x: x.started_at):
             name = r.label or r.agent or "default"
+            lineage = ""
+            if r.parent_run_id:
+                parent = self.agent.subagents.get(r.parent_run_id)
+                pname = (parent.label or parent.agent or parent.run_id) if parent else "?"
+                lineage = f"\n└ spawned by <b>{pname}</b>"
             text = (
-                f"🤖 <b>{name}</b> · {r.status} · {r.elapsed_str}\n"
+                f"🤖 <b>{name}</b> · {r.status} · {r.elapsed_str}{lineage}\n"
                 f"{(r.progress or '—')}\n"
                 f"<i>{r.task[:160]}</i>"
             )

--- a/humux/config.yml.example
+++ b/humux/config.yml.example
@@ -209,15 +209,20 @@ workspace:
   directory: ""            # e.g. "~/projects/my-repo" — the only dir the agent may touch
 
 # Subagents — the agent can delegate a scoped subtask to a sub-loop running
-# under a chosen agent, on demand (spawn_subagent tool) or on a schedule
-# (a "subagent" job above). A child's tools/skills/secrets are a subset of the
-# caller's — never wider. Defaults work out of the box; tune the guardrails:
+# under a chosen agent, on demand (spawn_subagent tool, or spawn_subagents to
+# fan several out in parallel — top level only, no nested fan-out) or on a
+# schedule (a "subagent" job above). A child's tools/skills/secrets are a
+# subset of the caller's — never wider. Defaults work out of the box; tune
+# the guardrails:
 subagents:
   enabled: true
-  recursion_depth: 3   # max nesting (a top-level spawn is depth 1)
-  max_steps: 12        # max tool-call rounds per run (hard stop)
-  token_budget: 100000 # approx token ceiling per run (best-effort)
-  max_concurrent: 3    # max background runs at once
+  recursion_depth: 3        # max nesting (a top-level spawn is depth 1)
+  max_steps: 12             # max tool-call rounds per run (hard stop)
+  token_budget: 100000      # approx token ceiling per run (best-effort)
+  max_concurrent: 4         # per-chat concurrency gate for ALL runs (sync + background); extras queue, not fail
+  max_fanout: 6             # max tasks in one spawn_subagents call
+  max_spawns_per_turn: 12    # max spawns across the whole subagent tree, per turn
+  turn_token_budget: 400000  # max subagent tokens across the whole tree, per turn (reserve-then-refund)
   # "provider:model" a spawn may pick instead of inheriting the caller's LLM
   # (e.g. a cheap worker under an expensive coordinator). Empty = inherit only.
   allowed_models: []   # e.g. ["deepseek:deepseek-v4-flash"]

--- a/humux/config.yml.example
+++ b/humux/config.yml.example
@@ -222,7 +222,7 @@ subagents:
   max_concurrent: 4         # per-chat concurrency gate for ALL runs (sync + background); extras queue, not fail
   max_fanout: 6             # max tasks in one spawn_subagents call
   max_spawns_per_turn: 12    # max spawns across the whole subagent tree, per turn
-  turn_token_budget: 400000  # max subagent tokens across the whole tree, per turn (reserve-then-refund)
+  turn_token_budget: 400000  # max subagent tokens across the whole tree, per turn (charged as spent; runs stop when the pool drains)
   # "provider:model" a spawn may pick instead of inheriting the caller's LLM
   # (e.g. a cheap worker under an expensive coordinator). Empty = inherit only.
   allowed_models: []   # e.g. ["deepseek:deepseek-v4-flash"]

--- a/humux/config.yml.example
+++ b/humux/config.yml.example
@@ -218,11 +218,11 @@ subagents:
   enabled: true
   recursion_depth: 3        # max nesting (a top-level spawn is depth 1)
   max_steps: 12             # max tool-call rounds per run (hard stop)
-  token_budget: 100000      # approx token ceiling per run (best-effort)
+  token_budget: 300000      # approx token ceiling per run (best-effort)
   max_concurrent: 4         # per-chat concurrency gate for ALL runs (sync + background); extras queue, not fail
   max_fanout: 6             # max tasks in one spawn_subagents call
   max_spawns_per_turn: 12    # max spawns across the whole subagent tree, per turn
-  turn_token_budget: 400000  # max subagent tokens across the whole tree, per turn (charged as spent; runs stop when the pool drains)
+  turn_token_budget: 1200000  # max subagent tokens across the whole tree, per turn (charged as spent; runs stop when the pool drains)
   # "provider:model" a spawn may pick instead of inheriting the caller's LLM
   # (e.g. a cheap worker under an expensive coordinator). Empty = inherit only.
   allowed_models: []   # e.g. ["deepseek:deepseek-v4-flash"]

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -754,11 +754,10 @@ TOOLS = [
             "that is never wider than yours, and returns a structured result. It "
             "has NO memory of this conversation — put everything it needs in "
             "'task'.\n"
-            "Agent: by DEFAULT omit 'agent' — the subagent runs as YOU (your "
-            "identity, tools, scope). This is almost always what you want. Set "
-            "'agent' ONLY when the user explicitly asked for a named specialist, "
-            "or the subtask plainly belongs to a different one. Never pick a "
-            "agent just because the roster lists some.\n"
+            "Agent: omit 'agent' to run the subagent as YOU (your identity, "
+            "tools, scope). Name an agent from your roster when the subtask "
+            "belongs to that specialist — follow the roster's guidance on when. "
+            "Never pick an agent the roster doesn't list.\n"
             "Sizing: by default the subagent runs at the configured ceilings. Size "
             "it to the job with 'max_steps', 'token_budget', and 'thinking_effort' "
             "— smaller for a quick lookup, larger / 'high' effort for hard "
@@ -1942,6 +1941,13 @@ class AgentCore:
             log.exception("Failed to list agents for the subagent roster")
             return ""
         current = agent.name if agent else ""
+        # A curated team (spawnable_agents) narrows the roster to the trusted
+        # teammates — the owner explicitly wants delegation to them, and they
+        # run with their OWN capabilities, so the guidance flips from "only if
+        # asked" to "pick the best-equipped teammate".
+        team = list(agent.spawnable_agents) if agent and agent.spawnable_agents else []
+        if team:
+            agents = [a for a in agents if a.name in team or a.name == current]
         lines = []
         for p in agents:
             role = p.role.strip().splitlines()[0].strip() if (p.role or "").strip() else ""
@@ -1950,15 +1956,23 @@ class AgentCore:
         if not lines:
             return ""
         body = "\n".join(lines)
-        return (
-            "<agents>\n"
-            "These agents exist ONLY so you can honour an explicit request for a "
-            "specialist. By default, spawn_subagent with NO 'agent' so the "
-            "subagent runs as you — do not assign one of these unless the user "
-            "asked for it or the subtask plainly belongs to it.\n"
-            f"{body}\n"
-            "</agents>"
-        )
+        if team:
+            intro = (
+                "Your team. When a subtask plainly belongs to one of these "
+                "specialists, name it in spawn_subagent(s) — it runs with its "
+                "own tools, skills, accounts and memory, so it is better "
+                "equipped there than you. Omit 'agent' to run a subtask as "
+                "yourself. You may not name agents outside this list."
+            )
+        else:
+            intro = (
+                "These agents exist ONLY so you can honour an explicit request "
+                "for a specialist. By default, spawn_subagent with NO 'agent' "
+                "so the subagent runs as you — do not assign one of these "
+                "unless the user asked for it or the subtask plainly belongs "
+                "to it."
+            )
+        return f"<agents>\n{intro}\n{body}\n</agents>"
 
     async def _skills_block_in_history(self, session_key: tuple[str, str, str], block: str) -> bool:
         """True if the exact ``<available_skills>`` block is already present in the
@@ -4215,9 +4229,23 @@ class AgentCore:
         if ov_error:
             return {"error": ov_error}
 
-        # Resolve + narrow the agent. A name must exist; with no name the child
-        # inherits the caller's identity and scope.
+        # Resolve the agent. With no name the child inherits the caller's
+        # identity and scope. A name is checked against the caller's delegation
+        # trust list (spawnable_agents): a curated list is a trust grant — only
+        # listed agents may be named, and a listed specialist runs with its OWN
+        # capabilities (that is the point of picking it). No list = legacy: any
+        # agent, scoped down to the intersection (inherit-never-widen).
+        parent_agent: Agent | None = parent_state.get("agent_obj")
+        team = list(parent_agent.spawnable_agents) if parent_agent else []
+        trusted = False
         if agent_name:
+            if parent_agent and team and agent_name != parent_agent.name and agent_name not in team:
+                return {
+                    "error": (
+                        f"Agent '{parent_agent.name}' may only delegate to: "
+                        f"{', '.join(team)}. Omit 'agent' to run as yourself."
+                    )
+                }
             requested = await self._load_agent(agent_name)
             if requested is None:
                 try:
@@ -4232,9 +4260,15 @@ class AgentCore:
                 }
             if not requested.enabled:  # kill-switch: can't spawn a disabled agent (#115 flw)
                 return {"error": f"Agent '{agent_name}' is disabled and can't be spawned."}
+            trusted = bool(parent_agent and team and requested.name != parent_agent.name)
         else:
-            requested = parent_state.get("agent_obj")
-        child_agent = self._narrow_agent(requested, parent_state) if requested else None
+            requested = parent_agent
+        if requested is None:
+            child_agent = None
+        elif trusted:
+            child_agent = requested
+        else:
+            child_agent = self._narrow_agent(requested, parent_state)
 
         run_id = f"sub_{uuid.uuid4().hex[:8]}"
         child_state = self._new_request_state(
@@ -4315,6 +4349,12 @@ class AgentCore:
             skills=narrow_scope(p_skills, requested.skills),
             tools=narrow_scope(p_tools, requested.tools),
             secrets=narrow_scope(p_secrets, requested.secrets),
+            # The delegation trust list is a per-identity owner grant — like tool
+            # identity, it travels with the agent. Dropping it would strip an
+            # anonymous child (which IS the caller) of the caller's team, leaving
+            # it in the legacy any-agent regime — an escape from the very
+            # containment the list exists to provide.
+            spawnable_agents=list(requested.spawnable_agents),
             # Tool identity travels verbatim with the agent (#93) — it is who the
             # child IS (its own gh token / browser profile), not a caller-subset
             # scope. Dropping it would silently fall back to the owner's token and
@@ -4401,10 +4441,6 @@ class AgentCore:
         # lives. A child may still spawn serially below the ceiling (the shared
         # FanoutBudget bounds its spend either way).
         tools = [t for t in tools if t["name"] != "spawn_subagents"]
-        # Subagents have no native-media delivery path (#55): a subagent returns
-        # only text, so a generated image would be billed + saved + silently
-        # dropped. Don't offer the tool at all.
-        tools = [t for t in tools if t["name"] != "generate_image"]
 
         system = await self._build_system_prompt(agent=child_agent)
         system = f"{system}\n\n{RESULT_FOR_AGENT_INSTRUCTION}\n\n{FILE_HANDOFF_INSTRUCTION}"
@@ -4959,11 +4995,19 @@ class AgentCore:
             Attachment(data=data, mime_type=mime, filename=Path(path).name)
         )
         log.info("Generated image (%d bytes, %s) → %s", len(data), mime, path)
+        # A subagent has no native-media delivery path of its own (#55): its
+        # pending_attachments die with the run. The file is on the shared
+        # filesystem, so the path IS the delivery — report it via the Files:
+        # handoff and let the spawning agent send it.
+        in_subagent = int(request_state.get("depth", 0) or 0) > 0
         result = {
             "ok": True,
             "path": path,
             "note": (
-                "Image generated and queued for delivery to the user as a photo. "
+                "Image generated and saved. Report this absolute path in your "
+                "'Files:' line so the agent that spawned you can deliver it."
+                if in_subagent
+                else "Image generated and queued for delivery to the user as a photo. "
                 "Do not include the path or base64 in your reply — just say briefly "
                 "what you made."
             ),

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -3917,7 +3917,7 @@ class AgentCore:
             if err:
                 entries.append({"index": i, "label": label, "error": err})
                 continue
-            self._start_subagent(run)
+            await self._start_subagent(run)
             entries.append(
                 {
                     "index": i,
@@ -4186,7 +4186,7 @@ class AgentCore:
             err = budget.take_spawn()
             if err:
                 return {"error": err}
-            self._start_subagent(run)
+            await self._start_subagent(run)
             bg = asyncio.create_task(
                 self._run_subagent_background(run, child_agent, child_state),
                 name=f"subagent-{run_id}",
@@ -4210,7 +4210,7 @@ class AgentCore:
         err = budget.take_spawn()
         if err:
             return {"error": err}
-        self._start_subagent(run)
+        await self._start_subagent(run)
         log.info("Running subagent %s (agent=%s)", run_id, run.agent or "default")
         try:
             text = await self._run_subagent_loop(task, child_agent, child_state, run)
@@ -4375,12 +4375,26 @@ class AgentCore:
             )
         return budget
 
-    def _start_subagent(self, run: SubagentRun) -> None:
-        """Register a prepared run and link it into its parent's run tree."""
+    async def _start_subagent(self, run: SubagentRun) -> None:
+        """Register a prepared run, link it into its parent's run tree, and
+        announce it in the originating chat. Every run passes through here, so
+        the note also covers nested spawns — the user sees the tree grow and can
+        cancel any of it via /subagents. Fan-out children are skipped: their
+        group note already names every label."""
         self.subagents.register(run)
         parent_run = self.subagents.get(run.parent_run_id) if run.parent_run_id else None
         if parent_run and run.run_id not in parent_run.children:
             parent_run.children.append(run.run_id)
+        if run.group_id:
+            return
+        name = run.label or run.agent or run.run_id
+        as_agent = f" (as {run.agent})" if run.agent and run.agent != name else ""
+        if run.depth >= 2 and parent_run:
+            parent_name = parent_run.label or parent_run.agent or parent_run.run_id
+            text = f"🧬 {parent_name} spawned subagent {name}{as_agent}"
+        else:
+            text = f"🧬 Spawned subagent {name}{as_agent}"
+        await self._notify_origin_chat(run.origin_channel, run.origin_chat_id, text)
 
     @staticmethod
     def _subagent_chat_key(channel: str, chat_id: str) -> str:

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -157,6 +157,10 @@ _LOOP_ABORT_MESSAGE = (
     "Could you rephrase, or break the request into smaller steps?"
 )
 
+# A sync spawn's result lands in the very next reply, so a completion note only
+# earns its noise when the run kept the user waiting this long.
+_SUBAGENT_NOTE_MIN_SECONDS = 10.0
+
 
 def _failure_signature(name: str, params: object) -> str:
     """Stable key identifying a tool call, for the repeat-failure breaker (#78)."""
@@ -3983,13 +3987,18 @@ class AgentCore:
             try:
                 text = await self._run_subagent_loop(run.task, e["agent_obj"], e["state"], run)
             except asyncio.CancelledError:
+                # No note: cancellation is the user's own /stop (or an explicit
+                # per-run cancel, which shows its own notice) — a wide fan-out
+                # would otherwise spam one 🚫 bubble per child.
                 self.subagents.finish(run.run_id, "cancelled")
                 raise
             except Exception as exc:
                 log.exception("Subagent %s failed", run.run_id)
                 self.subagents.finish(run.run_id, "error", error=str(exc))
+                await self._notify_run_finished(run)
                 return
             self.subagents.finish(run.run_id, "done", result=text)
+            await self._notify_run_finished(run)
 
         child_tasks: dict[str, asyncio.Task] = {}
         for e in live:
@@ -4079,6 +4088,35 @@ class AgentCore:
             await ch.send(chat_id, text)
         except Exception:
             log.exception("Failed to send progress note (chat=%s)", chat_id)
+
+    async def _notify_background_progress(self, run: SubagentRun) -> None:
+        """Completion note for a background run, but only mid-batch: the last
+        finisher's note would land right next to the batch digest — one event,
+        two bubbles — so it is skipped and the digest speaks for it. The check
+        mirrors _maybe_deliver_subagent_batch's barrier (background runs only),
+        so note-or-digest is exhaustive and exclusive."""
+        still_running = any(
+            r.background
+            and r.status == "running"
+            and r.origin_channel == run.origin_channel
+            and r.origin_chat_id == run.origin_chat_id
+            for r in self.subagents.list_runs()
+        )
+        if still_running:
+            await self._notify_run_finished(run)
+
+    async def _notify_run_finished(self, run: SubagentRun) -> None:
+        """One-line status note when a subagent run ends. Notification only: it
+        goes out over the channel, so it is never recorded in history and never
+        reaches the model as input."""
+        name = run.label or run.agent or run.run_id
+        if run.status == "error":
+            text = f"⚠️ Subagent {name} — failed ({run.elapsed_str})"
+        else:
+            used = run.tokens_used
+            tokens = f"{round(used / 1000)}k" if used >= 1000 else str(used)
+            text = f"✅ Subagent {name} — done ({run.elapsed_str}, {tokens} tokens)"
+        await self._notify_origin_chat(run.origin_channel, run.origin_chat_id, text)
 
     async def run_subagent(
         self,
@@ -4179,8 +4217,12 @@ class AgentCore:
         except Exception as exc:
             log.exception("Subagent %s failed", run_id)
             self.subagents.finish(run_id, "error", error=str(exc))
+            if run.elapsed >= _SUBAGENT_NOTE_MIN_SECONDS:
+                await self._notify_run_finished(run)
             return {"error": f"Subagent failed: {exc}", "run_id": run_id}
         self.subagents.finish(run_id, "done", result=text)
+        if run.elapsed >= _SUBAGENT_NOTE_MIN_SECONDS:
+            await self._notify_run_finished(run)
         return {
             "ok": True,
             "run_id": run_id,
@@ -4597,6 +4639,8 @@ class AgentCore:
             # finish() is a no-op here). Mark it synthesised so a sibling's batch
             # doesn't report on a run the user deliberately cancelled.
             self.subagents.finish(run.run_id, "cancelled")
+            # No completion note here: a user-initiated cancel already shows its
+            # own notice (the /subagents button message becomes "Cancelled.").
             run.synthesized = True
             # This may have been the last running sibling: a done/error run that
             # deferred earlier would otherwise be orphaned (its reply lost), since
@@ -4608,11 +4652,13 @@ class AgentCore:
         except Exception as exc:
             log.exception("Background subagent %s failed", run.run_id)
             if self.subagents.finish(run.run_id, "error", error=str(exc)):
+                await self._notify_background_progress(run)
                 await self._maybe_deliver_subagent_batch(run)
             return
         # finish() returns False if a late cancellation already finalised the run,
         # in which case this completion must not also trigger a reply.
         if self.subagents.finish(run.run_id, "done", result=text):
+            await self._notify_background_progress(run)
             await self._maybe_deliver_subagent_batch(run)
 
     async def _maybe_deliver_subagent_batch(self, run: SubagentRun) -> None:

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -124,6 +124,15 @@ _TRUNCATION_GIVEUP_MESSAGE = (
 )
 
 
+# Fed back as the tool_result for a budget-stopped subagent's pending calls, so
+# its final round writes up what it already found instead of returning nothing.
+_BUDGET_WRAPUP_NOTICE = (
+    "Not executed: you are out of budget and cannot call any more tools. Write your "
+    "final answer NOW from what you already found — the findings so far, plus one "
+    "line on what is still missing."
+)
+
+
 def _truncation_tool_results(response) -> list[dict]:
     """Error tool_results for a truncated response's pending calls (issue #77).
 
@@ -152,6 +161,11 @@ _REPEAT_FAILURE_NOTICE = (
     "kept failing. Stop retrying it — change the arguments, take a different "
     "approach, or report the problem to the user."
 )
+_REPEAT_ERROR_NOTICE = (
+    "This tool has now failed the same way several times in a row — the problem is "
+    "the tool or the service behind it, not your arguments. Stop calling it and "
+    "carry on without it, or tell the user."
+)
 _LOOP_ABORT_MESSAGE = (
     "I had to stop — I made too many tool calls without reaching an answer. "
     "Could you rephrase, or break the request into smaller steps?"
@@ -160,6 +174,17 @@ _LOOP_ABORT_MESSAGE = (
 # A sync spawn's result lands in the very next reply, so a completion note only
 # earns its noise when the run kept the user waiting this long.
 _SUBAGENT_NOTE_MIN_SECONDS = 10.0
+
+# Returned for ANY web-search backend failure. The raw exception was an httpx
+# message carrying the internal endpoint URL and a link to the HTTP status docs,
+# which models read as an invitation to go curl the backend — one subagent spent
+# its whole budget diagnosing a 404 instead of giving up. Say what to do instead,
+# and leak no URL; the real exception is in the log.
+_SEARCH_BACKEND_DOWN = (
+    "The web search backend is unavailable — this is an infrastructure outage, not "
+    "a problem with your query. Do NOT retry, rephrase, or try to diagnose it. "
+    "Continue with what you can do without web results, and say search was down."
+)
 
 
 def _failure_signature(name: str, params: object) -> str:
@@ -809,9 +834,10 @@ TOOLS = [
                     "type": "integer",
                     "description": (
                         "Approximate token ceiling for the whole run, counting the "
-                        "prompt EVERY round — one round typically costs 10-20k "
-                        "tokens, so below ~20000 a run rarely finishes real work. "
-                        "Omit for the configured default; capped at the maximum."
+                        "prompt EVERY round — one round costs 15-35k tokens and each "
+                        "round costs more than the last, so below ~50000 a run cannot "
+                        "finish real work. Usually omit it: the default is sized to let "
+                        "max_steps be what stops the run. Capped at the maximum."
                     ),
                 },
                 "thinking_effort": {
@@ -908,7 +934,8 @@ TOOLS = [
                                 "description": (
                                     "Usually omit it — the shared turn pool already "
                                     "bounds total spend. If set, one round costs "
-                                    "10-20k tokens; below ~20000 a run rarely finishes."
+                                    "15-35k tokens and grows; below ~50000 a run "
+                                    "cannot finish."
                                 ),
                             },
                             "thinking_effort": {
@@ -2641,6 +2668,14 @@ class AgentCore:
         failures = request_state.setdefault("failure_counts", {})
         if failures.get(sig, 0) >= _MAX_REPEAT_FAILURES:
             return {"error": _REPEAT_FAILURE_NOTICE}
+        # Second breaker, on the *error* rather than the arguments: a dead backend
+        # fails every call identically while the arguments keep changing (five
+        # different search queries, five identical 404s), so the signature breaker
+        # above never trips on the outage it most needs to stop.
+        streaks: dict[str, tuple[str, int]] = request_state.setdefault("error_streaks", {})
+        prev_err, prev_n = streaks.get(tool_call.name, ("", 0))
+        if prev_n >= _MAX_REPEAT_FAILURES:
+            return {"error": f"{_REPEAT_ERROR_NOTICE} The error was: {prev_err}"}
         try:
             result = await self._execute_tool_inner(tool_call, channel, user_id, request_state)
         except Exception as exc:
@@ -2657,6 +2692,10 @@ class AgentCore:
         # *identical* call many times — varying the args resets the count.
         if isinstance(result, dict) and result.get("error"):
             failures[sig] = failures.get(sig, 0) + 1
+            err = str(result.get("error"))
+            streaks[tool_call.name] = (err, prev_n + 1 if err == prev_err else 1)
+        else:
+            streaks.pop(tool_call.name, None)  # a success clears the streak
         return result
 
     async def _execute_tool_inner(
@@ -4044,7 +4083,11 @@ class AgentCore:
                 "subtask whether to retry, work around it, or tell the user — do "
                 "not silently drop them."
             )
-        capped = sum(1 for r in results if r.get("stopped_reason") in ("max_steps", "token_budget"))
+        capped = sum(
+            1
+            for r in results
+            if r.get("stopped_reason") in ("max_steps", "token_budget", "turn_budget", "truncated")
+        )
         if capped:
             notes.append(f"{capped} hit a step/token budget — their results may be partial.")
         if notes:
@@ -4355,7 +4398,11 @@ class AgentCore:
             group_id=group_id,
             parent_run_id=str(parent_state.get("run_id") or ""),
             max_steps=resolve_cap(max_steps, cfg.max_steps),
-            token_budget=resolve_cap(token_budget, cfg.token_budget, floor=1000),
+            # floor: one round costs 15-35k, so a sub-50k budget can only fail —
+            # clamp a model's undersized ask up (never above the configured ceiling).
+            token_budget=resolve_cap(
+                token_budget, cfg.token_budget, floor=min(50_000, cfg.token_budget)
+            ),
             effort=normalize_effort(thinking_effort),
             provider=ov_provider,
             model=ov_model,
@@ -4515,7 +4562,13 @@ class AgentCore:
         system = f"{system}\n\n{RESULT_FOR_AGENT_INSTRUCTION}\n\n{FILE_HANDOFF_INSTRUCTION}"
         # Memory/reflections inject per-turn via the preamble (#41), scoped to the
         # child agent (#42); query=task keeps the injection relevant.
-        preamble = await self._turn_preamble(None, query=task, scope=_agent_scope(child_agent))
+        # agent=child_agent, not None: the preamble scopes the skills index and the
+        # account list to the identity it names, and the child's scopes were already
+        # narrowed against the caller's — passing None advertised EVERY skill and the
+        # default agent's accounts to a child that may reach neither.
+        preamble = await self._turn_preamble(
+            None, query=task, scope=_agent_scope(child_agent), agent=child_agent
+        )
         messages: list[dict] = [await self._build_user_message(task, None, preamble)]
 
         # The child runs on its own agent's LLM override when it has one (so a
@@ -4613,6 +4666,34 @@ class AgentCore:
                 pool.charge(spent)
 
         text = response.text or ""
+        if response.tool_calls and not aborted:
+            # Every non-abort stop lands on a response that wanted MORE tool calls,
+            # so its text is empty or a stub — returning that throws away everything
+            # the run gathered (the findings live only in the local `messages`). One
+            # wrap-up round with no tools forces prose, turning a spent budget into a
+            # usable partial answer. Charged like any other round.
+            messages.append(llm.assistant_message(response))
+            messages.extend(
+                llm.tool_result_messages(
+                    [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": call.id,
+                            "content": json.dumps({"error": _BUDGET_WRAPUP_NOTICE}),
+                        }
+                        for call in response.tool_calls
+                    ]
+                )
+            )
+            wrap = await llm.generate(
+                model=model, max_tokens=max_tokens, system=system, messages=messages, tools=[]
+            )
+            spent = self._usage_total(wrap.usage)
+            tokens += spent
+            run.tokens_used = tokens
+            if pool is not None:
+                pool.charge(spent)
+            text = wrap.text or text
         # stopped_reason is a field the calling model can act on (retry, size up,
         # accept partial); the text suffix stays too — belt and braces.
         if aborted:
@@ -4871,9 +4952,9 @@ class AgentCore:
                 query=query,
                 max_results=max_results,
             )
-        except Exception as exc:
+        except Exception:
             log.exception("Tavily search failed for query: %s", query)
-            return {"error": f"Search failed: {exc}"}
+            return {"error": _SEARCH_BACKEND_DOWN}
 
         # Format results for the LLM
         results = []
@@ -4909,9 +4990,9 @@ class AgentCore:
                 )
                 resp.raise_for_status()
                 data = resp.json()
-        except Exception as exc:
+        except Exception:
             log.exception("SearXNG search failed for query: %s", query)
-            return {"error": f"Search failed: {exc}"}
+            return {"error": _SEARCH_BACKEND_DOWN}
 
         results = [
             {
@@ -5096,9 +5177,14 @@ class AgentCore:
                 )
             }
         await self.image_budget.record()
-        # imagegen.save returns a cwd-relative path; resolve it so a subagent's
-        # Files: report actually names a findable file.
-        path = str(Path(imagegen.save(data, mime)).resolve())
+        # Save inside the coding workspace when there is one: the file tools and
+        # bash are confined to that tree, so an image under the process cwd was
+        # unreachable by every tool that could publish it (the model had to go
+        # hunting for it with `ls -t`). Resolve it either way so a subagent's
+        # Files: report names a findable file.
+        ws_img = self._workspace_dir()
+        directory = str(Path(ws_img).expanduser() / "images") if ws_img else "data/images"
+        path = str(Path(imagegen.save(data, mime, directory=directory)).resolve())
         request_state.setdefault("pending_attachments", []).append(
             Attachment(data=data, mime_type=mime, filename=Path(path).name)
         )
@@ -5122,6 +5208,13 @@ class AgentCore:
                 "what you made."
             ),
         }
+        if ws_img and self.config.artifacts.enabled:
+            # The path is only useful while this turn's tool results are live, so
+            # say here — not in a skill — how to get the file onto a web page.
+            result["note"] += (
+                " To put it on a web page, copy it into the artifact first: "
+                f"`cp {path} artifacts/<slug>/`, then reference it relatively."
+            )
         # Issue #55 cost controls: warn the user when nearing a budget cap.
         warning = await self.image_budget.warning(ig.daily_budget, ig.monthly_budget)
         if warning:

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -51,9 +51,11 @@ from core.skills import SkillsEngine
 from core.subagents import (
     FILE_HANDOFF_INSTRUCTION,
     RESULT_FOR_AGENT_INSTRUCTION,
+    FanoutBudget,
     SubagentRegistry,
     SubagentRun,
     allowed_models_hint,
+    derive_label,
     fallback_summary,
     narrow_accounts,
     narrow_scope,
@@ -769,7 +771,9 @@ TOOLS = [
             "or cancel it via /subagents or the admin Jobs page). Use background=false "
             "(default) to block and get the result back in this turn.\n"
             "Subagents are depth-limited, so prefer one focused delegation over "
-            "deep nesting."
+            "deep nesting.\n"
+            "ONE subtask → this tool. TWO OR MORE independent subtasks → "
+            "spawn_subagents (plural), which runs them in parallel."
         ),
         "input_schema": {
             "type": "object",
@@ -838,6 +842,88 @@ TOOLS = [
                 },
             },
             "required": ["task"],
+        },
+    },
+    # Fan-out (plural spawn) — 2+ independent subtasks in parallel.
+    {
+        "name": "spawn_subagents",
+        "description": (
+            "Delegate TWO OR MORE independent subtasks at once — they run in "
+            "PARALLEL and you get every result back in this turn. Use this "
+            "instead of several spawn_subagent calls whenever the subtasks don't "
+            "depend on each other: same wall-clock as the slowest one, not the "
+            "sum.\n"
+            "Only for INDEPENDENT work. If task B needs task A's output, that is "
+            "a pipeline: spawn A, read its result, then spawn B in a later step.\n"
+            "Each subtask is self-contained — a subagent cannot see this "
+            "conversation, so put everything it needs in its own 'task'. Say "
+            "exactly what shape you want back. Give each a short 'label' so runs "
+            "are tellable apart in logs and the admin UI.\n"
+            "Fanning out costs one full agent run per subtask, and all spawns "
+            "this turn share one token/spawn budget pool. Two or three focused "
+            "subtasks beat six vague ones. For quick lookups, just do them "
+            "yourself.\n"
+            "Partial failure is normal: read each result's status and decide "
+            "what to do about the ones that failed — never silently synthesize "
+            "as though you got everything.\n"
+            "Use background=true only for long-running work: you get run ids "
+            "now and one combined result is posted to this chat when all finish."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "tasks": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "task": {
+                                "type": "string",
+                                "description": (
+                                    "Complete, self-contained instruction for this "
+                                    "subagent, including the exact result shape you want."
+                                ),
+                            },
+                            "label": {
+                                "type": "string",
+                                "description": (
+                                    "Short distinctive name for logs/UI, e.g. 'pricing'."
+                                ),
+                            },
+                            "agent": {
+                                "type": "string",
+                                "description": (
+                                    "Agent to run as; omit to run as yourself (default)."
+                                ),
+                            },
+                            "max_steps": {"type": "integer"},
+                            "token_budget": {"type": "integer"},
+                            "thinking_effort": {
+                                "type": "string",
+                                "enum": ["off", "low", "medium", "high"],
+                            },
+                            "model": {
+                                "type": "string",
+                                "description": (
+                                    "Model override; only models named in this tool's "
+                                    "description may be picked."
+                                ),
+                            },
+                            "provider": {"type": "string"},
+                        },
+                        "required": ["task"],
+                    },
+                },
+                "background": {
+                    "type": "boolean",
+                    "description": (
+                        "Default false (block, results return in this turn). True "
+                        "returns run ids now; results post to this chat when done."
+                    ),
+                },
+            },
+            "required": ["tasks"],
         },
     },
     # Secrets vault (issue #19) — discover + request secrets by NAME only.
@@ -1019,7 +1105,7 @@ def apply_feature_gates(
     if not secrets_available:
         out = [t for t in out if t["name"] not in ("list_secrets", "request_secret")]
     if not subagents_enabled:
-        out = [t for t in out if t["name"] != "spawn_subagent"]
+        out = [t for t in out if t["name"] not in ("spawn_subagent", "spawn_subagents")]
     if not imagegen_enabled:
         out = [t for t in out if t["name"] != "generate_image"]
     if not search_enabled:
@@ -1543,7 +1629,7 @@ class AgentCore:
         # Record every generate() this turn under this context so the admin
         # Inspect tab can show the exact last-sent payload (#99). Reset in finally
         # so a context never leaks onto an unrelated later turn on the same task.
-        cap_token = set_capture_context((channel, user_id, chat_id))
+        cap_token = set_capture_context((channel, user_id, chat_id, ""))
         # Attribute this turn's token usage to the serving agent (#199 flw).
         agent_token = set_usage_agent(agent.name if agent else "")
         try:
@@ -1699,13 +1785,21 @@ class AgentCore:
         # scope withholds web_search (#293); the handler refuses too.
         if agent and agent.tools and not agent.allows_tool("web_search"):
             tools = [t for t in tools if t["name"] != "deep_research"]
+        # Legacy allowlists predate the plural tool: an agent scoped to
+        # ["spawn_subagent"] may fan out too — gate the plural on the singular
+        # here rather than special-casing allows_tool (a hot path).
+        names = {t["name"] for t in tools}
+        if "spawn_subagent" in names and "spawn_subagents" not in names:
+            plural = next((t for t in TOOLS if t["name"] == "spawn_subagents"), None)
+            if plural:
+                tools = [*tools, plural]
         # Name the models a spawn may pick (#299), else the agent can't know them.
         # Copy the schema — the module-level list is shared across turns.
         hint = allowed_models_hint(self.config.subagents.allowed_models)
         if hint:
             tools = [
                 {**t, "description": f"{t['description']}\nSubagent models — {hint}."}
-                if t["name"] == "spawn_subagent"
+                if t["name"] in ("spawn_subagent", "spawn_subagents")
                 else t
                 for t in tools
             ]
@@ -1903,7 +1997,8 @@ class AgentCore:
             return ""
         lines = []
         for r in runs:
-            who = f"- [{r.run_id}] {r.agent or 'default'} — running ({r.elapsed_str})"
+            name = r.label or r.agent or "default"
+            who = f"- [{r.run_id}] {name} — running ({r.elapsed_str})"
             lines.append(f"{who}; {r.progress}" if r.progress else who)
         body = "\n".join(lines)
         return (
@@ -2579,7 +2674,7 @@ class AgentCore:
         # in a turn is legitimate (it is a write action only so it always asks).
         if (
             is_write_action
-            and name not in ("manage_jobs", "spawn_subagent")
+            and name not in ("manage_jobs", "spawn_subagent", "spawn_subagents")
             and not unlisted_bash
             and write_sig in executed_writes
         ):
@@ -2816,6 +2911,12 @@ class AgentCore:
 
         if name == "spawn_subagent":
             result = await self._tool_spawn_subagent(params, channel, user_id, request_state)
+            if is_write_action and self._is_tool_success(result):
+                executed_writes.add(write_sig)
+            return result
+
+        if name == "spawn_subagents":
+            result = await self._tool_spawn_subagents(params, channel, user_id, request_state)
             if is_write_action and self._is_tool_success(result):
                 executed_writes.add(write_sig)
             return result
@@ -3703,6 +3804,259 @@ class AgentCore:
             provider=str(params.get("provider", "")),
         )
 
+    async def _tool_spawn_subagents(
+        self, params: dict, channel: str, user_id: str, request_state: dict
+    ) -> dict:
+        """``spawn_subagents``: fan out 2+ independent subtasks in parallel.
+
+        One call, gathered internally — provider-independent (works even when
+        the model emits one tool call per round), one place to enforce width /
+        concurrency / budget, and one aggregate result with explicit per-index
+        status the model can reason over. Wall-clock ≈ the slowest subtask.
+        """
+        cfg = self.config.subagents
+        if not cfg.enabled:
+            return {"error": "Subagents are disabled."}
+        tasks = params.get("tasks")
+        if not isinstance(tasks, list) or not tasks:
+            return {"error": "Provide 'tasks': a list of subtask objects, each with 'task'."}
+        # Belt and braces with the tool strip in the subagent loop: fan-out is
+        # top-level only — nested fan-out is where the multiplication lives.
+        if int(request_state.get("depth", 0) or 0) >= 1:
+            return {
+                "error": (
+                    "Nested fan-out is not allowed — use spawn_subagent for a "
+                    "single delegation instead."
+                )
+            }
+        if len(tasks) > cfg.max_fanout:
+            return {
+                "error": (
+                    f"Too many subtasks ({len(tasks)}): max_fanout is "
+                    f"{cfg.max_fanout}. Merge related subtasks or drop the least "
+                    "important ones."
+                )
+            }
+        background = bool(params.get("background", False))
+        if len(tasks) == 1:
+            one = tasks[0] if isinstance(tasks[0], dict) else {}
+            return await self._tool_spawn_subagent(
+                {**one, "background": background}, channel, user_id, request_state
+            )
+
+        origin = request_state.get("origin") or {}
+        o_channel = str(origin.get("channel", channel))
+        o_user = str(origin.get("user_id", user_id))
+        o_chat = str(origin.get("chat_id", ""))
+        budget = self._turn_budget(request_state)
+        group_id = f"grp_{uuid.uuid4().hex[:6]}"
+        started_at = time.time()
+
+        # Prepare + reserve per index; a refusal becomes that index's error
+        # entry, never an all-or-nothing failure.
+        entries: list[dict] = []
+        for i, item in enumerate(tasks):
+            item = item if isinstance(item, dict) else {}
+            label = derive_label(str(item.get("label", "")), str(item.get("task", "")), i)
+            task_text = str(item.get("task", "")).strip()
+            if not task_text:
+                entries.append(
+                    {"index": i, "label": label, "error": "Missing 'task' for this subtask."}
+                )
+                continue
+            prepared = await self._prepare_subagent_run(
+                task=task_text,
+                agent_name=str(item.get("agent", "")).strip(),
+                origin_channel=o_channel,
+                origin_user_id=o_user,
+                origin_chat_id=o_chat,
+                parent_state=request_state,
+                background=background,
+                max_steps=item.get("max_steps"),
+                token_budget=item.get("token_budget"),
+                thinking_effort=item.get("thinking_effort"),
+                model=str(item.get("model", "")),
+                provider=str(item.get("provider", "")),
+                label=label,
+                group_id=group_id,
+            )
+            if isinstance(prepared, dict):
+                entries.append(
+                    {"index": i, "label": label, "error": prepared.get("error", "spawn refused")}
+                )
+                continue
+            run, child_agent, child_state = prepared
+            err = budget.reserve(run.token_budget)
+            if err:
+                entries.append({"index": i, "label": label, "error": err})
+                continue
+            self._start_subagent(run)
+            entries.append(
+                {
+                    "index": i,
+                    "label": label,
+                    "run": run,
+                    "agent_obj": child_agent,
+                    "state": child_state,
+                }
+            )
+
+        live = [e for e in entries if "run" in e]
+        if not live:
+            return {
+                "ok": False,
+                "group_id": group_id,
+                "count": len(entries),
+                "succeeded": 0,
+                "failed": len(entries),
+                "results": [self._fanout_result_entry(e) for e in entries],
+                "note": "No subtask could be started — read each result's error.",
+            }
+
+        # One progress note so a several-minute silent fan-out doesn't look
+        # hung, and so the steering semantics are visible: messages sent
+        # meanwhile are read after the fan-out returns (👀 still means "seen").
+        labels = ", ".join(e["run"].label for e in live)
+        await self._notify_origin_chat(
+            o_channel,
+            o_chat,
+            f"🧩 Delegating {len(live)} subtasks in parallel: {labels}. "
+            "I'll read any new messages here once they're done.",
+        )
+
+        if background:
+            # Unlike a singular background spawn, a background fan-out never
+            # refuses at the chat cap — refusing half a requested group is a
+            # worse answer than letting the excess queue on the per-chat slots.
+            for e in live:
+                run = e["run"]
+                bg = asyncio.create_task(
+                    self._run_subagent_background(run, e["agent_obj"], e["state"]),
+                    name=f"subagent-{run.run_id}",
+                )
+                self.subagents.attach_task(run.run_id, bg)
+            return {
+                "ok": True,
+                "group_id": group_id,
+                "background": True,
+                "count": len(entries),
+                "started": len(live),
+                "runs": [
+                    {"index": e["index"], "run_id": e["run"].run_id, "label": e["run"].label}
+                    for e in live
+                ],
+                "results": [self._fanout_result_entry(e) for e in entries if "run" not in e],
+                "note": (
+                    "Running in the background; one combined result is posted to "
+                    "this chat when the whole group finishes — you don't relay it."
+                ),
+            }
+
+        # Synchronous: drive every child concurrently (per-chat max_concurrent
+        # queues the excess), racing the whole group against the turn's abort
+        # Event so /stop cancels the fan-out instead of letting it run out.
+        async def drive(e: dict) -> None:
+            run = e["run"]
+            try:
+                text = await self._run_subagent_loop(run.task, e["agent_obj"], e["state"], run)
+            except asyncio.CancelledError:
+                self.subagents.finish(run.run_id, "cancelled")
+                raise
+            except Exception as exc:
+                log.exception("Subagent %s failed", run.run_id)
+                self.subagents.finish(run.run_id, "error", error=str(exc))
+                return
+            self.subagents.finish(run.run_id, "done", result=text)
+
+        child_tasks: dict[str, asyncio.Task] = {}
+        for e in live:
+            t = asyncio.create_task(drive(e), name=f"subagent-{e['run'].run_id}")
+            child_tasks[e["run"].run_id] = t
+            self.subagents.attach_task(e["run"].run_id, t)
+        log.info("Fan-out %s: %d subtasks (%s)", group_id, len(live), labels)
+
+        abort = self._active_turns_map().get((o_channel, o_user, o_chat))
+        abort_waiter = asyncio.create_task(abort.wait()) if abort else None
+        try:
+            children = set(child_tasks.values())
+            pending = children | ({abort_waiter} if abort_waiter else set())
+            while pending & children:
+                done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+                if abort_waiter and abort_waiter in done:
+                    for rid, t in child_tasks.items():
+                        if not t.done():
+                            self.subagents.cancel(rid)  # cascades to grandchildren
+                    await asyncio.gather(*children, return_exceptions=True)
+                    break
+        finally:
+            if abort_waiter and not abort_waiter.done():
+                abort_waiter.cancel()
+
+        results = [self._fanout_result_entry(e) for e in entries]
+        succeeded = sum(1 for r in results if r.get("status") == "done")
+        failed = len(results) - succeeded
+        out = {
+            "ok": failed == 0,
+            "group_id": group_id,
+            "count": len(results),
+            "succeeded": succeeded,
+            "failed": failed,
+            "tokens_used": sum(r.get("tokens_used", 0) or 0 for r in results),
+            "elapsed_s": round(time.time() - started_at, 1),
+            "results": results,
+        }
+        notes = []
+        if failed:
+            notes.append(
+                f"{failed} of {len(results)} subtasks did not complete. Decide per "
+                "subtask whether to retry, work around it, or tell the user — do "
+                "not silently drop them."
+            )
+        capped = sum(1 for r in results if r.get("stopped_reason") in ("max_steps", "token_budget"))
+        if capped:
+            notes.append(f"{capped} hit a step/token budget — their results may be partial.")
+        if notes:
+            out["note"] = " ".join(notes)
+        return out
+
+    @staticmethod
+    def _fanout_result_entry(e: dict) -> dict:
+        """One per-index result row (request order) for the fan-out tool result."""
+        run: SubagentRun | None = e.get("run")
+        if run is None:
+            return {
+                "index": e["index"],
+                "label": e.get("label", ""),
+                "status": "error",
+                "error": e.get("error", ""),
+            }
+        out = {
+            "index": e["index"],
+            "label": run.label,
+            "run_id": run.run_id,
+            "agent": run.agent,
+            "status": run.status,
+            "steps": run.steps,
+            "tokens_used": run.tokens_used,
+            "stopped_reason": run.stopped_reason,
+        }
+        if run.status == "done":
+            out["summary"] = short_summary(run.result)
+            out["result"] = run.result
+        elif run.error:
+            out["error"] = run.error
+        return out
+
+    async def _notify_origin_chat(self, channel: str, chat_id: str, text: str) -> None:
+        """Best-effort one-line progress note to the originating chat."""
+        ch = self.channels.get(channel)
+        if not (ch and chat_id):
+            return
+        try:
+            await ch.send(chat_id, text)
+        except Exception:
+            log.exception("Failed to send progress note (chat=%s)", chat_id)
+
     async def run_subagent(
         self,
         *,
@@ -3733,9 +4087,117 @@ class AgentCore:
         ``subagents.allowed_models`` allowlist or the spawn is refused.
         """
         cfg = self.config.subagents
+        parent_state = parent_state or {}
+        prepared = await self._prepare_subagent_run(
+            task=task,
+            agent_name=agent_name,
+            origin_channel=origin_channel,
+            origin_user_id=origin_user_id,
+            origin_chat_id=origin_chat_id,
+            parent_state=parent_state,
+            background=background,
+            max_steps=max_steps,
+            token_budget=token_budget,
+            thinking_effort=thinking_effort,
+            model=model,
+            provider=provider,
+        )
+        if isinstance(prepared, dict):
+            return prepared
+        run, child_agent, child_state = prepared
+        run_id = run.run_id
+        budget: FanoutBudget = child_state["fanout_budget"]
+
+        if background:
+            # Background must return a run id immediately, so it refuses at the
+            # chat's cap instead of queueing like a sync spawn does. Best-effort:
+            # slots are counted at loop entry, so same-tick spawns can slip past
+            # the check — they then queue on the slot, never over-run the cap.
+            chat_key = self._subagent_chat_key(origin_channel, origin_chat_id)
+            if self.subagents.slots_in_use(chat_key) >= cfg.max_concurrent:
+                return {
+                    "error": (
+                        f"Too many subagents running in this chat (max "
+                        f"{cfg.max_concurrent}). Wait for one to finish or cancel "
+                        "it via /subagents."
+                    )
+                }
+            err = budget.reserve(run.token_budget)
+            if err:
+                return {"error": err}
+            self._start_subagent(run)
+            bg = asyncio.create_task(
+                self._run_subagent_background(run, child_agent, child_state),
+                name=f"subagent-{run_id}",
+            )
+            self.subagents.attach_task(run_id, bg)
+            log.info("Spawned background subagent %s (agent=%s)", run_id, run.agent or "default")
+            return {
+                "ok": True,
+                "run_id": run_id,
+                "background": True,
+                "status": "running",
+                "agent": run.agent,
+                "note": (
+                    "Running in the background; its result is posted to this chat "
+                    "automatically when done — you don't relay it. Each later turn "
+                    "shows this run's status until it finishes."
+                ),
+            }
+
+        # Synchronous: run to completion and return the result to the caller.
+        err = budget.reserve(run.token_budget)
+        if err:
+            return {"error": err}
+        self._start_subagent(run)
+        log.info("Running subagent %s (agent=%s)", run_id, run.agent or "default")
+        try:
+            text = await self._run_subagent_loop(task, child_agent, child_state, run)
+        except Exception as exc:
+            log.exception("Subagent %s failed", run_id)
+            self.subagents.finish(run_id, "error", error=str(exc))
+            return {"error": f"Subagent failed: {exc}", "run_id": run_id}
+        self.subagents.finish(run_id, "done", result=text)
+        return {
+            "ok": True,
+            "run_id": run_id,
+            "agent": run.agent,
+            "steps": run.steps,
+            "tokens_used": run.tokens_used,
+            "stopped_reason": run.stopped_reason,
+            "summary": short_summary(text),
+            "result": text,
+        }
+
+    async def _prepare_subagent_run(
+        self,
+        *,
+        task: str,
+        agent_name: str = "",
+        origin_channel: str = "",
+        origin_user_id: str = "",
+        origin_chat_id: str = "",
+        parent_state: dict,
+        background: bool = False,
+        max_steps: object = None,
+        token_budget: object = None,
+        thinking_effort: str | None = None,
+        model: str = "",
+        provider: str = "",
+        label: str = "",
+        group_id: str = "",
+    ) -> dict | tuple[SubagentRun, Agent | None, dict]:
+        """Validate a spawn and build its ``(run, child_agent, child_state)``.
+
+        The one preparation path behind the singular tool, the plural fan-out,
+        and scheduled jobs. Returns an ``{"error": ...}`` dict (for the calling
+        model to read) on any refusal; never raises. Does NOT register the run
+        or reserve budget — the caller does, so a fan-out can report per-index
+        refusals and refuse-vs-queue stays a caller decision.
+        """
+        cfg = self.config.subagents
         if not cfg.enabled:
             return {"error": "Subagents are disabled."}
-        parent_state = parent_state or {}
         parent_depth = int(parent_state.get("depth", 0) or 0)
         if parent_depth >= cfg.recursion_depth:
             return {
@@ -3785,12 +4247,18 @@ class AgentCore:
             },
             run_id=run_id,
         )
+        # The whole subagent tree of one turn draws from a single budget pool —
+        # shared by reference parent → child, so a grandchild's spend counts too.
+        child_state["fanout_budget"] = self._turn_budget(parent_state)
         run = SubagentRun(
             run_id=run_id,
             agent=child_agent.name if child_agent else "",
             task=task,
             depth=parent_depth + 1,
             background=background,
+            label=derive_label(label, task),
+            group_id=group_id,
+            parent_run_id=str(parent_state.get("run_id") or ""),
             max_steps=resolve_cap(max_steps, cfg.max_steps),
             token_budget=resolve_cap(token_budget, cfg.token_budget, floor=1000),
             effort=normalize_effort(thinking_effort),
@@ -3800,52 +4268,29 @@ class AgentCore:
             origin_user_id=origin_user_id,
             origin_chat_id=origin_chat_id,
         )
+        return run, child_agent, child_state
 
-        if background:
-            if self.subagents.active_count() >= cfg.max_concurrent:
-                return {
-                    "error": (
-                        f"Too many subagents running (max {cfg.max_concurrent}). "
-                        "Wait for one to finish or cancel it via /subagents."
-                    )
-                }
-            self.subagents.register(run)
-            bg = asyncio.create_task(
-                self._run_subagent_background(run, child_agent, child_state),
-                name=f"subagent-{run_id}",
+    def _turn_budget(self, parent_state: dict) -> FanoutBudget:
+        """The turn's shared subagent spend pool, created lazily on first spawn."""
+        budget = parent_state.get("fanout_budget")
+        if budget is None:
+            cfg = self.config.subagents
+            budget = parent_state["fanout_budget"] = FanoutBudget(
+                tokens_left=cfg.turn_token_budget, spawns_left=cfg.max_spawns_per_turn
             )
-            self.subagents.attach_task(run_id, bg)
-            log.info("Spawned background subagent %s (agent=%s)", run_id, run.agent or "default")
-            return {
-                "ok": True,
-                "run_id": run_id,
-                "background": True,
-                "status": "running",
-                "agent": run.agent,
-                "note": (
-                    "Running in the background; its result is posted to this chat "
-                    "automatically when done — you don't relay it. Each later turn "
-                    "shows this run's status until it finishes."
-                ),
-            }
+        return budget
 
-        # Synchronous: run to completion and return the result to the caller.
+    def _start_subagent(self, run: SubagentRun) -> None:
+        """Register a prepared run and link it into its parent's run tree."""
         self.subagents.register(run)
-        log.info("Running subagent %s (agent=%s)", run_id, run.agent or "default")
-        try:
-            text = await self._run_subagent_loop(task, child_agent, child_state, run)
-        except Exception as exc:
-            log.exception("Subagent %s failed", run_id)
-            self.subagents.finish(run_id, "error", error=str(exc))
-            return {"error": f"Subagent failed: {exc}", "run_id": run_id}
-        self.subagents.finish(run_id, "done", result=text)
-        return {
-            "ok": True,
-            "run_id": run_id,
-            "agent": run.agent,
-            "summary": short_summary(text),
-            "result": text,
-        }
+        parent_run = self.subagents.get(run.parent_run_id) if run.parent_run_id else None
+        if parent_run and run.run_id not in parent_run.children:
+            parent_run.children.append(run.run_id)
+
+    @staticmethod
+    def _subagent_chat_key(channel: str, chat_id: str) -> str:
+        """Key for the per-chat concurrency pool (same shape as _yolo_scope)."""
+        return f"{channel}\x1f{chat_id}"
 
     def _narrow_agent(self, requested: Agent, parent_state: dict) -> Agent:
         """Build a child agent whose scopes are a subset of the caller's."""
@@ -3889,14 +4334,17 @@ class AgentCore:
     ) -> str:
         """Route this subagent's log records into its spawner's stream (#75).
 
-        The label (agent slug, else run id) prefixes each line as
-        ``[subagent:<label>]`` so it filters out of the shared stream; ``fallback``
-        names the stream for a top-level scheduled run that inherited none.
+        The label (run label or agent slug, made unique with a run-id suffix so
+        N fan-out siblings stay tellable apart) prefixes each line as
+        ``[subagent:<label>]``; ``fallback`` names the stream for a top-level
+        scheduled run that inherited none.
         """
-        # Suppress Inspect capture (#99): a subagent runs inside the spawner's
-        # contextvar but is a different conversation — don't clobber the parent's
-        # last-sent payload with the child's.
-        cap_token = set_capture_context(None)
+        # Inspect capture (#99): a subagent is captured under its own run id —
+        # the 4-tuple key means it can't clobber the parent's last-sent payload,
+        # and a fan-out's children each stay individually inspectable.
+        cap_token = set_capture_context(
+            (run.origin_channel, run.origin_user_id, run.origin_chat_id, run.run_id)
+        )
         # Attribute the subagent's token usage to the child agent (#199 flw) so its
         # (often heavy) generate() calls don't land in the parent's bucket or, for a
         # scheduled/background spawn that ran outside any turn, in "(unknown)". Only
@@ -3904,9 +4352,30 @@ class AgentCore:
         # yourself", so it should keep the spawner's inherited attribution.
         child_name = run.agent or (child_agent.name if child_agent else "")
         usage_token = set_usage_agent(child_name) if child_name else None
+        base_label = run.label or run.agent
+        stream_label = f"{base_label}#{run.run_id[4:8]}" if base_label else run.run_id
         try:
-            with subagent_stream(run.agent or run.run_id, fallback=run.agent):
-                return await self._run_subagent_loop_inner(task, child_agent, child_state, run)
+            with subagent_stream(stream_label, fallback=run.agent):
+                # Per-chat concurrency gate: only a top-level (depth-1) run holds
+                # a slot — a nested child runs under its parent's slot, else a
+                # parent blocked awaiting its own child could deadlock the pool.
+                if run.depth <= 1:
+                    async with self.subagents.slot(
+                        self._subagent_chat_key(run.origin_channel, run.origin_chat_id),
+                        lambda: self.config.subagents.max_concurrent,
+                    ):
+                        text = await self._run_subagent_loop_inner(
+                            task, child_agent, child_state, run
+                        )
+                else:
+                    text = await self._run_subagent_loop_inner(task, child_agent, child_state, run)
+            # Reserve-then-refund (FanoutBudget): a run that finished cleanly
+            # hands its unspent reservation back to the turn's pool. A crashed
+            # or cancelled run deliberately doesn't refund — fails safe.
+            budget = child_state.get("fanout_budget")
+            if budget is not None:
+                budget.refund(run.token_budget - run.tokens_used)
+            return text
         finally:
             if usage_token is not None:
                 reset_usage_agent(usage_token)
@@ -3928,6 +4397,10 @@ class AgentCore:
         # At the depth ceiling a subagent may not spawn further — don't even offer it.
         if child_state["depth"] >= cfg.recursion_depth:
             tools = [t for t in tools if t["name"] != "spawn_subagent"]
+        # Fan-out is top-level only: nested fan-out is where the multiplication
+        # lives. A child may still spawn serially below the ceiling (the shared
+        # FanoutBudget bounds its spend either way).
+        tools = [t for t in tools if t["name"] != "spawn_subagents"]
         # Subagents have no native-media delivery path (#55): a subagent returns
         # only text, so a generated image would be billed + saved + silently
         # dropped. Don't offer the tool at all.
@@ -3955,6 +4428,17 @@ class AgentCore:
             clone = copy.copy(llm)
             clone.thinking_level = run.effort
             llm = clone
+        # /stop must reach a running child (same origin-Event resolution as
+        # deep_research): polled between steps, so even a singular sync spawn is
+        # stoppable mid-run instead of running its full budget after /stop.
+        origin = child_state.get("origin") or {}
+        abort = self._active_turns_map().get(
+            (
+                str(origin.get("channel", "")),
+                str(origin.get("user_id", "")),
+                str(origin.get("chat_id", "")),
+            )
+        )
         response = await llm.generate(
             model=model,
             max_tokens=max_tokens,
@@ -3964,8 +4448,14 @@ class AgentCore:
         )
         steps = 0
         tokens = self._usage_total(response.usage)
+        run.tokens_used = tokens
+        aborted = False
         while response.tool_calls and steps < run.max_steps and tokens < run.token_budget:
+            if abort and abort.is_set():
+                aborted = True
+                break
             steps += 1
+            run.steps = steps
             run.progress = f"step {steps}: {', '.join(c.name for c in response.tool_calls)}"[:120]
             # A truncated round (issue #77) has half-built call args; skip
             # execution and feed back the notice. steps caps the retries here.
@@ -3994,10 +4484,21 @@ class AgentCore:
                 tools=cast(Any, tools),
             )
             tokens += self._usage_total(response.usage)
+            run.tokens_used = tokens
 
         text = response.text or ""
-        if response.tool_calls:
+        # stopped_reason is a field the calling model can act on (retry, size up,
+        # accept partial); the text suffix stays too — belt and braces.
+        if aborted:
+            run.stopped_reason = "aborted"
+            text = (text + "\n\n[subagent stopped: the user stopped this turn]").strip()
+        elif response.tool_calls:
+            run.stopped_reason = "max_steps" if steps >= run.max_steps else "token_budget"
             text = (text + "\n\n[subagent stopped: reached its step/token budget]").strip()
+        elif response.truncated:
+            run.stopped_reason = "truncated"
+        else:
+            run.stopped_reason = "complete"
         run.progress = "done"
         return text
 

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -902,9 +902,9 @@ TOOLS = [
                             "token_budget": {
                                 "type": "integer",
                                 "description": (
-                                    "Omit it: unsized tasks share the turn's pool "
-                                    "fairly. If set, one round costs 10-20k tokens — "
-                                    "below ~20000 a run rarely finishes."
+                                    "Usually omit it — the shared turn pool already "
+                                    "bounds total spend. If set, one round costs "
+                                    "10-20k tokens; below ~20000 a run rarely finishes."
                                 ),
                             },
                             "thinking_effort": {
@@ -3875,16 +3875,8 @@ class AgentCore:
         group_id = f"grp_{uuid.uuid4().hex[:6]}"
         started_at = time.time()
 
-        # An unsized fan-out task must not reserve the full per-run ceiling —
-        # width × ceiling rarely fits the pool (it never does when the owner
-        # raised token_budget near turn_token_budget), and reserve-then-refund
-        # would refuse most of the group. Split what's left across the width
-        # instead, still capped at the per-run ceiling; an explicit
-        # token_budget is honoured (or refused) as requested.
-        default_tb = min(cfg.token_budget, max(10_000, budget.tokens_left // len(tasks)))
-
-        # Prepare + reserve per index; a refusal becomes that index's error
-        # entry, never an all-or-nothing failure.
+        # Prepare + claim a spawn per index; a refusal becomes that index's
+        # error entry, never an all-or-nothing failure.
         entries: list[dict] = []
         for i, item in enumerate(tasks):
             item = item if isinstance(item, dict) else {}
@@ -3904,7 +3896,7 @@ class AgentCore:
                 parent_state=request_state,
                 background=background,
                 max_steps=item.get("max_steps"),
-                token_budget=item.get("token_budget") or default_tb,
+                token_budget=item.get("token_budget"),
                 thinking_effort=item.get("thinking_effort"),
                 model=str(item.get("model", "")),
                 provider=str(item.get("provider", "")),
@@ -3917,7 +3909,7 @@ class AgentCore:
                 )
                 continue
             run, child_agent, child_state = prepared
-            err = budget.reserve(run.token_budget)
+            err = budget.take_spawn()
             if err:
                 entries.append({"index": i, "label": label, "error": err})
                 continue
@@ -4153,7 +4145,7 @@ class AgentCore:
                         "it via /subagents."
                     )
                 }
-            err = budget.reserve(run.token_budget)
+            err = budget.take_spawn()
             if err:
                 return {"error": err}
             self._start_subagent(run)
@@ -4177,7 +4169,7 @@ class AgentCore:
             }
 
         # Synchronous: run to completion and return the result to the caller.
-        err = budget.reserve(run.token_budget)
+        err = budget.take_spawn()
         if err:
             return {"error": err}
         self._start_subagent(run)
@@ -4223,8 +4215,8 @@ class AgentCore:
         The one preparation path behind the singular tool, the plural fan-out,
         and scheduled jobs. Returns an ``{"error": ...}`` dict (for the calling
         model to read) on any refusal; never raises. Does NOT register the run
-        or reserve budget — the caller does, so a fan-out can report per-index
-        refusals and refuse-vs-queue stays a caller decision.
+        or claim a spawn from the pool — the caller does, so a fan-out can
+        report per-index refusals and refuse-vs-queue stays a caller decision.
         """
         cfg = self.config.subagents
         if not cfg.enabled:
@@ -4301,6 +4293,16 @@ class AgentCore:
         # The whole subagent tree of one turn draws from a single budget pool —
         # shared by reference parent → child, so a grandchild's spend counts too.
         child_state["fanout_budget"] = self._turn_budget(parent_state)
+        # A sync child's generated media must reach the user: share the parent
+        # turn's pending_attachments by reference, so anything the child queues
+        # (e.g. generate_image) rides out on the parent's reply natively. A
+        # background run has no live turn to deliver through — it hands files
+        # back via the Files: path convention instead.
+        parent_attachments = parent_state.get("pending_attachments")
+        reaches_user = parent_depth == 0 or bool(parent_state.get("attachments_reach_user"))
+        if not background and parent_attachments is not None and reaches_user:
+            child_state["pending_attachments"] = parent_attachments
+            child_state["attachments_reach_user"] = True
         run = SubagentRun(
             run_id=run_id,
             agent=child_agent.name if child_agent else "",
@@ -4322,19 +4324,12 @@ class AgentCore:
         return run, child_agent, child_state
 
     def _turn_budget(self, parent_state: dict) -> FanoutBudget:
-        """The turn's shared subagent spend pool, created lazily on first spawn.
-
-        The pool is never smaller than one default-sized run: an owner who
-        raised ``token_budget`` past ``turn_token_budget`` (the per-run knob
-        predates the pool) would otherwise find every unsized spawn refused
-        out of the box.
-        """
+        """The turn's shared subagent spend pool, created lazily on first spawn."""
         budget = parent_state.get("fanout_budget")
         if budget is None:
             cfg = self.config.subagents
             budget = parent_state["fanout_budget"] = FanoutBudget(
-                tokens_left=max(cfg.turn_token_budget, cfg.token_budget),
-                spawns_left=cfg.max_spawns_per_turn,
+                tokens_left=cfg.turn_token_budget, spawns_left=cfg.max_spawns_per_turn
             )
         return budget
 
@@ -4433,12 +4428,6 @@ class AgentCore:
                         )
                 else:
                     text = await self._run_subagent_loop_inner(task, child_agent, child_state, run)
-            # Reserve-then-refund (FanoutBudget): a run that finished cleanly
-            # hands its unspent reservation back to the turn's pool. A crashed
-            # or cancelled run deliberately doesn't refund — fails safe.
-            budget = child_state.get("fanout_budget")
-            if budget is not None:
-                budget.refund(run.token_budget - run.tokens_used)
             return text
         finally:
             if usage_token is not None:
@@ -4509,6 +4498,13 @@ class AgentCore:
         steps = 0
         tokens = self._usage_total(response.usage)
         run.tokens_used = tokens
+        # The turn's shared pool is charged as spend happens, one round at a
+        # time — no reservations, so a spawn always starts and stops gracefully
+        # between rounds once the pool drains (bounded overshoot: ≤1 round per
+        # concurrent child).
+        pool: FanoutBudget | None = child_state.get("fanout_budget")
+        if pool is not None:
+            pool.charge(tokens)
         aborted = False
         # ``steps == 0 or``: the first tool round always runs. The opening
         # generate alone can cost more than a small budget (system prompt +
@@ -4517,7 +4513,10 @@ class AgentCore:
         while (
             response.tool_calls
             and steps < run.max_steps
-            and (steps == 0 or tokens < run.token_budget)
+            and (
+                steps == 0
+                or (tokens < run.token_budget and not (pool is not None and pool.exhausted))
+            )
         ):
             if abort and abort.is_set():
                 aborted = True
@@ -4551,8 +4550,11 @@ class AgentCore:
                 messages=messages,
                 tools=cast(Any, tools),
             )
-            tokens += self._usage_total(response.usage)
+            spent = self._usage_total(response.usage)
+            tokens += spent
             run.tokens_used = tokens
+            if pool is not None:
+                pool.charge(spent)
 
         text = response.text or ""
         # stopped_reason is a field the calling model can act on (retry, size up,
@@ -4561,8 +4563,20 @@ class AgentCore:
             run.stopped_reason = "aborted"
             text = (text + "\n\n[subagent stopped: the user stopped this turn]").strip()
         elif response.tool_calls:
-            run.stopped_reason = "max_steps" if steps >= run.max_steps else "token_budget"
-            text = (text + "\n\n[subagent stopped: reached its step/token budget]").strip()
+            if steps >= run.max_steps:
+                run.stopped_reason = "max_steps"
+            elif pool is not None and pool.exhausted:
+                # Wins the tie with the run's own cap: a drained pool means
+                # retrying or sizing up won't help — stop delegating.
+                run.stopped_reason = "turn_budget"
+            else:
+                run.stopped_reason = "token_budget"
+            suffix = (
+                "[subagent stopped: the turn's subagent token budget is exhausted]"
+                if run.stopped_reason == "turn_budget"
+                else "[subagent stopped: reached its step/token budget]"
+            )
+            text = (text + f"\n\n{suffix}").strip()
         elif response.truncated:
             run.stopped_reason = "truncated"
         else:
@@ -5022,23 +5036,27 @@ class AgentCore:
                 )
             }
         await self.image_budget.record()
-        path = imagegen.save(data, mime)
+        # imagegen.save returns a cwd-relative path; resolve it so a subagent's
+        # Files: report actually names a findable file.
+        path = str(Path(imagegen.save(data, mime)).resolve())
         request_state.setdefault("pending_attachments", []).append(
             Attachment(data=data, mime_type=mime, filename=Path(path).name)
         )
         log.info("Generated image (%d bytes, %s) → %s", len(data), mime, path)
-        # A subagent has no native-media delivery path of its own (#55): its
-        # pending_attachments die with the run. The file is on the shared
-        # filesystem, so the path IS the delivery — report it via the Files:
-        # handoff and let the spawning agent send it.
-        in_subagent = int(request_state.get("depth", 0) or 0) > 0
+        # A sync subagent shares the spawning turn's pending_attachments, so its
+        # image is queued for native delivery like the main turn's. A background
+        # run has no live turn to deliver through — there the saved file's path
+        # IS the delivery, reported via the Files: handoff.
+        orphaned = int(request_state.get("depth", 0) or 0) > 0 and not request_state.get(
+            "attachments_reach_user"
+        )
         result = {
             "ok": True,
             "path": path,
             "note": (
                 "Image generated and saved. Report this absolute path in your "
                 "'Files:' line so the agent that spawned you can deliver it."
-                if in_subagent
+                if orphaned
                 else "Image generated and queued for delivery to the user as a photo. "
                 "Do not include the path or base64 in your reply — just say briefly "
                 "what you made."

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -804,7 +804,9 @@ TOOLS = [
                 "token_budget": {
                     "type": "integer",
                     "description": (
-                        "Approximate token ceiling for the whole run (minimum 1000). "
+                        "Approximate token ceiling for the whole run, counting the "
+                        "prompt EVERY round — one round typically costs 10-20k "
+                        "tokens, so below ~20000 a run rarely finishes real work. "
                         "Omit for the configured default; capped at the maximum."
                     ),
                 },
@@ -897,7 +899,14 @@ TOOLS = [
                                 ),
                             },
                             "max_steps": {"type": "integer"},
-                            "token_budget": {"type": "integer"},
+                            "token_budget": {
+                                "type": "integer",
+                                "description": (
+                                    "Omit it: unsized tasks share the turn's pool "
+                                    "fairly. If set, one round costs 10-20k tokens — "
+                                    "below ~20000 a run rarely finishes."
+                                ),
+                            },
                             "thinking_effort": {
                                 "type": "string",
                                 "enum": ["off", "low", "medium", "high"],
@@ -3866,6 +3875,14 @@ class AgentCore:
         group_id = f"grp_{uuid.uuid4().hex[:6]}"
         started_at = time.time()
 
+        # An unsized fan-out task must not reserve the full per-run ceiling —
+        # width × ceiling rarely fits the pool (it never does when the owner
+        # raised token_budget near turn_token_budget), and reserve-then-refund
+        # would refuse most of the group. Split what's left across the width
+        # instead, still capped at the per-run ceiling; an explicit
+        # token_budget is honoured (or refused) as requested.
+        default_tb = min(cfg.token_budget, max(10_000, budget.tokens_left // len(tasks)))
+
         # Prepare + reserve per index; a refusal becomes that index's error
         # entry, never an all-or-nothing failure.
         entries: list[dict] = []
@@ -3887,7 +3904,7 @@ class AgentCore:
                 parent_state=request_state,
                 background=background,
                 max_steps=item.get("max_steps"),
-                token_budget=item.get("token_budget"),
+                token_budget=item.get("token_budget") or default_tb,
                 thinking_effort=item.get("thinking_effort"),
                 model=str(item.get("model", "")),
                 provider=str(item.get("provider", "")),
@@ -4305,12 +4322,19 @@ class AgentCore:
         return run, child_agent, child_state
 
     def _turn_budget(self, parent_state: dict) -> FanoutBudget:
-        """The turn's shared subagent spend pool, created lazily on first spawn."""
+        """The turn's shared subagent spend pool, created lazily on first spawn.
+
+        The pool is never smaller than one default-sized run: an owner who
+        raised ``token_budget`` past ``turn_token_budget`` (the per-run knob
+        predates the pool) would otherwise find every unsized spawn refused
+        out of the box.
+        """
         budget = parent_state.get("fanout_budget")
         if budget is None:
             cfg = self.config.subagents
             budget = parent_state["fanout_budget"] = FanoutBudget(
-                tokens_left=cfg.turn_token_budget, spawns_left=cfg.max_spawns_per_turn
+                tokens_left=max(cfg.turn_token_budget, cfg.token_budget),
+                spawns_left=cfg.max_spawns_per_turn,
             )
         return budget
 
@@ -4486,7 +4510,15 @@ class AgentCore:
         tokens = self._usage_total(response.usage)
         run.tokens_used = tokens
         aborted = False
-        while response.tool_calls and steps < run.max_steps and tokens < run.token_budget:
+        # ``steps == 0 or``: the first tool round always runs. The opening
+        # generate alone can cost more than a small budget (system prompt +
+        # tools ≈ 10k+ input tokens), and stopping before the first round would
+        # bill that call and do nothing with it.
+        while (
+            response.tool_calls
+            and steps < run.max_steps
+            and (steps == 0 or tokens < run.token_budget)
+        ):
             if abort and abort.is_set():
                 aborted = True
                 break

--- a/humux/core/agents.py
+++ b/humux/core/agents.py
@@ -84,6 +84,7 @@ _MIGRATIONS = (
     "ALTER TABLE agents ADD COLUMN cot_feedback TEXT DEFAULT ''",  # Telegram CoT feedback mode
     "ALTER TABLE agents ADD COLUMN is_default INTEGER NOT NULL DEFAULT 0",  # #115 flw
     "ALTER TABLE agents ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1",  # #115 flw kill-switch
+    "ALTER TABLE agents ADD COLUMN spawnable_agents TEXT DEFAULT ''",  # delegation trust list
     # #98: personalia merged into character. Prepend any existing personalia to
     # character (idempotent — the WHERE guard empties it, so a re-run is a no-op),
     # then drop the now-unused column. On a fresh DB (no such column) both raise
@@ -134,6 +135,15 @@ class Agent:
     skills: list[str] = field(default_factory=list)  # allowlist; [] = all
     tools: list[str] = field(default_factory=list)  # allowlist; [] = all
     secrets: list[str] = field(default_factory=list)  # vault scope; stored only (#19)
+    # Delegation trust list: the agents this one may name in spawn_subagent(s).
+    # [] = no curated team (legacy): any agent may be named, scoped down to the
+    # intersection with this agent's own capabilities (inherit-never-widen).
+    # Non-empty = ONLY these may be named, and a listed specialist runs with its
+    # OWN tools/skills/secrets/accounts — the list itself is the trust grant, so
+    # delegation to it is capability handoff, not capability leakage. Naming an
+    # agent off the list is refused. Anonymous spawns (no name) always run as
+    # this agent itself, list or no list.
+    spawnable_agents: list[str] = field(default_factory=list)
     # Own Telegram bot token; empty = no bot. The default agent's bot runs as the
     # bare "telegram" channel, every other agent's as "telegram:<slug>" (#29/#133).
     bot_token: str = ""
@@ -517,6 +527,7 @@ def parse_markdown(text: str, *, name: str) -> Agent:
         skills=_as_list(fm.get("skills")),
         tools=_as_list(fm.get("tools")),
         secrets=_as_list(fm.get("secrets")),
+        spawnable_agents=_as_list(fm.get("spawnable_agents")),
         bot_token=str(fm.get("bot_token", "") or ""),
         allowed_user_ids=_as_int_list(fm.get("allowed_user_ids")),
         tool_config=_as_tool_config(fm.get("tool_config")),
@@ -541,6 +552,7 @@ def to_markdown(a: Agent) -> str:
         "skills": a.skills,
         "tools": a.tools,
         "secrets": a.secrets,
+        "spawnable_agents": a.spawnable_agents,
         "tool_config": a.tool_config,
         "email_accounts": a.email_accounts,
         "calendar_accounts": a.calendar_accounts,
@@ -727,14 +739,15 @@ class AgentStore:
         await db.execute(
             "INSERT INTO agents "
             "(name, agent_name, role, voice, character, skills, tools, "
-            "secrets, bot_token, allowed_user_ids, tool_config, "
+            "secrets, spawnable_agents, bot_token, allowed_user_ids, tool_config, "
             "email_accounts, calendar_accounts, contacts_accounts, chat_settings, group_chat, "
             "llm_config, cot_feedback) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
             "ON CONFLICT(name) DO UPDATE SET "
             "agent_name=excluded.agent_name, role=excluded.role, "
             "voice=excluded.voice, character=excluded.character, "
             "skills=excluded.skills, tools=excluded.tools, secrets=excluded.secrets, "
+            "spawnable_agents=excluded.spawnable_agents, "
             "bot_token=excluded.bot_token, allowed_user_ids=excluded.allowed_user_ids, "
             "tool_config=excluded.tool_config, email_accounts=excluded.email_accounts, "
             "calendar_accounts=excluded.calendar_accounts, "
@@ -751,6 +764,7 @@ class AgentStore:
                 "\n".join(a.skills),
                 "\n".join(a.tools),
                 "\n".join(a.secrets),
+                "\n".join(a.spawnable_agents),
                 a.bot_token,
                 "\n".join(str(i) for i in a.allowed_user_ids),
                 json.dumps(a.tool_config) if a.tool_config else "",
@@ -775,6 +789,9 @@ class AgentStore:
             skills=_as_list(row["skills"]),
             tools=_as_list(row["tools"]),
             secrets=_as_list(row["secrets"]),
+            spawnable_agents=_as_list(
+                row["spawnable_agents"] if "spawnable_agents" in row.keys() else ""
+            ),
             bot_token=(row["bot_token"] if "bot_token" in row.keys() else "") or "",
             allowed_user_ids=_as_int_list(
                 row["allowed_user_ids"] if "allowed_user_ids" in row.keys() else ""

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -523,7 +523,12 @@ class SubagentsConfig(BaseModel):
     enabled: bool = True
     recursion_depth: int = 3  # max nesting; spawns are refused beyond this
     max_steps: int = 12  # max tool-call rounds per run (hard stop)
-    token_budget: int = 100_000  # approx token ceiling per run (best-effort)
+    # Approx token ceiling per run. Counted as input+output EVERY round, and on
+    # OpenAI-shaped providers `input_tokens` includes the whole re-sent prompt
+    # (system + tool defs ≈ 14k before any history), so the real cost of a round
+    # grows and 100k bought only ~4 rounds — max_steps, the honest limiter, never
+    # got to bind. Sized so it does.
+    token_budget: int = 300_000
     # Runs executing at once, PER CHAT, all paths (sync fan-out queues at the
     # cap; a single background spawn still refuses). Was a background-only
     # process-wide counter before the fan-out work.
@@ -532,7 +537,7 @@ class SubagentsConfig(BaseModel):
     # Whole-tree per-turn pools (see FanoutBudget): total spawns and total
     # subagent tokens a single turn may consume, parents and children combined.
     max_spawns_per_turn: int = 12
-    turn_token_budget: int = 400_000
+    turn_token_budget: int = 1_200_000  # max_concurrent × token_budget
     # "provider:model" entries a spawn may pick instead of inheriting the
     # caller's LLM (#299). Empty = no overrides; a subagent always inherits.
     allowed_models: list[str] = []

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -524,7 +524,15 @@ class SubagentsConfig(BaseModel):
     recursion_depth: int = 3  # max nesting; spawns are refused beyond this
     max_steps: int = 12  # max tool-call rounds per run (hard stop)
     token_budget: int = 100_000  # approx token ceiling per run (best-effort)
-    max_concurrent: int = 3  # max background runs at once
+    # Runs executing at once, PER CHAT, all paths (sync fan-out queues at the
+    # cap; a single background spawn still refuses). Was a background-only
+    # process-wide counter before the fan-out work.
+    max_concurrent: int = 4
+    max_fanout: int = 6  # max tasks in one spawn_subagents call
+    # Whole-tree per-turn pools (see FanoutBudget): total spawns and total
+    # subagent tokens a single turn may consume, parents and children combined.
+    max_spawns_per_turn: int = 12
+    turn_token_budget: int = 400_000
     # "provider:model" entries a spawn may pick instead of inheriting the
     # caller's LLM (#299). Empty = no overrides; a subagent always inherits.
     allowed_models: list[str] = []
@@ -543,6 +551,7 @@ class SubagentSummaryConfig(BaseModel):
     provider: str = "deepseek"  # fast + cheap is ideal for this distillation
     model: str = "deepseek-v4-flash"
     thinking_level: str = ""  # "" (off) | "low" | "medium" | "high" | "max"
+
 
 class Config(BaseModel):
     agent: AgentConfig = AgentConfig()

--- a/humux/core/embeddings.py
+++ b/humux/core/embeddings.py
@@ -99,7 +99,12 @@ class EmbeddingClient:
             client_class = cast(Any, getattr(module, "AsyncOpenAI"))
         except Exception as exc:  # pragma: no cover - import guard
             raise RuntimeError("openai package is required for embeddings") from exc
-        self._client = cast(Any, client_class)(api_key=api_key, base_url=resolved_base or None)
+        # timeout/max_retries mirror the LLM clients: the SDK default is 600s with
+        # 2 retries, so a hung sidecar would stall every turn preamble — and each
+        # subagent's too — for ten minutes before falling back.
+        self._client = cast(Any, client_class)(
+            api_key=api_key, base_url=resolved_base or None, timeout=20.0, max_retries=1
+        )
 
     async def embed(self, texts: list[str]) -> list[list[float]]:
         """Return one embedding vector per input text."""

--- a/humux/core/llm.py
+++ b/humux/core/llm.py
@@ -505,12 +505,16 @@ class LLMClient:
         openai_tools = _openai_tools(tools)
         client_any = cast(Any, self._client)
         full_messages = [{"role": "system", "content": system}, *messages]
+        # The OpenAI schema rejects an empty `tools` array, so a deliberately
+        # tool-free call (vision captioning, a subagent's wrap-up round) has to
+        # omit the field entirely rather than send [].
+        tool_kwargs = {"tools": cast(Any, openai_tools)} if openai_tools else {}
         response = await _call_with_retries(
             lambda: client_any.chat.completions.create(
                 model=resolved_model,
                 max_tokens=max_tokens,
                 messages=cast(Any, full_messages),
-                tools=cast(Any, openai_tools),
+                **tool_kwargs,
                 **self._reasoning_kwargs(),
             )
         )

--- a/humux/core/llm.py
+++ b/humux/core/llm.py
@@ -7,6 +7,7 @@ import contextvars
 import importlib
 import json
 import logging
+import random
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -25,21 +26,22 @@ reasoning_log.setLevel(logging.WARNING)
 # the agent sets the context for a turn, generate() records the payload, the
 # admin Inspect tab reads it back. ponytail: process-global dict, fine for one
 # agent process; move onto the agent instance if multi-tenant ever lands.
-# Context key = (channel, user_id, chat_id) — same triple as ConversationHistory.
+# Context key = (channel, user_id, chat_id, run_id) — the ConversationHistory
+# triple plus a subagent run id ("" for a main turn), so a fan-out of children
+# is inspectable per run instead of clobbering the parent's slot.
 _capture_ctx: contextvars.ContextVar = contextvars.ContextVar("humux_llm_capture_ctx", default=None)
 # The agent slug whose turn is running, so token usage can be attributed per
 # agent for the dashboard (#199 flw). Empty = unknown (subagents/system tasks).
 _usage_agent: contextvars.ContextVar = contextvars.ContextVar("humux_llm_usage_agent", default="")
-_LAST_SENT: OrderedDict[tuple[str, str, str], dict[str, Any]] = OrderedDict()
+_LAST_SENT: OrderedDict[tuple[str, str, str, str], dict[str, Any]] = OrderedDict()
 _CAPTURE_CAP = 100  # ponytail: LRU cap; bump if you watch >100 live chats
 
 
-def set_capture_context(ctx: tuple[str, str, str] | None) -> Any:
+def set_capture_context(ctx: tuple[str, str, str, str] | None) -> Any:
     """Bind the conversation context that generate() should record under.
 
-    Pass ``None`` to suppress capture (e.g. subagents, which run inside the
-    spawner's context but must not overwrite its captured payload). Returns a
-    token for :func:`reset_capture_context`."""
+    Pass ``None`` to suppress capture entirely. Returns a token for
+    :func:`reset_capture_context`."""
     return _capture_ctx.set(ctx)
 
 
@@ -57,7 +59,7 @@ def reset_usage_agent(token: Any) -> None:
     _usage_agent.reset(token)
 
 
-def record_sent_payload(ctx: tuple[str, str, str] | None, payload: dict[str, Any]) -> None:
+def record_sent_payload(ctx: tuple[str, str, str, str] | None, payload: dict[str, Any]) -> None:
     """Store ``payload`` as the last-sent request for ``ctx`` (no-op if None)."""
     if ctx is None:
         return
@@ -67,13 +69,53 @@ def record_sent_payload(ctx: tuple[str, str, str] | None, payload: dict[str, Any
         _LAST_SENT.popitem(last=False)
 
 
-def get_sent_payload(ctx: tuple[str, str, str]) -> dict[str, Any] | None:
+def get_sent_payload(ctx: tuple[str, str, str, str]) -> dict[str, Any] | None:
     return _LAST_SENT.get(ctx)
+
+
+def list_captured() -> list[tuple[str, str, str, str]]:
+    """Keys of every captured payload, newest first — the admin Inspect tab
+    merges these with the chat list so subagent runs (which never appear in
+    ConversationHistory) still get an entry."""
+    return list(reversed(_LAST_SENT.keys()))
 
 
 def clear_captured() -> None:
     """Drop all captured payloads (used by tests)."""
     _LAST_SENT.clear()
+
+
+# Transport-level resilience (#fan-out): concurrent subagents hitting one
+# provider will surface 429s/5xxs that today's serial calls never did. A short
+# jittered retry on the SDK call itself; deliberately NOT an automatic re-run of
+# a failed subagent (that would double spend invisibly — the model can retry a
+# failed child from the fan-out result instead).
+_RETRY_STATUSES = {429, 500, 502, 503, 504, 529}
+_RETRY_ATTEMPTS = 3
+
+
+async def _call_with_retries(fn):
+    """Await ``fn()`` retrying transient provider errors with jittered backoff.
+
+    Both SDKs raise typed errors carrying ``status_code``; anything else (auth,
+    bad request, timeout) propagates immediately.
+    """
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            return await fn()
+        except Exception as exc:
+            status = getattr(exc, "status_code", None)
+            if status not in _RETRY_STATUSES or attempt >= _RETRY_ATTEMPTS - 1:
+                raise
+            delay = (2**attempt) * 0.5 * (1 + random.random())
+            logging.getLogger(__name__).warning(
+                "LLM call failed with %s; retrying in %.1fs (%d/%d)",
+                status,
+                delay,
+                attempt + 1,
+                _RETRY_ATTEMPTS,
+            )
+            await asyncio.sleep(delay)
 
 
 _DEFAULT_BASE_URLS = {
@@ -400,13 +442,15 @@ class LLMClient:
                         "cache_control": {"type": "ephemeral"},
                     }
                 ]
-            response = await messages_client.create(
-                model=resolved_model,
-                max_tokens=max_tokens,
-                system=cast(Any, system_param),
-                messages=cast(Any, messages),
-                tools=cast(Any, tools),
-                **self._sampling_kwargs(),
+            response = await _call_with_retries(
+                lambda: messages_client.create(
+                    model=resolved_model,
+                    max_tokens=max_tokens,
+                    system=cast(Any, system_param),
+                    messages=cast(Any, messages),
+                    tools=cast(Any, tools),
+                    **self._sampling_kwargs(),
+                )
             )
             tool_calls = []
             text_parts = []
@@ -461,12 +505,14 @@ class LLMClient:
         openai_tools = _openai_tools(tools)
         client_any = cast(Any, self._client)
         full_messages = [{"role": "system", "content": system}, *messages]
-        response = await client_any.chat.completions.create(
-            model=resolved_model,
-            max_tokens=max_tokens,
-            messages=cast(Any, full_messages),
-            tools=cast(Any, openai_tools),
-            **self._reasoning_kwargs(),
+        response = await _call_with_retries(
+            lambda: client_any.chat.completions.create(
+                model=resolved_model,
+                max_tokens=max_tokens,
+                messages=cast(Any, full_messages),
+                tools=cast(Any, openai_tools),
+                **self._reasoning_kwargs(),
+            )
         )
         message = response.choices[0].message
         tool_calls = []

--- a/humux/core/memory.py
+++ b/humux/core/memory.py
@@ -629,8 +629,10 @@ class MemoryStore:
 
         try:
             query_vec = await self.embedder.embed_one(query)
-        except Exception:
-            log.exception("Query embedding failed; falling back to recency order")
+        except Exception as exc:
+            # warning, not exception: this is a designed fallback, and a fan-out
+            # embeds once per child — a traceback per subagent buries real errors.
+            log.warning("Query embedding failed; falling back to recency order (%s)", exc)
             return await self.get_long_term(scope)
         if not query_vec:
             return await self.get_long_term(scope)
@@ -1093,8 +1095,8 @@ class MemoryStore:
             return None
         try:
             vec = await self.embedder.embed_one(text)
-        except Exception:
-            log.exception("Embedding call failed; proceeding without a vector")
+        except Exception as exc:
+            log.warning("Embedding call failed; proceeding without a vector (%s)", exc)
             return None
         return vec or None
 
@@ -1206,7 +1208,10 @@ class MemoryStore:
                 return 0
             old_subject, old_content, old_blob = row
             if subject != old_subject or content != old_content:
-                blob = await self._embed_blob(f"{subject}: {content}")
+                # Keep the old vector when re-embedding fails (embedder down):
+                # writing NULL would silently drop this row out of semantic
+                # recall until someone ran a manual reindex.
+                blob = await self._embed_blob(f"{subject}: {content}") or old_blob
             else:
                 blob = old_blob
             cursor = await db.execute(

--- a/humux/core/permissions.py
+++ b/humux/core/permissions.py
@@ -260,6 +260,7 @@ DEFAULT_RULES: dict[str, str] = {
     # Delegating to a subagent is approved once per spawn; the subagent then runs
     # autonomously within its narrowed scope (system semantics), like a job.
     "spawn_subagent": "ASK",
+    "spawn_subagents": "ASK",
     # Publishing a web artifact is now just a write under {workspace}/artifacts/
     # (issue #82) — it inherits the write ASK rule, no separate entry.
     # Dangerous — never allow
@@ -573,6 +574,7 @@ class PermissionEngine:
             "schedule_task",
             "manage_jobs",
             "spawn_subagent",
+            "spawn_subagents",
             "write",
             "edit",
         }:

--- a/humux/core/permissions.py
+++ b/humux/core/permissions.py
@@ -810,6 +810,21 @@ def format_approval_message(tool_name: str, params: dict) -> str:
         if action == "list":
             return "List scheduled jobs"
         return f"Manage jobs: {action}"
+    if tool_name == "spawn_subagent":
+        # Name the target: subagents run with system semantics (no per-action
+        # prompts), so this approval is the one human gate on the whole run.
+        who = params.get("agent") or ""
+        head = f"Delegate to agent '{who}'" if who else "Delegate to a subagent (runs as itself)"
+        return f"{head}\n{_preview(str(params.get('task', '?')), 200)}"
+    if tool_name == "spawn_subagents":
+        tasks = params.get("tasks") or []
+        tasks = tasks if isinstance(tasks, list) else []
+        parts = []
+        for t in tasks:
+            t = t if isinstance(t, dict) else {}
+            who = f" → {t['agent']}" if t.get("agent") else ""
+            parts.append(f"- {_preview(str(t.get('task', '?')), 80)}{who}")
+        return f"Delegate {len(tasks)} subtasks to parallel subagents:\n" + "\n".join(parts)
     if tool_name == "bash":
         cmd = _preview(params.get("command", "?"))
         purpose = params.get("purpose", "")

--- a/humux/core/prompt_builder.py
+++ b/humux/core/prompt_builder.py
@@ -204,6 +204,27 @@ def build_prompt_sections(
         "</messages>"
     )
 
+    # Delegation discoverability (#312 flw): the tool schemas say HOW to spawn and
+    # the subagent-orchestration skill says WHEN — but the model has to already
+    # suspect fan-out is relevant to go read that skill. This block is the missing
+    # trigger, so delegation happens without the user asking for it.
+    if getattr(config.subagents, "enabled", False) and (
+        agent is None or agent.allows_tool("spawn_subagent")
+    ):
+        intro += (
+            "\n\n<delegation>\n"
+            "You can hand work to subagents: spawn_subagent for one subtask, "
+            "spawn_subagents for two to six that run in PARALLEL. Reach for them on "
+            "your own — the owner does not have to ask. Delegate when a request has "
+            "parts that each need several tool calls and their own reading and that "
+            "do not depend on each other: separate research threads, several sources "
+            "or files to survey, a few options to produce side by side. Parts that "
+            "chain are a pipeline — spawn one, read its result, then spawn the next. "
+            "Quick lookups and single tool calls: just do them yourself. Read the "
+            "subagent-orchestration skill for briefing, sizing and patterns.\n"
+            "</delegation>"
+        )
+
     character = f"<character>\n{character_text}\n</character>"
     about_user = f"<about_user>\n{about_user_block}\n</about_user>" if about_user_block else ""
     tool_usage = f"<tool_usage>\n{tool_usage_text}\n</tool_usage>"

--- a/humux/core/subagents.py
+++ b/humux/core/subagents.py
@@ -205,7 +205,12 @@ def narrow_scope(parent: list[str] | None, child: list[str] | None) -> list[str]
         return list(c)
     if not c:
         return list(p)
-    return [x for x in c if x in p]
+    # An empty intersection must stay restrictive: [] means *all*, so collapsing
+    # two disjoint non-empty scopes to it would WIDEN the child to everything —
+    # the exact inversion of inherit-never-widen. The sentinel matches no real
+    # tool/skill/secret, so it grants nothing (mirrors Agent.__post_init__'s
+    # legacy-migration rule of keeping a scope non-empty).
+    return [x for x in c if x in p] or ["__nothing__"]
 
 
 def narrow_accounts(parent: list[dict] | None, child: list[dict] | None) -> list[dict]:
@@ -484,6 +489,8 @@ def _selfcheck() -> None:
     assert narrow_scope([], ["a"]) == ["a"]  # empty parent = no restriction
     assert narrow_scope(["a", "b"], []) == ["a", "b"]  # empty child inherits
     assert narrow_scope(["a", "b"], ["b", "c"]) == ["b"]  # intersection, never widen
+    # Disjoint non-empty scopes must NOT collapse to [] ("all") — that would widen.
+    assert narrow_scope(["a"], ["b"]) == ["__nothing__"]
 
     rw = {"account": "x", "access_level": "read_write", "is_sender_identity": True}
     ro = {"account": "x", "access_level": "read", "is_sender_identity": False}

--- a/humux/core/subagents.py
+++ b/humux/core/subagents.py
@@ -16,8 +16,10 @@ registry is the right scope; nothing here needs to survive a reboot.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 # Keep at most this many finished runs for after-the-fact inspection.
@@ -126,6 +128,50 @@ def resolve_model_override(
     )
 
 
+def derive_label(label: str, task: str, index: int = 0) -> str:
+    """A short run label for logs/UI: the model's own when supplied, else the
+    first few words of the task (so five siblings of one agent stay tellable
+    apart in the Logs and Jobs tabs)."""
+    lbl = " ".join(str(label or "").split())
+    if not lbl:
+        lbl = " ".join(str(task or "").split()[:4]) or f"task{index}"
+    return lbl[:32]
+
+
+@dataclass(slots=True)
+class FanoutBudget:
+    """Whole-tree subagent spend guard for one turn, shared by reference
+    parent → child so a depth-2 grandchild draws from the same pool.
+
+    Reserve-then-refund, not spend-then-check: each run reserves its full token
+    budget at spawn (so concurrent runs can't all observe the same "plenty
+    left") and refunds the unspent remainder when it completes. A crashed run
+    simply doesn't refund — fails safe.
+    """
+
+    tokens_left: int
+    spawns_left: int
+
+    def reserve(self, tokens: int) -> str | None:
+        """Take a run's worth up front; an error message when there isn't one."""
+        if self.spawns_left <= 0:
+            return (
+                "Spawn budget for this turn is exhausted — finish with what "
+                "you have instead of delegating more."
+            )
+        if tokens > self.tokens_left:
+            return (
+                f"Only ~{self.tokens_left} subagent tokens are left this turn; "
+                "size the run smaller or do the work yourself."
+            )
+        self.spawns_left -= 1
+        self.tokens_left -= tokens
+        return None
+
+    def refund(self, unspent: int) -> None:
+        self.tokens_left += max(0, int(unspent))
+
+
 def resolve_cap(value: object, ceiling: int, floor: int = 1) -> int:
     """Clamp a caller-requested run cap (steps / token budget) into bounds.
 
@@ -205,6 +251,19 @@ class SubagentRun:
     task: str
     depth: int = 1
     background: bool = False
+    # Short display name for logs/UI (model-picked or derived from the task).
+    label: str = ""
+    # Fan-out bookkeeping: siblings of one spawn_subagents call share a
+    # group_id; parent_run_id/children link the run tree so the admin UI can
+    # render it and cancel can cascade.
+    group_id: str = ""
+    parent_run_id: str = ""
+    children: list[str] = field(default_factory=list)
+    # Live spend/outcome telemetry, updated by the run loop as it goes.
+    tokens_used: int = 0
+    steps: int = 0
+    # "" while running; complete | max_steps | token_budget | truncated | aborted.
+    stopped_reason: str = ""
     # Per-run sizing the spawning agent chose, resolved/clamped via resolve_cap
     # before the run starts (so always concrete on a live run; the 0 defaults are
     # only placeholders for direct construction). effort None = inherit caller level.
@@ -245,10 +304,40 @@ class SubagentRegistry:
 
     def __init__(self) -> None:
         self._runs: OrderedDict[str, SubagentRun] = OrderedDict()
+        # Per-chat concurrency gate (see slot()): chat key → depth-1 runs
+        # currently holding a slot. One Condition for all chats — wakeups are
+        # rare and cheap at this scale.
+        self._slots: dict[str, int] = {}
+        self._slots_cond = asyncio.Condition()
 
     def register(self, run: SubagentRun) -> None:
         self._runs[run.run_id] = run
         self._trim()
+
+    @contextlib.asynccontextmanager
+    async def slot(self, chat_key: str, limit: Callable[[], int]):
+        """Acquire a per-chat concurrency slot; queues (never refuses) when the
+        chat is at its cap. ``limit`` is read at every acquire so a live config
+        change to ``max_concurrent`` applies without a restart. Per-chat, so one
+        chat's fan-out never starves another chat's spawn.
+        """
+        async with self._slots_cond:
+            while self._slots.get(chat_key, 0) >= max(1, limit()):
+                await self._slots_cond.wait()
+            self._slots[chat_key] = self._slots.get(chat_key, 0) + 1
+        try:
+            yield
+        finally:
+            async with self._slots_cond:
+                n = self._slots.get(chat_key, 1) - 1
+                if n <= 0:
+                    self._slots.pop(chat_key, None)
+                else:
+                    self._slots[chat_key] = n
+                self._slots_cond.notify_all()
+
+    def slots_in_use(self, chat_key: str) -> int:
+        return self._slots.get(chat_key, 0)
 
     def attach_task(self, run_id: str, task: asyncio.Task) -> None:
         run = self._runs.get(run_id)
@@ -293,12 +382,21 @@ class SubagentRegistry:
         self._trim()
         return True
 
+    def list_group(self, group_id: str) -> list[SubagentRun]:
+        """All runs of one fan-out group, oldest first."""
+        out = [r for r in self._runs.values() if group_id and r.group_id == group_id]
+        return sorted(out, key=lambda r: r.started_at)
+
     def cancel(self, run_id: str) -> bool:
-        """Request cancellation of a running subagent. Returns False if it is not
-        running (unknown id or already finished)."""
+        """Request cancellation of a running subagent, cascading to any children
+        it spawned (a ``create_task`` child survives its parent's cancellation,
+        so without the walk a cancelled orchestrator would orphan its fan-out).
+        Returns False if it is not running (unknown id or already finished)."""
         run = self._runs.get(run_id)
         if not run or run.status != "running":
             return False
+        for child_id in list(run.children):
+            self.cancel(child_id)
         if run._task and not run._task.done():
             run._task.cancel()
         # The task's CancelledError handler flips status to "cancelled"; set it
@@ -410,6 +508,23 @@ def _selfcheck() -> None:
     assert resolve_model_override("", "b", ["a:b"]) == ("a", "b", "")
     assert resolve_model_override("a", "b", ["a:b", "c:d"]) == ("a", "b", "")
     assert resolve_model_override("a", "d", ["a:b", "c:d"])[2]  # wrong pairing → refused
+
+    # FanoutBudget: reserve-then-refund, fails closed on exhaustion.
+    b = FanoutBudget(tokens_left=100, spawns_left=2)
+    assert b.reserve(60) is None and b.tokens_left == 40 and b.spawns_left == 1
+    assert b.reserve(60)  # over the token pool → message, not exception
+    b.refund(30)
+    assert b.tokens_left == 70
+    assert b.reserve(60) is None and b.spawns_left == 0
+    assert b.reserve(1)  # spawn pool exhausted
+    b.refund(-5)  # a bogus negative refund never shrinks the pool
+    assert b.tokens_left == 10
+
+    # Labels: model-picked wins, else derived from the task, always bounded.
+    assert derive_label("pricing", "whatever task") == "pricing"
+    assert derive_label("", "Read the six PRs and summarise") == "Read the six PRs"
+    assert derive_label("", "", 3) == "task3"
+    assert len(derive_label("x" * 99, "")) == 32
     print("subagents.py self-check OK")
 
 

--- a/humux/core/subagents.py
+++ b/humux/core/subagents.py
@@ -140,36 +140,41 @@ def derive_label(label: str, task: str, index: int = 0) -> str:
 
 @dataclass(slots=True)
 class FanoutBudget:
-    """Whole-tree subagent spend guard for one turn, shared by reference
+    """Whole-tree subagent spend pool for one turn, shared by reference
     parent → child so a depth-2 grandchild draws from the same pool.
 
-    Reserve-then-refund, not spend-then-check: each run reserves its full token
-    budget at spawn (so concurrent runs can't all observe the same "plenty
-    left") and refunds the unspent remainder when it completes. A crashed run
-    simply doesn't refund — fails safe.
+    Spend is charged as it happens (once per LLM round), not reserved up
+    front: a spawn is never refused for tokens — runs stop gracefully between
+    rounds once the pool drains. Concurrent runs can overshoot by at most one
+    round each, which is bounded and far simpler than reserve-then-refund
+    (whose upfront refusals also confused the model whenever the per-run
+    ceiling approached the pool size).
     """
 
     tokens_left: int
     spawns_left: int
 
-    def reserve(self, tokens: int) -> str | None:
-        """Take a run's worth up front; an error message when there isn't one."""
+    def take_spawn(self) -> str | None:
+        """Claim one spawn from the pool; an error message when none is left."""
         if self.spawns_left <= 0:
             return (
                 "Spawn budget for this turn is exhausted — finish with what "
                 "you have instead of delegating more."
             )
-        if tokens > self.tokens_left:
+        if self.exhausted:
             return (
-                f"Only ~{self.tokens_left} subagent tokens are left this turn; "
-                "size the run smaller or do the work yourself."
+                "The turn's subagent token budget is exhausted — finish with "
+                "what you have instead of delegating more."
             )
         self.spawns_left -= 1
-        self.tokens_left -= tokens
         return None
 
-    def refund(self, unspent: int) -> None:
-        self.tokens_left += max(0, int(unspent))
+    def charge(self, tokens: int) -> None:
+        self.tokens_left -= max(0, int(tokens))
+
+    @property
+    def exhausted(self) -> bool:
+        return self.tokens_left <= 0
 
 
 def resolve_cap(value: object, ceiling: int, floor: int = 1) -> int:
@@ -516,16 +521,17 @@ def _selfcheck() -> None:
     assert resolve_model_override("a", "b", ["a:b", "c:d"]) == ("a", "b", "")
     assert resolve_model_override("a", "d", ["a:b", "c:d"])[2]  # wrong pairing → refused
 
-    # FanoutBudget: reserve-then-refund, fails closed on exhaustion.
+    # FanoutBudget: charge-as-you-go, spawns refused only on exhausted pools.
     b = FanoutBudget(tokens_left=100, spawns_left=2)
-    assert b.reserve(60) is None and b.tokens_left == 40 and b.spawns_left == 1
-    assert b.reserve(60)  # over the token pool → message, not exception
-    b.refund(30)
-    assert b.tokens_left == 70
-    assert b.reserve(60) is None and b.spawns_left == 0
-    assert b.reserve(1)  # spawn pool exhausted
-    b.refund(-5)  # a bogus negative refund never shrinks the pool
-    assert b.tokens_left == 10
+    assert b.take_spawn() is None and b.spawns_left == 1
+    b.charge(60)
+    assert b.tokens_left == 40 and not b.exhausted
+    assert b.take_spawn() is None and b.spawns_left == 0
+    assert b.take_spawn()  # spawn pool exhausted → message, not exception
+    b.charge(-5)  # a bogus negative charge never grows the pool back
+    b.charge(50)
+    assert b.tokens_left == -10 and b.exhausted  # bounded overshoot is fine
+    assert FanoutBudget(tokens_left=0, spawns_left=5).take_spawn()  # token pool dry
 
     # Labels: model-picked wins, else derived from the task, always bounded.
     assert derive_label("pricing", "whatever task") == "pricing"

--- a/humux/core/task_reflection.py
+++ b/humux/core/task_reflection.py
@@ -246,14 +246,24 @@ class ReflectionStore:
         )
 
         try:
-            raw = await llm.generate_text(model=model, prompt=prompt, max_tokens=1024)
+            # 1024 cut off a reflection on a busy turn (fan-out + several tool
+            # failures = one tool_issues entry each), and a cut-off object has no
+            # closing brace, so it parses as "non-JSON" rather than as truncation.
+            raw = await llm.generate_text(model=model, prompt=prompt, max_tokens=2048)
         except Exception:
             log.exception("Task reflection LLM call failed")
             return False
 
         parsed = _extract_json_object(raw)
         if not parsed:
-            log.warning("Task reflection returned non-JSON: %s", raw[:200])
+            # Log the TAIL as well: the head of a truncated object looks like
+            # perfectly good JSON, which is what made this misleading.
+            log.warning(
+                "Task reflection returned non-JSON (%d chars): %s … %s",
+                len(raw),
+                raw[:200],
+                raw[-200:],
+            )
             return False
 
         lesson = parsed.get("lesson", "").strip()

--- a/humux/skills/subagent-orchestration.md
+++ b/humux/skills/subagent-orchestration.md
@@ -47,6 +47,15 @@ message. Everything it needs goes in `task`. Include:
 If a brief is hard to write self-contained, that is a signal the task is not
 independent — pipeline it.
 
+## Delegating to specialists
+
+Omit `agent` to run a subtask as yourself — the right default. Name an agent
+only when your roster lists it and the subtask plainly belongs to it: a listed
+teammate runs with its *own* tools, skills, accounts and memory, which is
+exactly why you pick it (a legal question to the legal agent, a code review to
+the QA agent). Never name an agent your roster doesn't show — the spawn will be
+refused.
+
 ## Labels
 
 Always give every fan-out task a short distinctive `label`, 1–3 words:

--- a/humux/skills/subagent-orchestration.md
+++ b/humux/skills/subagent-orchestration.md
@@ -152,18 +152,18 @@ guessed column is worse than a table with a visible gap.
 
 Every spawn — singular, plural, and any nested subagent — draws from one shared
 pool for the whole turn: `max_spawns_per_turn` (default 12) and
-`turn_token_budget` (default 400000). Each run reserves its `token_budget` up
-front and refunds the unused part on completion — so a generous budget on a
-short task is cheap; generous budgets on many tasks are not. In a fan-out,
-prefer omitting `token_budget`: unsized tasks split the pool fairly. If you
-do size one, remember every round re-reads the prompt (10-20k tokens a
-round) — budgets under ~20k rarely finish real work.
+`turn_token_budget` (default 400000). Spend is counted as it happens, one round
+at a time — you are never refused for tokens up front, only once the pool is
+already drained or the spawn count is used up. Remember every round re-reads
+the prompt (10-20k tokens a round) — budgets under ~20k rarely finish real
+work.
 
-Two or three well-briefed subtasks beat six vague ones, every time. A spawn
-refused with a budget error is the signal to finish with what you have and tell
-the user what you skipped — not to retry the fan-out in smaller pieces until
-the pool drains. Note also that only `max_concurrent` (default 4) runs execute
-at once per chat, so a width-6 fan-out is two waves, not one.
+Two or three well-briefed subtasks beat six vague ones, every time. A run that
+comes back with `stopped_reason: "turn_budget"` means the turn's shared pool is
+drained — finish with what you have and tell the user what you skipped;
+retrying or sizing the budget up won't help, there is nothing left to spend.
+Note also that only `max_concurrent` (default 4) runs execute at once per
+chat, so a width-6 fan-out is two waves, not one.
 
 ## Anti-patterns
 

--- a/humux/skills/subagent-orchestration.md
+++ b/humux/skills/subagent-orchestration.md
@@ -67,10 +67,15 @@ the task's first words if nothing better comes to mind.
 
 | Task shape | max_steps | token_budget | thinking_effort | model |
 |---|---|---|---|---|
-| Mechanical extraction (read file, pull fields) | 5–8 | 15k–25k | `off`/`low` | cheap fast model |
-| Focused web research, 3–6 sources | 10–15 | 30k–50k | `low` | cheap fast model |
-| Code reading + explanation across a module | 15–25 | 50k–80k | `medium` | parent's model |
-| Judgement, design, tradeoff analysis, review | 20–30 | 80k–120k | `high` | parent's model |
+| Mechanical extraction (read file, pull fields) | 5–8 | 50k–80k | `off`/`low` | cheap fast model |
+| Focused web research, 3–6 sources | 10–15 | 100k–150k | `low` | cheap fast model |
+| Code reading + explanation across a module | 15–25 | 150k–250k | `medium` | parent's model |
+| Judgement, design, tradeoff analysis, review | 20–30 | 250k–300k | `high` | parent's model |
+
+A round re-sends the whole prompt, so it costs 15–35k tokens and each round
+costs more than the last: `max_steps` × ~25k is the honest floor for a budget.
+Leaving `token_budget` out entirely is usually right — the default already
+sizes it so `max_steps` is what stops the run.
 
 Requested values are capped at the configured maxima — asking for 1M tokens
 gets the cap, not an error. Undersizing is the commoner mistake: a run that

--- a/humux/skills/subagent-orchestration.md
+++ b/humux/skills/subagent-orchestration.md
@@ -1,0 +1,166 @@
+# Subagent orchestration — split big work across parallel subagents, then synthesize
+
+You can delegate work to subagents: `spawn_subagent` runs one, `spawn_subagents`
+runs 2–6 in parallel. This skill is about *when* that is worth it and how to
+brief, size, and reassemble the runs.
+
+## When NOT to fan out
+
+Start here. A subagent is a full agent run: own system prompt, cold start, own
+tokens, and no knowledge of this conversation. Three quick web searches, two
+file reads, one API call — do those inline. Spawning for them costs more tokens
+and more wall-clock than doing the work yourself.
+
+Fan out when **both** hold: each subtask needs several tool calls and its own
+reading, and the subtasks are genuinely independent. If only one holds, do it
+inline or run a pipeline.
+
+## Independent vs dependent
+
+**Independent → `spawn_subagents`.** "Compare Postgres, MySQL and SQLite for
+this workload." Each is researched without knowing the others. One call, three
+tasks, all at once; wall-clock ≈ the slowest one.
+
+**Dependent → pipeline.** "Find the slowest endpoint, then optimize it." You
+cannot brief the optimizer before you know the endpoint. Spawn the profiler,
+read its result, *then* spawn the optimizer in a later step with the finding
+baked into the brief. Never fan out a chain — the later briefs would be blanks.
+
+## Writing a brief
+
+The subagent cannot see the conversation, your memory, or the user's last
+message. Everything it needs goes in `task`. Include:
+
+- **goal** — one sentence, what "done" means;
+- **inputs** — absolute paths, URLs, ids, versions. Never "the file we discussed";
+- **constraints** — what not to touch, time/source limits, tone;
+- **answer shape** — the exact structure you want back, since you will paste it
+  into a synthesis.
+
+> **Bad:** Look into the pricing thing and report back.
+
+> **Good:** Research current list pricing for Vercel Pro (goal). Use
+> vercel.com/pricing and the official docs only; ignore blogs (constraints).
+> Report: monthly base price, included bandwidth, overage price per GB, and the
+> date the page was last updated. Six lines max, no prose intro (shape).
+
+If a brief is hard to write self-contained, that is a signal the task is not
+independent — pipeline it.
+
+## Labels
+
+Always give every fan-out task a short distinctive `label`, 1–3 words:
+`pricing`, `docs-sweep`, `sqlite-bench`. It names the run in the logs and the
+admin UI — it is how four concurrent runs stay tellable apart. Derive it from
+the task's first words if nothing better comes to mind.
+
+## Sizing
+
+| Task shape | max_steps | token_budget | thinking_effort | model |
+|---|---|---|---|---|
+| Mechanical extraction (read file, pull fields) | 5–8 | 15k–25k | `off`/`low` | cheap fast model |
+| Focused web research, 3–6 sources | 10–15 | 30k–50k | `low` | cheap fast model |
+| Code reading + explanation across a module | 15–25 | 50k–80k | `medium` | parent's model |
+| Judgement, design, tradeoff analysis, review | 20–30 | 80k–120k | `high` | parent's model |
+
+Requested values are capped at the configured maxima — asking for 1M tokens
+gets the cap, not an error. Undersizing is the commoner mistake: a run that
+stops with `stopped_reason: max_steps` wasted everything it spent.
+
+## The patterns
+
+**Map** — same operation, many inputs.
+
+```jsonc
+{
+  "tasks": [
+    {"label": "auth-audit", "task": "Read /srv/app/auth.py; list every function touching a password or token, with line numbers. Bullets only.", "max_steps": 8, "thinking_effort": "low"},
+    {"label": "billing-audit", "task": "Read /srv/app/billing.py; list every function touching a password or token, with line numbers. Bullets only.", "max_steps": 8, "thinking_effort": "low"}
+  ]
+}
+```
+
+**Map-reduce** — same, but *you* are the reduce step. Fan out, then write the
+comparison yourself from the returned summaries. Do not spawn a child to
+synthesize; you already have every result in-turn.
+
+**Pipeline** — sequential, each brief built from the last result. Spawn step
+one, read it, then spawn step two with the finding baked in.
+
+```jsonc
+{
+  "task": "Profile /srv/app with `python -m cProfile` over the test suite at /srv/app/tests; report the 5 slowest functions with cumulative times. No fixes.",
+  "max_steps": 15,
+  "thinking_effort": "medium"
+}
+```
+
+**Verification pass** — the highest-value pattern and the most underused. After
+producing something substantial (a plan, a migration, a report, a refactor),
+spawn one fresh subagent whose only job is to check it against the original
+brief. Fresh context means no attachment to your reasoning and no memory of why
+you chose what you chose — it sees what the user will see.
+
+```jsonc
+{
+  "task": "Verify a deliverable. The original request was: 'migrate the settings module from JSON to TOML without changing the public API'. The work is at /srv/app/settings.py and /srv/app/settings.toml. Check: (1) every key present in the old JSON schema at /srv/app/settings.schema.json still exists, (2) the public function signatures are unchanged, (3) nothing else in /srv/app imports json for settings. Report only discrepancies, each with file and line. If there are none, say 'no discrepancies'.",
+  "max_steps": 12,
+  "thinking_effort": "high"
+}
+```
+
+Cheap, bounded, and it catches the class of error you are structurally blind to.
+Do it before handing anything consequential to the user.
+
+**Best-of-N** — same task to N subagents at different angles, then pick. Only
+when the user actually asked for options ("give me a few directions for the
+landing page"); otherwise it is N× the cost for one answer you must arbitrate.
+
+## Handing back big results
+
+Subagents share your filesystem. A child producing bulk output — a long report,
+extracted data, generated code — should write it to a file and return the
+absolute path plus a summary. Put that in the brief:
+
+> Write the full table to /srv/scratch/pricing.md and return only the absolute
+> path under a `Files:` line plus a 3-line summary.
+
+Then read the file only if you need the detail. Returning 20k tokens of body
+text through the result field burns your turn budget for no gain.
+
+## Partial failure
+
+Results are per-index and order is preserved. You will get 3-of-4. Read `status`
+on **every** entry, and `stopped_reason` on any that came back thin —
+`max_steps` or `token_budget` means truncated, not wrong-but-complete.
+
+For each failure: retry once with a larger budget if a cap caused it, work
+around it (do that piece inline), or tell the user which part is missing. Never
+synthesize as though you got everything — a comparison table with one silently
+guessed column is worse than a table with a visible gap.
+
+## Budgets
+
+Every spawn — singular, plural, and any nested subagent — draws from one shared
+pool for the whole turn: `max_spawns_per_turn` (default 12) and
+`turn_token_budget` (default 400000). Each run reserves its `token_budget` up
+front and refunds the unused part on completion — so a generous budget on a
+short task is cheap; generous budgets on many tasks are not.
+
+Two or three well-briefed subtasks beat six vague ones, every time. A spawn
+refused with a budget error is the signal to finish with what you have and tell
+the user what you skipped — not to retry the fan-out in smaller pieces until
+the pool drains. Note also that only `max_concurrent` (default 4) runs execute
+at once per chat, so a width-6 fan-out is two waves, not one.
+
+## Anti-patterns
+
+- **Nested fan-out.** `spawn_subagents` exists only at the top level; a child
+  can still `spawn_subagent` serially up to `recursion_depth` (default 3). If
+  you want a tree, flatten it into one top-level fan-out.
+- **Fanning out to dodge a hard problem.** Four confused children produce four
+  confused answers you then have to reconcile. Understand it first, then split.
+- **Spawning for something you have a direct tool for.** If one tool call
+  answers it, call the tool.
+- **Six near-identical briefs.** If they differ by one word, you wanted one
+  subagent with a list, or a loop you run yourself.

--- a/humux/skills/subagent-orchestration.md
+++ b/humux/skills/subagent-orchestration.md
@@ -154,7 +154,10 @@ Every spawn — singular, plural, and any nested subagent — draws from one sha
 pool for the whole turn: `max_spawns_per_turn` (default 12) and
 `turn_token_budget` (default 400000). Each run reserves its `token_budget` up
 front and refunds the unused part on completion — so a generous budget on a
-short task is cheap; generous budgets on many tasks are not.
+short task is cheap; generous budgets on many tasks are not. In a fan-out,
+prefer omitting `token_budget`: unsized tasks split the pool fairly. If you
+do size one, remember every round re-reads the prompt (10-20k tokens a
+round) — budgets under ~20k rarely finish real work.
 
 Two or three well-briefed subtasks beat six vague ones, every time. A spawn
 refused with a budget error is the signal to finish with what you have and tell

--- a/humux/tests/conftest.py
+++ b/humux/tests/conftest.py
@@ -34,6 +34,21 @@ def pytest_configure(config: pytest.Config) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run every test from its own tmp cwd.
+
+    Several stores default to cwd-relative SQLite paths (data/config.db,
+    data/agents.db, data/jobs.db). Tests that construct them bare — e.g. a
+    plain ``PermissionEngine()``, or an admin app with ``agent=None`` — used
+    to share ONE real file across pytest-xdist workers, which flaked with
+    "database is locked" on a loaded CI runner. A per-test cwd makes every
+    cwd-relative default hermetic; nothing in the suite reads repo files
+    relative to the cwd.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.fixture
 def agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AgentCore:  # noqa: F821
     """A bare AgentCore operating in tmp_path.

--- a/humux/tests/test_agents.py
+++ b/humux/tests/test_agents.py
@@ -295,3 +295,31 @@ async def test_delete_seeded_agent_does_not_reseed(tmp_path) -> None:
     await store.upsert(Agent(name="fitness-coach", role="Back"))
     assert (await store.get("fitness-coach")).role == "Back"
     assert [p.name for p in await store.list_agents()] == ["fitness-coach"]
+
+
+def _prompt(cfg, agent=None) -> str:
+    return build_prompt_sections(
+        config=cfg,
+        history_mode="injection",
+        skills_index="",
+        memories="",
+        reflections="",
+        decomposed_goal=None,
+        agent=agent,
+    ).full_prompt
+
+
+def test_delegation_block_present_and_gated() -> None:
+    """The tool schemas say HOW to spawn; the orchestration skill says WHEN — but
+    the model only reads that skill if it already suspects fan-out. This block is
+    the trigger, so it has to be in the prompt whenever spawning is possible."""
+    cfg = Config()
+    cfg.subagents.enabled = True
+    assert "<delegation>" in _prompt(cfg)
+
+    cfg.subagents.enabled = False
+    assert "<delegation>" not in _prompt(cfg)
+
+    cfg.subagents.enabled = True
+    walled_off = Agent(name="solo", tools=["bash"])  # allowlist without spawn_subagent
+    assert "<delegation>" not in _prompt(cfg, walled_off)

--- a/humux/tests/test_agents.py
+++ b/humux/tests/test_agents.py
@@ -56,6 +56,33 @@ def test_markdown_roundtrip() -> None:
     assert p2.character.strip() == "How."
 
 
+def test_spawnable_agents_roundtrip_and_coercion() -> None:
+    # Frontmatter list, plus the form-input shapes _as_list must coerce.
+    p = parse_markdown("---\nspawnable_agents: [qa, legal]\n---\n", name="boss")
+    assert p.spawnable_agents == ["qa", "legal"]
+    assert parse_markdown("---\nspawnable_agents: qa, legal\n---\n", name="b").spawnable_agents == [
+        "qa",
+        "legal",
+    ]
+    assert parse_markdown(
+        "---\nspawnable_agents: |\n  qa\n  legal\n---\n", name="b"
+    ).spawnable_agents == ["qa", "legal"]
+    assert parse_markdown("---\nrole: X\n---\n", name="b").spawnable_agents == []  # absent = []
+    # Survives the markdown round-trip.
+    back = parse_markdown(to_markdown(p), name="boss")
+    assert back.spawnable_agents == ["qa", "legal"]
+
+
+@pytest.mark.asyncio
+async def test_store_roundtrips_spawnable_agents(tmp_path) -> None:
+    store = AgentStore(db_path=str(tmp_path / "p.db"), seed_dir=tmp_path / "missing")
+    await store.upsert(Agent(name="boss", spawnable_agents=["qa", "legal"]))
+    assert (await store.get("boss")).spawnable_agents == ["qa", "legal"]
+    # Clearing the team sticks (upsert overwrites, not merges).
+    await store.upsert(Agent(name="boss", spawnable_agents=[]))
+    assert (await store.get("boss")).spawnable_agents == []
+
+
 def test_allow_semantics() -> None:
     blank = Agent(name="d")  # empty allowlists = everything
     assert blank.allows_skill("anything") and blank.allows_tool("anything")

--- a/humux/tests/test_github_app.py
+++ b/humux/tests/test_github_app.py
@@ -264,7 +264,9 @@ def test_narrow_gh_repos_disjoint_blocks_not_widens() -> None:
     # NOT "unrestricted". Narrowing yields an empty list, and the gate blocks.
     parent = Agent(name="p", tool_config={"gh": {"enabled": True, "repos": ["me/a"]}})
     narrowed = _narrow_gh_repos(parent, {"gh": {"enabled": True, "repos": ["me/evil"]}})
-    assert narrowed["gh"]["repos"] == []
+    # narrow_scope returns a match-nothing sentinel for disjoint scopes
+    # ("[]" would mean *all* for tools/skills); for repos either value blocks.
+    assert narrowed["gh"]["repos"] == ["__nothing__"]
     child = Agent(name="c", tool_config=narrowed)
     assert github_repo_violation(child, "gh issue create --repo other/xyz") == "other/xyz"
 

--- a/humux/tests/test_inspect_admin.py
+++ b/humux/tests/test_inspect_admin.py
@@ -4,7 +4,8 @@ and the last-sent LLM payload view (#99)."""
 from __future__ import annotations
 
 import asyncio
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 
 from fastapi.testclient import TestClient
 
@@ -12,6 +13,7 @@ from api.admin import AgentState, create_admin_app
 from core import llm
 from core.config_store import ConfigStore
 from core.history import ConversationHistory
+from core.subagents import SubagentRun
 
 AUTH = {"Authorization": "Bearer secret"}
 
@@ -200,6 +202,50 @@ def test_inspect_payload_empty_for_uncaptured_context(tmp_path) -> None:
     )
     assert r.status_code == 200
     assert "No payload captured yet" in r.text
+
+
+# ── Live subagent runs panel (moved from the Jobs tab) ──────────────────────
+
+
+def _runs_client(tmp_path, runs) -> TestClient:
+    agent = SimpleNamespace(subagents=SimpleNamespace(list_runs=lambda: runs))
+    app, _ = create_admin_app(
+        AgentState(agent=cast(Any, agent)), cast(ConfigStore, _Store(tmp_path))
+    )
+    return TestClient(app)
+
+
+def test_inspect_partial_hosts_runs_panel_with_per_context_filter(tmp_path) -> None:
+    asyncio.run(_seed(tmp_path))
+    r = _client(tmp_path).get("/partials/inspect", headers=AUTH)
+    assert r.status_code == 200
+    assert 'id="subagent-runs"' in r.text  # panel lives in Inspect now
+    # Each main context row filters the panel to its own channel + chat.
+    assert "/partials/subagent-runs?channel=telegram&chat_id=c1" in r.text
+
+
+def test_subagent_runs_filtered_by_channel_and_chat(tmp_path) -> None:
+    runs = [
+        SubagentRun(
+            run_id="r1", agent="a", task="mine", origin_channel="telegram", origin_chat_id="c1"
+        ),
+        SubagentRun(
+            run_id="r2", agent="a", task="theirs", origin_channel="telegram", origin_chat_id="c2"
+        ),
+    ]
+    client = _runs_client(tmp_path, runs)
+    both = client.get("/partials/subagent-runs", headers=AUTH)
+    assert "mine" in both.text and "theirs" in both.text
+    assert "show all" not in both.text  # no reset link while unfiltered
+
+    one = client.get(
+        "/partials/subagent-runs", params={"channel": "telegram", "chat_id": "c1"}, headers=AUTH
+    )
+    assert one.status_code == 200
+    assert "mine" in one.text and "theirs" not in one.text
+    assert "show all" in one.text  # reset link shown while filtered
+    # The filter is echoed into the panel's own poll URL, so it survives refreshes.
+    assert "chat_id=c1" in one.text
 
 
 def test_config_requires_restart_flags_startup_only_keys() -> None:

--- a/humux/tests/test_inspect_admin.py
+++ b/humux/tests/test_inspect_admin.py
@@ -76,7 +76,7 @@ def test_inspect_partial_lists_active_contexts(tmp_path) -> None:
 
 def test_capture_records_per_context_and_suppresses_when_unset() -> None:
     llm.clear_captured()
-    ctx = ("telegram", "u1", "c1")
+    ctx = ("telegram", "u1", "c1", "")
     tok = llm.set_capture_context(ctx)
     try:
         llm.record_sent_payload(llm._capture_ctx.get(), {"model": "m", "messages": [], "tools": []})
@@ -93,10 +93,10 @@ def test_capture_lru_evicts_oldest() -> None:
     llm.clear_captured()
     cap = llm._CAPTURE_CAP
     for i in range(cap + 5):
-        llm.record_sent_payload(("c", "u", str(i)), {"model": str(i)})
+        llm.record_sent_payload(("c", "u", str(i), ""), {"model": str(i)})
     assert len(llm._LAST_SENT) == cap
-    assert llm.get_sent_payload(("c", "u", "0")) is None  # oldest evicted
-    assert llm.get_sent_payload(("c", "u", str(cap + 4))) is not None
+    assert llm.get_sent_payload(("c", "u", "0", "")) is None  # oldest evicted
+    assert llm.get_sent_payload(("c", "u", str(cap + 4), "")) is not None
     llm.clear_captured()
 
 
@@ -105,7 +105,7 @@ def test_inspect_payload_renders_captured_request(tmp_path) -> None:
     client = _client(tmp_path)
     llm.clear_captured()
     llm.record_sent_payload(
-        ("telegram", "u1", "c1"),
+        ("telegram", "u1", "c1", ""),
         {
             "captured_at": 1_700_000_000.0,
             "provider": "anthropic",
@@ -137,7 +137,7 @@ def test_inspect_payload_shows_context_usage_and_percent(tmp_path) -> None:
     client = _client(tmp_path)
     llm.clear_captured()
     llm.record_sent_payload(
-        ("telegram", "u1", "c1"),
+        ("telegram", "u1", "c1", ""),
         {
             "captured_at": 1_700_000_000.0,
             "provider": "anthropic",
@@ -168,7 +168,7 @@ def test_inspect_payload_omits_usage_when_absent(tmp_path) -> None:
     client = _client(tmp_path)
     llm.clear_captured()
     llm.record_sent_payload(
-        ("telegram", "u1", "c1"),
+        ("telegram", "u1", "c1", ""),
         {
             "captured_at": 1_700_000_000.0,
             "provider": "x",

--- a/humux/tests/test_inspect_admin.py
+++ b/humux/tests/test_inspect_admin.py
@@ -204,6 +204,26 @@ def test_inspect_payload_empty_for_uncaptured_context(tmp_path) -> None:
     assert "No payload captured yet" in r.text
 
 
+def test_subagent_context_row_is_named_by_its_run(tmp_path) -> None:
+    """A captured subagent payload is listed by the run's label and task — a bare
+    run id makes every row of a fan-out look identical."""
+    llm.clear_captured()
+    llm.record_sent_payload(("telegram", "u1", "c1", "sub_1"), {"model": "m"})
+    run = SubagentRun(
+        run_id="sub_1",
+        agent="clio",
+        task="research competitor logos",
+        label="logo-research",
+        origin_channel="telegram",
+        origin_chat_id="c1",
+    )
+    r = _runs_client(tmp_path, [run]).get("/partials/inspect", headers=AUTH)
+    llm.clear_captured()
+    assert r.status_code == 200
+    assert "logo-research" in r.text
+    assert "research competitor logos" in r.text
+
+
 # ── Live subagent runs panel (moved from the Jobs tab) ──────────────────────
 
 

--- a/humux/tests/test_llm.py
+++ b/humux/tests/test_llm.py
@@ -141,7 +141,7 @@ async def test_generate_backfills_usage_into_captured_payload() -> None:
     client._client = type("C", (), {"messages": type("M", (), {"create": create})()})()
 
     llm.clear_captured()
-    ctx = ("telegram", "u1", "c1")
+    ctx = ("telegram", "u1", "c1", "")
     tok = llm.set_capture_context(ctx)
     try:
         await client.generate(model="claude-opus-4-8", system="s", messages=[], tools=[])
@@ -150,6 +150,32 @@ async def test_generate_backfills_usage_into_captured_payload() -> None:
     captured = llm.get_sent_payload(ctx)
     assert captured is not None
     assert captured["usage"]["context_tokens"] == 2000  # 1200 input + 800 cache read
+    llm.clear_captured()
+
+
+def test_list_captured_is_newest_first() -> None:
+    llm.clear_captured()
+    for i in range(3):
+        llm.record_sent_payload(("cli", "u", "c", f"sub_{i}"), {"model": str(i)})
+    assert llm.list_captured() == [
+        ("cli", "u", "c", "sub_2"),
+        ("cli", "u", "c", "sub_1"),
+        ("cli", "u", "c", "sub_0"),
+    ]
+    llm.clear_captured()
+
+
+def test_capture_run_id_is_a_separate_slot_from_the_main_turn() -> None:
+    """A subagent's payload is keyed by its run id, so it can't clobber the
+    parent turn's last-sent payload (#99 + fan-out)."""
+    llm.clear_captured()
+    main = ("telegram", "u1", "c1", "")
+    child = ("telegram", "u1", "c1", "sub_abc")
+    llm.record_sent_payload(main, {"model": "parent"})
+    llm.record_sent_payload(child, {"model": "child"})
+    assert llm.get_sent_payload(main)["model"] == "parent"
+    assert llm.get_sent_payload(child)["model"] == "child"
+    assert llm.list_captured()[0] == child  # newest first
     llm.clear_captured()
 
 

--- a/humux/tests/test_permissions.py
+++ b/humux/tests/test_permissions.py
@@ -405,6 +405,30 @@ def test_format_approval_message_truncates_huge_command() -> None:
     assert "…" in text
 
 
+def test_format_approval_message_spawn_subagent_names_the_agent() -> None:
+    # A subagent runs autonomously afterwards, so this prompt is the only human
+    # gate on the whole run — it must say WHO runs and WHAT.
+    engine = PermissionEngine()
+    text = engine.format_approval_message(
+        "spawn_subagent", {"agent": "qa", "task": "review the pending diff"}
+    )
+    assert "qa" in text
+    assert "review the pending diff" in text
+    # No agent named → the spawn runs as the caller itself.
+    assert "runs as itself" in engine.format_approval_message("spawn_subagent", {"task": "x"})
+
+
+def test_format_approval_message_spawn_subagents_lists_every_task() -> None:
+    engine = PermissionEngine()
+    text = engine.format_approval_message(
+        "spawn_subagents",
+        {"tasks": [{"task": "check prices", "agent": "shopper"}, {"task": "draft the email"}]},
+    )
+    assert "2 subtasks" in text
+    assert "check prices" in text and "→ shopper" in text
+    assert "draft the email" in text  # unassigned subtask still listed, with no arrow
+
+
 def test_readonly_unix_commands_are_default_always() -> None:
     # #148: fresh agent runs common read-only commands without a prompt.
     engine = PermissionEngine()

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -240,10 +240,10 @@ async def test_background_subagent_notifies_user_digests_context(agent, monkeypa
     await run._task
 
     assert run.status == "done"
-    # Chat: ONLY the one-line NOTIFICATION — no per-run completion note (the
-    # last/only finisher's note is suppressed; the digest speaks for it), and
-    # never the raw output.
-    assert _sent(channel) == ["Cheapest is CHF 599."]
+    # Chat: the spawn note, then ONLY the one-line NOTIFICATION — no per-run
+    # completion note (the last/only finisher's note is suppressed; the digest
+    # speaks for it), and never the raw output.
+    assert _sent(channel) == ["🧬 Spawned subagent price check", "Cheapest is CHF 599."]
     # Context: the concise digest is kept (merged), the raw output never is.
     turns = await agent.history.get_messages("telegram", "u1", "555")
     blob = str(turns[-1]["content"])
@@ -934,6 +934,9 @@ async def test_fanout_child_completion_notes(agent, monkeypatch) -> None:
         notes = [t for t in _sent(channel) if t.startswith(f"✅ Subagent {label} ")]
         assert len(notes) == 1, notes
         assert "done" in notes[0]
+    # No per-child spawn notes: the group 🧩 note already named every label.
+    assert not [t for t in _sent(channel) if t.startswith("🧬")]
+    assert len([t for t in _sent(channel) if t.startswith("🧩")]) == 1
     # Notification only: nothing reached the conversation history.
     msgs = await agent.history.get_messages("cli", "u", "c1")
     assert not any("Subagent" in str(m.get("content", "")) for m in msgs)
@@ -958,11 +961,13 @@ async def test_fanout_failed_child_notes_the_failure(agent, monkeypatch) -> None
     sent = _sent(channel)
     assert [t for t in sent if "bad" in t and "failed" in t]
     assert [t for t in sent if "good" in t and "done" in t]
+    assert not [t for t in sent if t.startswith("🧬")]  # group note only
 
 
 @pytest.mark.asyncio
 async def test_fast_sync_spawn_posts_no_completion_note(agent) -> None:
-    """A sync result lands in the very next reply — a 0s run needs no note."""
+    """A sync result lands in the very next reply — a 0s run needs no note.
+    The spawn note still goes out, so the user knows what started."""
     channel = AsyncMock()
     agent.channels["cli"] = channel
     agent.llm = _ScriptedLLM([LLMResponse(text="quick", tool_calls=[])])
@@ -970,7 +975,58 @@ async def test_fast_sync_spawn_posts_no_completion_note(agent) -> None:
     res = await agent.run_subagent(task="x", origin_channel="cli", origin_chat_id="c1")
 
     assert res["ok"] is True
-    assert not [t for t in _sent(channel) if "Subagent" in t]
+    assert _sent(channel) == ["🧬 Spawned subagent x"]
+
+
+@pytest.mark.asyncio
+async def test_spawn_note_names_the_target_agent(agent) -> None:
+    """When the run targets a named agent, the note says which."""
+    channel = AsyncMock()
+    agent.channels["cli"] = channel
+    await agent.agents.upsert(Agent(name="qa", role="Reviews changes"))
+    agent.llm = _ScriptedLLM([LLMResponse(text="ok", tool_calls=[])])
+
+    await agent.run_subagent(
+        task="pricing", agent_name="qa", origin_channel="cli", origin_chat_id="c1"
+    )
+
+    assert _sent(channel) == ["🧬 Spawned subagent pricing (as qa)"]
+
+
+@pytest.mark.asyncio
+async def test_nested_spawn_note_names_parent_and_child(agent) -> None:
+    """A subagent spawning a subagent announces itself in the origin chat too —
+    the run tree stays visible (and cancellable) as it grows."""
+    channel = AsyncMock()
+    agent.channels["cli"] = channel
+    nested = LLMToolCall(id="1", name="spawn_subagent", arguments={"task": "check stock"})
+    agent.llm = _ScriptedLLM(
+        [
+            LLMResponse(text="", tool_calls=[nested]),  # the parent run delegates
+            LLMResponse(text="in stock", tool_calls=[]),  # the nested child answers
+            LLMResponse(text="all good", tool_calls=[]),  # the parent wraps up
+        ]
+    )
+
+    res = await agent.run_subagent(task="price check", origin_channel="cli", origin_chat_id="c1")
+
+    assert res["ok"] is True
+    assert _sent(channel) == [
+        "🧬 Spawned subagent price check",
+        "🧬 price check spawned subagent check stock",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sync_spawn_without_chat_posts_nothing(agent) -> None:
+    """A system/scheduler run has no chat to announce into."""
+    channel = AsyncMock()
+    agent.channels["system"] = channel
+    agent.llm = _ScriptedLLM([LLMResponse(text="ok", tool_calls=[])])
+
+    await agent.run_subagent(task="x", origin_channel="system", origin_chat_id="")
+
+    channel.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -43,7 +43,9 @@ def test_narrow_scope_child_unspecified_inherits_parent() -> None:
 def test_narrow_scope_both_restricted_is_intersection() -> None:
     # The child can never gain a name the parent lacks.
     assert narrow_scope(["a", "b"], ["b", "c"]) == ["b"]
-    assert narrow_scope(["a"], ["b"]) == []
+    # Disjoint non-empty scopes stay restrictive: [] would mean "all", so the
+    # empty intersection becomes a sentinel that matches nothing.
+    assert narrow_scope(["a"], ["b"]) == ["__nothing__"]
 
 
 def test_narrow_scope_both_empty_stays_all() -> None:
@@ -395,6 +397,15 @@ def test_finish_does_not_overwrite_terminal_state() -> None:
     assert reg.get("a").result == ""
 
 
+def test_narrow_agent_keeps_the_trust_list(agent) -> None:
+    # The delegation trust list is a per-identity grant: an anonymous child runs
+    # AS the caller and must keep the caller's team — dropping it would let the
+    # child escape into the legacy any-agent regime.
+    parent = Agent(name="boss", tools=["a"], spawnable_agents=["qa"])
+    child = agent._narrow_agent(parent, {"agent_obj": parent})
+    assert child.spawnable_agents == ["qa"]
+
+
 def test_narrow_agent_intersects_scopes(agent) -> None:
     parent = Agent(name="p", skills=["s1", "s2"], tools=["a", "b"], secrets=["x"])
     requested = Agent(name="child", skills=[], tools=["b", "c"], secrets=["y"])
@@ -402,7 +413,8 @@ def test_narrow_agent_intersects_scopes(agent) -> None:
     assert child.name == "child"
     assert child.skills == ["s1", "s2"]  # child unspecified → inherits parent
     assert child.tools == ["b"]  # intersection, never 'c'
-    assert child.secrets == []  # 'y' not in parent's ['x']
+    # 'y' not in parent's ['x'] → restrictive sentinel, never [] (= all)
+    assert child.secrets == ["__nothing__"]
 
 
 def test_subagent_status_note_lists_only_running_runs(agent) -> None:
@@ -896,13 +908,16 @@ async def test_subagent_loop_is_not_offered_the_fanout_tool(agent) -> None:
             self.offered.append({t["name"] for t in tools})
             return await super().generate()
 
+    agent.config.tools.imagegen.enabled = True
     agent.llm = _ToolCapturingLLM([LLMResponse(text="ok", tool_calls=[])])
     await agent.run_subagent(task="x")
 
     offered = agent.llm.offered[0]
     assert "spawn_subagents" not in offered
     assert "spawn_subagent" in offered  # depth 1 < recursion_depth, so still allowed
-    assert "generate_image" not in offered
+    # #55 follow-up: the generate_image strip is gone — a subagent may draw and
+    # hands the file back by path (see the Files: note below).
+    assert "generate_image" in offered
 
 
 # ---------------------------------------------------------------------------
@@ -1057,6 +1072,152 @@ def test_legacy_spawn_subagent_allowlist_also_gets_the_plural(agent) -> None:
     assert "spawn_subagents" not in {
         t["name"] for t in agent._tools_for_turn(Agent(name="x", tools=["web_search"]))
     }
+
+
+# ---------------------------------------------------------------------------
+# Delegation trust list (spawnable_agents): a curated team is a capability
+# handoff — listed agents run verbatim, unlisted ones are refused.
+# ---------------------------------------------------------------------------
+
+QA_ACCOUNTS = [{"account": "qa-inbox", "access_level": "read_write"}]
+
+
+async def _seed_qa(agent) -> Agent:
+    """A specialist with tools and an account the parent below does NOT have."""
+    qa = Agent(
+        name="qa", role="Reviews changes", tools=["read", "edit"], email_accounts=QA_ACCOUNTS
+    )
+    await agent.agents.upsert(qa)
+    return qa
+
+
+@pytest.mark.asyncio
+async def test_spawn_off_the_trust_list_is_refused(agent) -> None:
+    parent = Agent(name="boss", tools=["web_search", "spawn_subagent"], spawnable_agents=["qa"])
+    await _seed_qa(agent)
+
+    out = await agent._prepare_subagent_run(
+        task="t", agent_name="legal", parent_state=agent._new_request_state(parent)
+    )
+
+    assert "may only delegate to" in out["error"]
+    assert "qa" in out["error"]
+    assert agent.subagents.list_runs() == []  # refused before anything was registered
+
+
+@pytest.mark.asyncio
+async def test_listed_teammate_runs_with_its_own_capabilities(agent) -> None:
+    """The list IS the trust grant: a named teammate is NOT intersected down to
+    the parent's scope, it runs as itself (tools, skills, accounts)."""
+    parent = Agent(name="boss", tools=["web_search", "spawn_subagent"], spawnable_agents=["qa"])
+    await _seed_qa(agent)
+
+    run, child, state = await agent._prepare_subagent_run(
+        task="t", agent_name="qa", parent_state=agent._new_request_state(parent)
+    )
+
+    assert run.agent == "qa"
+    assert child.tools == ["read", "edit"]  # verbatim — the intersection would be empty
+    # Its own account grant is kept; narrowing against a parent with none ([])
+    # would have stripped it.
+    assert [e["account"] for e in child.email_accounts] == ["qa-inbox"]
+    assert state["depth"] == 1
+
+
+@pytest.mark.asyncio
+async def test_no_trust_list_still_narrows_to_the_intersection(agent) -> None:
+    """Legacy behaviour is intact: with no curated team any agent may be named,
+    scoped down to what the caller itself has (inherit-never-widen)."""
+    parent = Agent(name="boss", tools=["read", "web_search"])  # spawnable_agents empty
+    await _seed_qa(agent)
+
+    run, child, _ = await agent._prepare_subagent_run(
+        task="t", agent_name="qa", parent_state=agent._new_request_state(parent)
+    )
+
+    assert run.agent == "qa"
+    assert child.tools == ["read"]  # intersection, never 'edit'
+    assert child.email_accounts == []  # parent has none → the child gets none
+
+
+@pytest.mark.asyncio
+async def test_anonymous_spawn_still_runs_as_the_parent(agent) -> None:
+    """A trust list changes only *named* spawns — omitting 'agent' is unchanged."""
+    parent = Agent(name="boss", tools=["web_search", "spawn_subagent"], spawnable_agents=["qa"])
+    await _seed_qa(agent)
+
+    run, child, _ = await agent._prepare_subagent_run(
+        task="t", parent_state=agent._new_request_state(parent)
+    )
+
+    assert run.agent == "boss"
+    assert child.tools == ["web_search", "spawn_subagent"]
+    assert child.email_accounts == []
+
+
+@pytest.mark.asyncio
+async def test_fanout_refuses_only_the_off_team_subtask(agent, monkeypatch) -> None:
+    """The trust list is enforced per index in the plural tool: the unlisted
+    agent's subtask errors, the listed sibling still runs."""
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+    await _seed_qa(agent)
+    parent = Agent(name="boss", tools=["web_search", "spawn_subagent"], spawnable_agents=["qa"])
+    state = agent._new_request_state(
+        parent, origin={"channel": "cli", "user_id": "u", "chat_id": "c1"}
+    )
+
+    out = await agent._tool_spawn_subagents(
+        {"tasks": [{"task": "a", "agent": "qa"}, {"task": "b", "agent": "legal"}]},
+        "cli",
+        "u",
+        state,
+    )
+
+    assert [r["status"] for r in out["results"]] == ["done", "error"]
+    assert "may only delegate to" in out["results"][1]["error"]
+    assert out["succeeded"] == 1 and out["failed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_roster_with_a_team_lists_only_teammates(agent, monkeypatch) -> None:
+    roster = [Agent(name="me", role="r0"), Agent(name="qa", role="r1"), Agent(name="legal")]
+    monkeypatch.setattr(agent.agents, "list_agents", AsyncMock(return_value=roster))
+
+    block = await agent._agents_roster_block(Agent(name="me", role="r0", spawnable_agents=["qa"]))
+    assert "- me (you) — r0" in block  # self stays, so anonymous spawns still make sense
+    assert "- qa — r1" in block
+    assert "legal" not in block
+    assert "may not name agents outside this list" in block
+
+    # No team → the old, deliberately restrictive guidance.
+    plain = await agent._agents_roster_block(Agent(name="me", role="r0"))
+    assert "ONLY so you can honour an explicit request" in plain
+    assert "legal" in plain  # the whole roster is visible again
+
+
+# ---------------------------------------------------------------------------
+# generate_image in a subagent — no delivery path, so the path IS the handoff
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_image_note_branches_on_subagent_depth(agent, monkeypatch) -> None:
+    agent.config.tools.imagegen.enabled = True
+
+    async def fake_generate(_config, _prompt, _size):
+        return b"PNG", "image/png"
+
+    monkeypatch.setattr("core.agent.imagegen.generate", fake_generate)
+
+    top = await agent._tool_generate_image({"prompt": "a cat"}, agent._new_request_state(None))
+    assert top["ok"] is True
+    assert "queued for delivery" in top["note"]
+
+    child = await agent._tool_generate_image(
+        {"prompt": "a cat"}, agent._new_request_state(None, depth=1)
+    )
+    assert "Files:" in child["note"]  # the spawner delivers it from the path
+    assert "queued for delivery" not in child["note"]
 
 
 def test_derive_label_prefers_the_model_label_then_the_task() -> None:

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -4,6 +4,7 @@ scheduled-job wiring (issue #15)."""
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -921,23 +922,23 @@ async def test_subagent_loop_is_not_offered_the_fanout_tool(agent) -> None:
 
 
 # ---------------------------------------------------------------------------
-# FanoutBudget — one reserve-then-refund pool per turn, shared by the whole tree
+# FanoutBudget — one charge-as-you-go pool per turn, shared by the whole tree
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_fanout_token_pool_starts_only_what_fits(agent, monkeypatch) -> None:
+async def test_fanout_never_refused_for_tokens_upfront(agent, monkeypatch) -> None:
+    """Nothing is reserved, so a small pool never refuses a spawn up front — the
+    whole group starts and runs stop between rounds once the pool drains."""
     agent.config.subagents.turn_token_budget = 2500
-    agent.config.subagents.token_budget = 1000  # keep the pool at 2500 (max() floor)
+    agent.config.subagents.token_budget = 1000
     _install_overlap_loop(agent, monkeypatch, delay=0.0)
     tasks = [{"task": f"t{i}", "label": f"l{i}", "token_budget": 1000} for i in range(3)]
 
     out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
 
-    assert out["succeeded"] == 2 and out["failed"] == 1
-    refused = out["results"][2]
-    assert refused["status"] == "error"
-    assert "tokens" in refused["error"] and "left this turn" in refused["error"]
+    assert out["succeeded"] == 3 and out["failed"] == 0
+    assert {r["status"] for r in out["results"]} == {"done"}
 
 
 @pytest.mark.asyncio
@@ -964,10 +965,11 @@ async def test_fanout_spawn_pool_is_shared_across_spawns_in_one_turn(agent, monk
 
 
 @pytest.mark.asyncio
-async def test_completed_run_refunds_its_unspent_reservation(agent) -> None:
-    """Reserve the full budget up front, hand back what the run didn't spend."""
+async def test_pool_is_charged_actual_spend(agent) -> None:
+    """Spend is charged as it happens: the pool drops by what the run really
+    used, never by its (much larger) per-run ceiling."""
     agent.config.subagents.turn_token_budget = 50_000
-    agent.config.subagents.token_budget = 5000  # keep the pool at 50k (max() floor)
+    agent.config.subagents.token_budget = 5000
     agent.llm = _ScriptedLLM(
         [LLMResponse(text="done", tool_calls=[], usage={"input_tokens": 30, "output_tokens": 20})]
     )
@@ -977,38 +979,61 @@ async def test_completed_run_refunds_its_unspent_reservation(agent) -> None:
 
     assert res["ok"] is True
     budget = state["fanout_budget"]
-    assert budget.tokens_left == 50_000 - 50  # 5000 reserved, 4950 refunded
+    assert budget.tokens_left == 50_000 - 50  # the 5000 ceiling is never taken
     assert budget.spawns_left == agent.config.subagents.max_spawns_per_turn - 1
 
 
 @pytest.mark.asyncio
-async def test_fanout_unsized_tasks_share_the_pool(agent, monkeypatch) -> None:
-    """Omitted token_budgets split the pool across the width instead of each
-    demanding the full per-run ceiling (which would refuse most of the group
-    whenever ceiling × width exceeds the pool)."""
-    agent.config.subagents.token_budget = 100_000
-    agent.config.subagents.turn_token_budget = 150_000
-    _install_overlap_loop(agent, monkeypatch, delay=0.0)
-    tasks = [{"task": f"t{i}", "label": f"l{i}"} for i in range(3)]
+async def test_run_bigger_than_the_pool_still_starts(agent) -> None:
+    """An owner who raised token_budget past turn_token_budget (the per-run knob
+    predates the pool) still gets their unsized spawn — nothing is reserved, so
+    there is no upfront refusal to trip over."""
+    agent.config.subagents.token_budget = 500_000
+    agent.config.subagents.turn_token_budget = 400_000
+    agent.llm = _ScriptedLLM(
+        [LLMResponse(text="done", tool_calls=[], usage={"input_tokens": 10, "output_tokens": 5})]
+    )
+    state = _fanout_state(agent)
 
-    out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+    res = await agent.run_subagent(task="x", parent_state=state)
 
-    assert out["succeeded"] == 3
-    for row in out["results"]:
-        assert agent.subagents.get(row["run_id"]).token_budget == 50_000
+    assert res["ok"] is True and res["stopped_reason"] == "complete"
+    assert state["fanout_budget"].tokens_left == 400_000 - 15
 
 
 @pytest.mark.asyncio
-async def test_pool_is_never_smaller_than_one_default_run(agent) -> None:
-    """An owner who raised token_budget past turn_token_budget (the per-run
-    knob predates the pool) must still be able to run one unsized spawn."""
-    agent.config.subagents.token_budget = 500_000
-    agent.config.subagents.turn_token_budget = 400_000
-    agent.llm = _ScriptedLLM([LLMResponse(text="done", tool_calls=[])])
+async def test_drained_pool_stops_the_run_between_rounds(agent) -> None:
+    """The shared pool, not the run's own ceiling, ends the loop — and says so."""
+    agent.config.subagents.turn_token_budget = 100
+    agent.config.subagents.max_steps = 10
+    call = LLMToolCall(id="1", name="web_search", arguments={"query": "q"})
+    agent.llm = _ScriptedLLM(
+        [
+            LLMResponse(text="", tool_calls=[call], usage={"input_tokens": 80, "output_tokens": 0})
+            for _ in range(10)
+        ]
+    )
+    state = _fanout_state(agent)
 
-    res = await agent.run_subagent(task="x")
+    res = await agent.run_subagent(task="loop", token_budget=100_000, parent_state=state)
 
     assert res["ok"] is True
+    assert res["stopped_reason"] == "turn_budget"
+    assert "turn's subagent token budget" in res["result"]
+    assert res["steps"] == 1  # round one always runs, then the drained pool stops it
+    assert state["fanout_budget"].exhausted
+
+
+@pytest.mark.asyncio
+async def test_spawn_on_an_exhausted_pool_is_refused(agent) -> None:
+    """Once the pool IS dry, no further spawn starts (the only token refusal)."""
+    state = _fanout_state(agent)
+    agent._turn_budget(state).charge(agent.config.subagents.turn_token_budget)
+
+    res = await agent.run_subagent(task="x", parent_state=state)
+
+    assert "token budget is exhausted" in res["error"]
+    assert agent.subagents.list_runs() == []  # refused before anything ran
 
 
 @pytest.mark.asyncio
@@ -1249,12 +1274,48 @@ async def test_roster_with_a_team_lists_only_teammates(agent, monkeypatch) -> No
 
 
 # ---------------------------------------------------------------------------
-# generate_image in a subagent — no delivery path, so the path IS the handoff
+# Media from a subagent: a sync child rides the parent turn's attachments; an
+# orphaned (background/nested) one hands the file back by path instead.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_generate_image_note_branches_on_subagent_depth(agent, monkeypatch) -> None:
+async def test_sync_child_shares_the_parent_turns_attachments(agent) -> None:
+    state = _fanout_state(agent)
+
+    _, _, child_state = await agent._prepare_subagent_run(task="t", parent_state=state)
+
+    # The SAME list object, so anything the child queues rides out on the reply.
+    assert child_state["pending_attachments"] is state["pending_attachments"]
+    assert child_state["attachments_reach_user"] is True
+
+
+@pytest.mark.asyncio
+async def test_background_child_never_shares_attachments(agent) -> None:
+    state = _fanout_state(agent)
+
+    _, _, child_state = await agent._prepare_subagent_run(
+        task="t", parent_state=state, background=True
+    )
+
+    assert child_state["pending_attachments"] is not state["pending_attachments"]
+    assert child_state["pending_attachments"] == []
+    assert child_state.get("attachments_reach_user") is None
+
+
+@pytest.mark.asyncio
+async def test_child_of_an_orphaned_run_stays_orphaned(agent) -> None:
+    """A parent whose own media can't reach the user can't hand a path down."""
+    orphan = agent._new_request_state(None, depth=1)  # no attachments_reach_user
+
+    _, _, child_state = await agent._prepare_subagent_run(task="t", parent_state=orphan)
+
+    assert child_state["pending_attachments"] is not orphan["pending_attachments"]
+    assert child_state.get("attachments_reach_user") is None
+
+
+@pytest.mark.asyncio
+async def test_generate_image_note_branches_on_delivery_reach(agent, monkeypatch) -> None:
     agent.config.tools.imagegen.enabled = True
 
     async def fake_generate(_config, _prompt, _size):
@@ -1265,12 +1326,22 @@ async def test_generate_image_note_branches_on_subagent_depth(agent, monkeypatch
     top = await agent._tool_generate_image({"prompt": "a cat"}, agent._new_request_state(None))
     assert top["ok"] is True
     assert "queued for delivery" in top["note"]
+    assert os.path.isabs(top["path"])  # a relative path is unfindable from a subagent
 
-    child = await agent._tool_generate_image(
+    # A sync child sharing the turn's attachments delivers natively, like the top.
+    shared = agent._new_request_state(None, depth=1)
+    shared["attachments_reach_user"] = True
+    child = await agent._tool_generate_image({"prompt": "a cat"}, shared)
+    assert "queued for delivery" in child["note"]
+    assert len(shared["pending_attachments"]) == 1
+
+    # Orphaned (background / nested): the absolute path IS the handoff.
+    orphan = await agent._tool_generate_image(
         {"prompt": "a cat"}, agent._new_request_state(None, depth=1)
     )
-    assert "Files:" in child["note"]  # the spawner delivers it from the path
-    assert "queued for delivery" not in child["note"]
+    assert "Files:" in orphan["note"]
+    assert "queued for delivery" not in orphan["note"]
+    assert os.path.isabs(orphan["path"])
 
 
 def test_derive_label_prefers_the_model_label_then_the_task() -> None:

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -3,6 +3,8 @@ scheduled-job wiring (issue #15)."""
 
 from __future__ import annotations
 
+import asyncio
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -16,6 +18,7 @@ from core.subagents import (
     FILE_HANDOFF_INSTRUCTION,
     SubagentRegistry,
     SubagentRun,
+    derive_label,
     narrow_scope,
     normalize_effort,
     resolve_cap,
@@ -345,11 +348,22 @@ async def test_summarize_batch_calls_llm_and_parses() -> None:
 
 @pytest.mark.asyncio
 async def test_run_subagent_background_respects_concurrency(agent) -> None:
+    """Background refuses (never queues) when the *chat* is at its slot cap —
+    the gate counts runs actually executing, not merely registered."""
     agent.config.subagents.max_concurrent = 1
-    # Pre-fill one running slot.
-    agent.subagents.register(SubagentRun(run_id="busy", agent="", task="t"))
-    result = await agent.run_subagent(task="x", background=True)
-    assert "concurrent" in result["error"].lower() or "max" in result["error"].lower()
+    chat_key = agent._subagent_chat_key("telegram", "c1")
+    async with agent.subagents.slot(chat_key, lambda: 1):
+        assert agent.subagents.slots_in_use(chat_key) == 1
+        result = await agent.run_subagent(
+            task="x",
+            background=True,
+            origin_channel="telegram",
+            origin_chat_id="c1",
+        )
+    assert "error" in result
+    assert "max 1" in result["error"].lower()
+    # Another chat is unaffected by this chat's cap.
+    assert agent.subagents.slots_in_use(agent._subagent_chat_key("telegram", "other")) == 0
 
 
 @pytest.mark.asyncio
@@ -706,3 +720,348 @@ async def test_run_subagent_unknown_agent_lists_available(agent, monkeypatch) ->
     result = await agent.run_subagent(task="x", agent_name="nope")
     assert "not found" in result["error"].lower()
     assert "coding-helper" in result["error"] and "analyst" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Fan-out — spawn_subagents: concurrency, per-chat cap, budgets, abort
+# ---------------------------------------------------------------------------
+
+
+def _fanout_state(agent, channel: str = "cli", user: str = "u", chat: str = "c1", depth: int = 0):
+    """A request_state shaped like a live turn's, so the fan-out finds its origin."""
+    return agent._new_request_state(
+        None,
+        depth=depth,
+        origin={"channel": channel, "user_id": user, "chat_id": chat},
+    )
+
+
+def _install_overlap_loop(agent, monkeypatch, delay: float = 0.02, per_task: dict | None = None):
+    """Replace the subagent's inner loop with a sleeper that records peak overlap.
+
+    Patched *inside* the per-chat slot gate (``_run_subagent_loop`` still runs),
+    so the peak concurrent count is exactly what the gate allowed.
+    """
+    tracker = {"active": 0, "peak": 0, "finished": []}
+
+    async def fake_inner(task, child_agent, child_state, run):
+        tracker["active"] += 1
+        tracker["peak"] = max(tracker["peak"], tracker["active"])
+        await asyncio.sleep((per_task or {}).get(task, delay))
+        tracker["active"] -= 1
+        tracker["finished"].append(run.label)
+        run.stopped_reason = "complete"
+        return f"result:{task}"
+
+    monkeypatch.setattr(agent, "_run_subagent_loop_inner", fake_inner)
+    return tracker
+
+
+@pytest.mark.asyncio
+async def test_fanout_runs_children_concurrently(agent, monkeypatch) -> None:
+    """Wall clock ≈ one child, not the sum — and all four overlap."""
+    agent.config.subagents.max_concurrent = 4
+    tracker = _install_overlap_loop(agent, monkeypatch, delay=0.05)
+    tasks = [{"task": f"t{i}", "label": f"l{i}"} for i in range(4)]
+
+    started = time.monotonic()
+    out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+    elapsed = time.monotonic() - started
+
+    assert out["ok"] is True
+    assert out["succeeded"] == 4 and out["failed"] == 0
+    assert tracker["peak"] == 4  # genuinely parallel, not a serial loop
+    assert elapsed < 0.05 * 3  # ≈ one child; the serial cost would be 4×
+
+
+@pytest.mark.asyncio
+async def test_fanout_queues_at_the_per_chat_cap(agent, monkeypatch) -> None:
+    """Over the cap the excess queues (never refuses): peak == max_concurrent,
+    every subtask still completes."""
+    agent.config.subagents.max_concurrent = 2
+    tracker = _install_overlap_loop(agent, monkeypatch, delay=0.02)
+    tasks = [{"task": f"t{i}", "label": f"l{i}"} for i in range(4)]
+
+    out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+
+    assert tracker["peak"] == 2
+    assert out["succeeded"] == 4
+    assert {r["status"] for r in out["results"]} == {"done"}
+
+
+@pytest.mark.asyncio
+async def test_slots_are_per_chat_not_global(agent, monkeypatch) -> None:
+    """A chat sitting at its cap blocks only itself — another chat runs at once."""
+    agent.config.subagents.max_concurrent = 1
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+    key_a = agent._subagent_chat_key("cli", "A")
+
+    async with agent.subagents.slot(key_a, lambda: 1):
+        # Chat B is unaffected by chat A's full pool.
+        res = await asyncio.wait_for(
+            agent.run_subagent(task="x", origin_channel="cli", origin_chat_id="B"), timeout=2
+        )
+        assert res["ok"] is True
+        # Chat A itself queues behind the held slot instead of running.
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(
+                agent.run_subagent(task="y", origin_channel="cli", origin_chat_id="A"),
+                timeout=0.05,
+            )
+
+
+@pytest.mark.asyncio
+async def test_fanout_results_are_ordered_by_index(agent, monkeypatch) -> None:
+    """Children finishing out of order still come back in request order."""
+    agent.config.subagents.max_concurrent = 4
+    per_task = {"t0": 0.04, "t1": 0.02, "t2": 0.0}
+    tracker = _install_overlap_loop(agent, monkeypatch, per_task=per_task)
+    tasks = [{"task": f"t{i}", "label": f"l{i}"} for i in range(3)]
+
+    out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+
+    assert tracker["finished"] == ["l2", "l1", "l0"]  # completion order is reversed
+    assert [r["index"] for r in out["results"]] == [0, 1, 2]
+    assert [r["label"] for r in out["results"]] == ["l0", "l1", "l2"]
+    assert [r["result"] for r in out["results"]] == ["result:t0", "result:t1", "result:t2"]
+
+
+@pytest.mark.asyncio
+async def test_fanout_labels_derive_from_the_task_when_unset(agent, monkeypatch) -> None:
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+    tasks = [
+        {"task": "check the swiss iPhone price today"},
+        {"task": "summarise the release notes", "label": "notes"},
+    ]
+
+    out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+
+    assert [r["label"] for r in out["results"]] == ["check the swiss iPhone", "notes"]
+
+
+@pytest.mark.asyncio
+async def test_fanout_reports_partial_failure_per_index(agent, monkeypatch) -> None:
+    """A bad subtask fails its own index; the siblings still run and the
+    aggregate carries a note so the model can't silently drop it."""
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+    tasks = [
+        {"task": "good one", "label": "a"},
+        {"task": "bad one", "label": "b", "agent": "does-not-exist"},
+        {"task": "good two", "label": "c"},
+    ]
+
+    out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+
+    assert out["ok"] is False
+    assert out["succeeded"] == 2 and out["failed"] == 1
+    statuses = [r["status"] for r in out["results"]]
+    assert statuses == ["done", "error", "done"]
+    assert "Agent not found" in out["results"][1]["error"]
+    assert "note" in out and "did not complete" in out["note"]
+
+
+@pytest.mark.asyncio
+async def test_fanout_refuses_beyond_max_fanout(agent) -> None:
+    agent.config.subagents.max_fanout = 2
+    out = await agent._tool_spawn_subagents(
+        {"tasks": [{"task": f"t{i}"} for i in range(3)]}, "cli", "u", _fanout_state(agent)
+    )
+    assert "max_fanout" in out["error"]
+    assert "2" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_nested_fanout_is_refused(agent) -> None:
+    """A subagent (depth ≥ 1) may delegate singly but never fan out again."""
+    out = await agent._tool_spawn_subagents(
+        {"tasks": [{"task": "a"}, {"task": "b"}]},
+        "system",
+        "u",
+        _fanout_state(agent, depth=1),
+    )
+    assert "Nested fan-out" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_subagent_loop_is_not_offered_the_fanout_tool(agent) -> None:
+    """Belt to the handler's braces: the plural tool is stripped from the schemas
+    a subagent's loop sends, while the singular stays below the depth ceiling."""
+
+    class _ToolCapturingLLM(_ScriptedLLM):
+        def __init__(self, responses):
+            super().__init__(responses)
+            self.offered: list[set[str]] = []
+
+        async def generate(self, *, tools=(), **kw) -> LLMResponse:
+            self.offered.append({t["name"] for t in tools})
+            return await super().generate()
+
+    agent.llm = _ToolCapturingLLM([LLMResponse(text="ok", tool_calls=[])])
+    await agent.run_subagent(task="x")
+
+    offered = agent.llm.offered[0]
+    assert "spawn_subagents" not in offered
+    assert "spawn_subagent" in offered  # depth 1 < recursion_depth, so still allowed
+    assert "generate_image" not in offered
+
+
+# ---------------------------------------------------------------------------
+# FanoutBudget — one reserve-then-refund pool per turn, shared by the whole tree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fanout_token_pool_starts_only_what_fits(agent, monkeypatch) -> None:
+    agent.config.subagents.turn_token_budget = 2500
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+    tasks = [{"task": f"t{i}", "label": f"l{i}", "token_budget": 1000} for i in range(3)]
+
+    out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+
+    assert out["succeeded"] == 2 and out["failed"] == 1
+    refused = out["results"][2]
+    assert refused["status"] == "error"
+    assert "tokens" in refused["error"] and "left this turn" in refused["error"]
+
+
+@pytest.mark.asyncio
+async def test_fanout_spawn_pool_is_shared_across_spawns_in_one_turn(agent, monkeypatch) -> None:
+    """One pool per turn, carried on request_state — a later spawn draws from
+    what the earlier one already took."""
+    agent.config.subagents.max_spawns_per_turn = 2
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+    state = _fanout_state(agent)
+
+    first = await agent._tool_spawn_subagents(
+        {"tasks": [{"task": "a"}, {"task": "b"}]}, "cli", "u", state
+    )
+    assert first["succeeded"] == 2
+    assert state["fanout_budget"].spawns_left == 0
+
+    second = await agent._tool_spawn_subagents(
+        {"tasks": [{"task": "c"}, {"task": "d"}]}, "cli", "u", state
+    )
+    assert second["ok"] is False
+    assert second["failed"] == 2
+    assert all("Spawn budget" in r["error"] for r in second["results"])
+    assert "No subtask could be started" in second["note"]
+
+
+@pytest.mark.asyncio
+async def test_completed_run_refunds_its_unspent_reservation(agent) -> None:
+    """Reserve the full budget up front, hand back what the run didn't spend."""
+    agent.config.subagents.turn_token_budget = 50_000
+    agent.llm = _ScriptedLLM(
+        [LLMResponse(text="done", tool_calls=[], usage={"input_tokens": 30, "output_tokens": 20})]
+    )
+    state = _fanout_state(agent)
+
+    res = await agent.run_subagent(task="x", token_budget=5000, parent_state=state)
+
+    assert res["ok"] is True
+    budget = state["fanout_budget"]
+    assert budget.tokens_left == 50_000 - 50  # 5000 reserved, 4950 refunded
+    assert budget.spawns_left == agent.config.subagents.max_spawns_per_turn - 1
+
+
+# ---------------------------------------------------------------------------
+# Run telemetry: steps / tokens_used / stopped_reason
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_reports_steps_tokens_and_stopped_reason(agent) -> None:
+    agent.config.subagents.max_steps = 2
+    call = LLMToolCall(id="1", name="web_search", arguments={"query": "q"})
+    agent.llm = _ScriptedLLM(
+        [
+            LLMResponse(text="", tool_calls=[call], usage={"input_tokens": 40, "output_tokens": 10})
+            for _ in range(6)
+        ]
+    )
+
+    res = await agent.run_subagent(task="loop")
+
+    run = agent.subagents.get(res["run_id"])
+    assert run.stopped_reason == "max_steps" == res["stopped_reason"]
+    assert res["steps"] == run.steps == 2
+    assert res["tokens_used"] == run.tokens_used == 150  # 3 rounds × 50
+
+
+@pytest.mark.asyncio
+async def test_sync_result_carries_telemetry_on_a_clean_run(agent) -> None:
+    agent.llm = _ScriptedLLM(
+        [
+            LLMResponse(
+                text="the answer", tool_calls=[], usage={"input_tokens": 7, "output_tokens": 3}
+            )
+        ]
+    )
+    res = await agent.run_subagent(task="x")
+    assert res["stopped_reason"] == "complete"
+    assert res["steps"] == 0
+    assert res["tokens_used"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Cancellation — /stop mid-fan-out, and cascade to a run's children
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_abort_mid_fanout_cancels_every_child(agent, monkeypatch) -> None:
+    abort = asyncio.Event()
+    agent._active_turns_map()[("cli", "u", "c1")] = abort
+
+    async def fake_inner(task, child_agent, child_state, run):
+        abort.set()  # the user hits /stop once the fan-out is under way
+        await asyncio.sleep(5)
+        raise AssertionError("child should have been cancelled")
+
+    monkeypatch.setattr(agent, "_run_subagent_loop_inner", fake_inner)
+
+    out = await agent._tool_spawn_subagents(
+        {"tasks": [{"task": "a", "label": "a"}, {"task": "b", "label": "b"}]},
+        "cli",
+        "u",
+        _fanout_state(agent),
+    )
+
+    assert [r["status"] for r in out["results"]] == ["cancelled", "cancelled"]
+    assert out["ok"] is False and out["succeeded"] == 0
+
+
+def test_cancel_cascades_to_child_runs() -> None:
+    """A create_task child outlives its parent's cancellation, so cancel walks
+    the tree instead of orphaning the fan-out."""
+    reg = SubagentRegistry()
+    reg.register(SubagentRun(run_id="p", agent="", task="t", children=["c1", "c2"]))
+    reg.register(_run("c1"))
+    reg.register(_run("c2"))
+
+    assert reg.cancel("p") is True
+    assert [reg.get(rid).status for rid in ("p", "c1", "c2")] == ["cancelled"] * 3
+
+
+# ---------------------------------------------------------------------------
+# Tool exposure + labels
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_spawn_subagent_allowlist_also_gets_the_plural(agent) -> None:
+    """Agents scoped before the plural tool existed may still fan out."""
+    scoped = Agent(name="legacy", tools=["spawn_subagent"])
+    names = {t["name"] for t in agent._tools_for_turn(scoped)}
+    assert {"spawn_subagent", "spawn_subagents"} <= names
+    # An agent scoped away from spawning gets neither.
+    assert "spawn_subagents" not in {
+        t["name"] for t in agent._tools_for_turn(Agent(name="x", tools=["web_search"]))
+    }
+
+
+def test_derive_label_prefers_the_model_label_then_the_task() -> None:
+    assert derive_label("pricing", "look up the price") == "pricing"
+    assert derive_label("  spaced  out ", "task") == "spaced out"
+    assert derive_label("", "look up the swiss price of an iPhone") == "look up the swiss"
+    assert derive_label("", "", 2) == "task2"
+    assert len(derive_label("z" * 99, "")) == 32

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -928,6 +928,7 @@ async def test_subagent_loop_is_not_offered_the_fanout_tool(agent) -> None:
 @pytest.mark.asyncio
 async def test_fanout_token_pool_starts_only_what_fits(agent, monkeypatch) -> None:
     agent.config.subagents.turn_token_budget = 2500
+    agent.config.subagents.token_budget = 1000  # keep the pool at 2500 (max() floor)
     _install_overlap_loop(agent, monkeypatch, delay=0.0)
     tasks = [{"task": f"t{i}", "label": f"l{i}", "token_budget": 1000} for i in range(3)]
 
@@ -966,6 +967,7 @@ async def test_fanout_spawn_pool_is_shared_across_spawns_in_one_turn(agent, monk
 async def test_completed_run_refunds_its_unspent_reservation(agent) -> None:
     """Reserve the full budget up front, hand back what the run didn't spend."""
     agent.config.subagents.turn_token_budget = 50_000
+    agent.config.subagents.token_budget = 5000  # keep the pool at 50k (max() floor)
     agent.llm = _ScriptedLLM(
         [LLMResponse(text="done", tool_calls=[], usage={"input_tokens": 30, "output_tokens": 20})]
     )
@@ -977,6 +979,57 @@ async def test_completed_run_refunds_its_unspent_reservation(agent) -> None:
     budget = state["fanout_budget"]
     assert budget.tokens_left == 50_000 - 50  # 5000 reserved, 4950 refunded
     assert budget.spawns_left == agent.config.subagents.max_spawns_per_turn - 1
+
+
+@pytest.mark.asyncio
+async def test_fanout_unsized_tasks_share_the_pool(agent, monkeypatch) -> None:
+    """Omitted token_budgets split the pool across the width instead of each
+    demanding the full per-run ceiling (which would refuse most of the group
+    whenever ceiling × width exceeds the pool)."""
+    agent.config.subagents.token_budget = 100_000
+    agent.config.subagents.turn_token_budget = 150_000
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+    tasks = [{"task": f"t{i}", "label": f"l{i}"} for i in range(3)]
+
+    out = await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+
+    assert out["succeeded"] == 3
+    for row in out["results"]:
+        assert agent.subagents.get(row["run_id"]).token_budget == 50_000
+
+
+@pytest.mark.asyncio
+async def test_pool_is_never_smaller_than_one_default_run(agent) -> None:
+    """An owner who raised token_budget past turn_token_budget (the per-run
+    knob predates the pool) must still be able to run one unsized spawn."""
+    agent.config.subagents.token_budget = 500_000
+    agent.config.subagents.turn_token_budget = 400_000
+    agent.llm = _ScriptedLLM([LLMResponse(text="done", tool_calls=[])])
+
+    res = await agent.run_subagent(task="x")
+
+    assert res["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_tiny_budget_still_gets_its_first_tool_round(agent) -> None:
+    """The opening generate alone can exceed a small budget; the run must still
+    execute round one rather than billing that call and doing nothing."""
+    agent.config.subagents.max_steps = 10
+    call = LLMToolCall(id="1", name="web_search", arguments={"query": "q"})
+    agent.llm = _ScriptedLLM(
+        [
+            LLMResponse(
+                text="", tool_calls=[call], usage={"input_tokens": 5000, "output_tokens": 0}
+            ),
+            LLMResponse(text="answer", tool_calls=[]),
+        ]
+    )
+
+    res = await agent.run_subagent(task="x", token_budget=1000)
+
+    assert res["ok"] is True
+    assert res["steps"] == 1  # round one ran despite tokens > budget after gen 1
 
 
 # ---------------------------------------------------------------------------

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -240,14 +240,56 @@ async def test_background_subagent_notifies_user_digests_context(agent, monkeypa
     await run._task
 
     assert run.status == "done"
-    # Chat: the one-line NOTIFICATION only — never the raw output.
-    channel.send.assert_awaited_once_with("555", "Cheapest is CHF 599.")
+    # Chat: ONLY the one-line NOTIFICATION — no per-run completion note (the
+    # last/only finisher's note is suppressed; the digest speaks for it), and
+    # never the raw output.
+    assert _sent(channel) == ["Cheapest is CHF 599."]
     # Context: the concise digest is kept (merged), the raw output never is.
     turns = await agent.history.get_messages("telegram", "u1", "555")
     blob = str(turns[-1]["content"])
     assert [t["role"] for t in turns] == ["user", "assistant"]  # still alternating
     assert "iPhone 17e 256GB at CHF 599" in blob
     assert "raw verbose findings" not in blob
+
+
+@pytest.mark.asyncio
+async def test_midbatch_background_finisher_posts_a_note(agent, monkeypatch) -> None:
+    """While siblings are still running, a background finisher notes its
+    completion; the LAST finisher stays silent — the batch digest follows."""
+    channel = AsyncMock()
+    agent.channels["telegram"] = channel
+
+    async def fake_summary(batch):
+        return "All done.", "digest"
+
+    monkeypatch.setattr(agent, "_summarize_subagent_batch", fake_summary)
+    # A second background run for the same chat is still "running", so the
+    # first finisher is mid-batch.
+    agent.subagents.register(
+        SubagentRun(
+            run_id="sub_pending",
+            agent="",
+            task="slow sibling",
+            background=True,
+            origin_channel="telegram",
+            origin_chat_id="555",
+        )
+    )
+    agent.llm = _ScriptedLLM([LLMResponse(text="findings", tool_calls=[])])
+    result = await agent.run_subagent(
+        task="quick check",
+        origin_channel="telegram",
+        origin_user_id="u1",
+        origin_chat_id="555",
+        background=True,
+    )
+    run = agent.subagents.get(result["run_id"])
+    await run._task
+
+    notes = [t for t in _sent(channel) if t.startswith("✅ Subagent")]
+    assert len(notes) == 1 and run.label in notes[0]
+    # And no batch digest yet — the sibling is still running.
+    assert "All done." not in _sent(channel)
 
 
 @pytest.mark.asyncio
@@ -871,6 +913,81 @@ async def test_fanout_reports_partial_failure_per_index(agent, monkeypatch) -> N
     assert statuses == ["done", "error", "done"]
     assert "Agent not found" in out["results"][1]["error"]
     assert "note" in out and "did not complete" in out["note"]
+
+
+def _sent(channel) -> list[str]:
+    """Texts the fake channel was asked to send."""
+    return [c.args[1] for c in channel.send.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_fanout_child_completion_notes(agent, monkeypatch) -> None:
+    """Each child posts exactly one completion note to the originating chat."""
+    channel = AsyncMock()
+    agent.channels["cli"] = channel
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+    tasks = [{"task": f"t{i}", "label": f"l{i}"} for i in range(3)]
+
+    await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+
+    for label in ("l0", "l1", "l2"):
+        notes = [t for t in _sent(channel) if t.startswith(f"✅ Subagent {label} ")]
+        assert len(notes) == 1, notes
+        assert "done" in notes[0]
+    # Notification only: nothing reached the conversation history.
+    msgs = await agent.history.get_messages("cli", "u", "c1")
+    assert not any("Subagent" in str(m.get("content", "")) for m in msgs)
+
+
+@pytest.mark.asyncio
+async def test_fanout_failed_child_notes_the_failure(agent, monkeypatch) -> None:
+    channel = AsyncMock()
+    agent.channels["cli"] = channel
+
+    async def fake_inner(task, child_agent, child_state, run):
+        if task == "boom":
+            raise RuntimeError("nope")
+        run.stopped_reason = "complete"
+        return "fine"
+
+    monkeypatch.setattr(agent, "_run_subagent_loop_inner", fake_inner)
+    tasks = [{"task": "boom", "label": "bad"}, {"task": "ok", "label": "good"}]
+
+    await agent._tool_spawn_subagents({"tasks": tasks}, "cli", "u", _fanout_state(agent))
+
+    sent = _sent(channel)
+    assert [t for t in sent if "bad" in t and "failed" in t]
+    assert [t for t in sent if "good" in t and "done" in t]
+
+
+@pytest.mark.asyncio
+async def test_fast_sync_spawn_posts_no_completion_note(agent) -> None:
+    """A sync result lands in the very next reply — a 0s run needs no note."""
+    channel = AsyncMock()
+    agent.channels["cli"] = channel
+    agent.llm = _ScriptedLLM([LLMResponse(text="quick", tool_calls=[])])
+
+    res = await agent.run_subagent(task="x", origin_channel="cli", origin_chat_id="c1")
+
+    assert res["ok"] is True
+    assert not [t for t in _sent(channel) if "Subagent" in t]
+
+
+@pytest.mark.asyncio
+async def test_system_origin_run_posts_no_note(agent, monkeypatch) -> None:
+    """Scheduler/system runs have no chat to notify."""
+    channel = AsyncMock()
+    agent.channels["system"] = channel  # present, but the run has no chat_id
+    _install_overlap_loop(agent, monkeypatch, delay=0.0)
+
+    await agent._tool_spawn_subagents(
+        {"tasks": [{"task": "t", "label": "l"}]},
+        "system",
+        "u",
+        _fanout_state(agent, channel="system", chat=""),
+    )
+
+    channel.send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -214,6 +214,29 @@ async def test_run_subagent_token_budget_stops_loop(agent) -> None:
 
 
 @pytest.mark.asyncio
+async def test_budget_stop_returns_the_work_done_so_far(agent) -> None:
+    """A budget stop lands on a tool_calls response whose text is empty, so the
+    findings live only in the run's local messages. The wrap-up round is what
+    gets them back to the caller — without it the parent pays for the run and
+    receives nothing but the stop marker."""
+    agent.config.subagents.max_steps = 1
+    call = LLMToolCall(id="1", name="web_search", arguments={"query": "q"})
+    agent.llm = _ScriptedLLM(
+        [
+            LLMResponse(text="", tool_calls=[call]),
+            LLMResponse(text="", tool_calls=[call]),
+            # The wrap-up round: no tools offered, so the model writes it up.
+            LLMResponse(text="found: CHF 599", tool_calls=[]),
+        ]
+    )
+    result = await agent.run_subagent(task="loop")
+    assert result["ok"] is True
+    assert "found: CHF 599" in result["result"]
+    assert "budget" in result["result"].lower()
+    assert agent.subagents.get(result["run_id"]).stopped_reason == "max_steps"
+
+
+@pytest.mark.asyncio
 async def test_background_subagent_notifies_user_digests_context(agent, monkeypatch) -> None:
     channel = AsyncMock()
     agent.channels["telegram"] = channel
@@ -1251,7 +1274,8 @@ async def test_run_reports_steps_tokens_and_stopped_reason(agent) -> None:
     run = agent.subagents.get(res["run_id"])
     assert run.stopped_reason == "max_steps" == res["stopped_reason"]
     assert res["steps"] == run.steps == 2
-    assert res["tokens_used"] == run.tokens_used == 150  # 3 rounds × 50
+    # 3 loop rounds + the wrap-up round that writes up the work done so far.
+    assert res["tokens_used"] == run.tokens_used == 200  # 4 rounds × 50
 
 
 @pytest.mark.asyncio

--- a/humux/tests/test_tools.py
+++ b/humux/tests/test_tools.py
@@ -887,6 +887,59 @@ async def test_repeat_failure_breaker_stops_after_n(agent) -> None:
     assert errors[-1] == _REPEAT_FAILURE_NOTICE
 
 
+@pytest.mark.asyncio
+async def test_error_streak_breaker_stops_a_dead_backend(agent, monkeypatch) -> None:
+    """Varying arguments defeat the signature breaker, so a down service keeps
+    getting called — five different search queries, five identical outages. The
+    error-streak breaker is what stops that."""
+    from core.agent import _MAX_REPEAT_FAILURES, _REPEAT_ERROR_NOTICE
+    from core.llm import LLMToolCall
+
+    async def down(*_a, **_kw):
+        return {"error": "The web search backend is unavailable."}
+
+    monkeypatch.setattr(agent, "_execute_tool_inner", down)
+    state = agent._new_request_state()
+    errors = [
+        (
+            await agent._execute_tool(
+                LLMToolCall(id=str(i), name="web_search", arguments={"query": f"q{i}"}),
+                "system",
+                "u",
+                state,
+            )
+        )["error"]
+        for i in range(_MAX_REPEAT_FAILURES + 1)
+    ]
+    assert all("unavailable" in e for e in errors[:_MAX_REPEAT_FAILURES])
+    assert errors[-1].startswith(_REPEAT_ERROR_NOTICE)
+
+
+@pytest.mark.asyncio
+async def test_error_streak_resets_on_success(agent, monkeypatch) -> None:
+    from core.agent import _MAX_REPEAT_FAILURES
+    from core.llm import LLMToolCall
+
+    outcomes = [{"error": "flaky"}] * (_MAX_REPEAT_FAILURES - 1) + [{"ok": True}]
+
+    async def flaky(*_a, **_kw):
+        return outcomes.pop(0) if outcomes else {"error": "flaky"}
+
+    monkeypatch.setattr(agent, "_execute_tool_inner", flaky)
+    state = agent._new_request_state()
+    # One more call than the streak allows: without the reset the success would
+    # not clear the two earlier failures and this last call would be refused.
+    for i in range(_MAX_REPEAT_FAILURES + 2):
+        res = await agent._execute_tool(
+            LLMToolCall(id=str(i), name="web_search", arguments={"query": f"q{i}"}),
+            "system",
+            "u",
+            state,
+        )
+    # The success cleared the streak, so the next failure starts counting again.
+    assert res["error"] == "flaky"
+
+
 # ---------------------------------------------------------------------------
 # Approval delivery (#79 B): fail closed when the prompt can't be sent
 # ---------------------------------------------------------------------------

--- a/humux/tools/skills.py
+++ b/humux/tools/skills.py
@@ -25,7 +25,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from core.skills import SkillsStore  # noqa: E402
 
-NAME_PATTERN = re.compile(r"^[a-z0-9-]+$")
+# Underscores allowed: the bundled image_generation skill uses one, and the
+# pattern exists to block path tricks and garbage, not naming style.
+NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
 
 # Resolve paths relative to this script's location, not CWD (which is the
 # workspace when run via bash). This ensures the CLI always finds the correct
@@ -58,7 +60,7 @@ def _validate_name(name: str) -> str:
     if "/" in value or "\\" in value:
         raise ValueError("Skill name cannot include path separators")
     if not NAME_PATTERN.match(value):
-        raise ValueError("Skill name must be lowercase letters, digits, and hyphens")
+        raise ValueError("Skill name must be lowercase letters, digits, hyphens, or underscores")
     if "--" in value or value.startswith("-") or value.endswith("-"):
         raise ValueError("Skill name cannot start/end with hyphen or contain consecutive hyphens")
     return value


### PR DESCRIPTION
Implements the SUBAGENTS.md fan-out plan (phases 1–5), with the open questions resolved per review: per-chat concurrency, plural `background: true` kept, Inspect capture for children, model-supplied labels with derivation fallback, transport-level retry only, and steering ack semantics unchanged (the progress note clarifies them instead).

## What

**`spawn_subagents` (plural tool)** — 2+ independent subtasks run in parallel inside one tool call; wall-clock ≈ the slowest subtask. Results are ordered per index with `status`, `steps`, `tokens_used`, `stopped_reason`, `summary`, `result` — partial failure is per-subtask, never all-or-nothing. `background: true` returns run ids and delivers one grouped notification via the existing batch barrier.

## Token spend minimization

- **`FanoutBudget`** — one reserve-then-refund pool per turn (`max_spawns_per_turn: 12`, `turn_token_budget: 400000`), shared by reference down the whole subagent tree, so recursion multiplies neither spawns nor tokens. Reserve the run's full budget at spawn, refund the unspent part on clean completion; a crashed run doesn't refund (fails safe).
- `tokens_used`/`steps` recorded live on every run (previously thrown away).
- Per-spawn model overrides (#299) advertised on both spawn tools, so cheap workers under an expensive coordinator stay one field away.
- The `subagent-orchestration` skill leads with *when not to fan out*.

## Concurrency & cancellation

- `max_concurrent` (now 4) is a real **per-chat** gate covering all runs: sync fan-out queues at the cap; only depth-1 runs hold slots so nesting can't deadlock; one chat's fan-out can't starve another chat's spawn. Limit is read live per acquire → hot-config safe.
- `max_fanout: 6` caps one call's width; nested fan-out is refused and the tool is stripped inside subagent loops.
- **/stop now reaches children**: the fan-out races the turn's abort Event, `registry.cancel` cascades to grandchildren, and the subagent loop polls the abort between steps (fixes the pre-existing "/stop lets a 12-step child finish" gap).
- Bounded jittered retry on 429/5xx in `LLMClient.generate` — transport-level only, never an automatic child re-run.

## Observability (session tree)

- `SubagentRun` gains `label`, `group_id`, `parent_run_id`, `children`, `tokens_used`, `steps`, `stopped_reason`.
- **Jobs tab**: fan-out siblings grouped, children indented with parent links, tokens/steps/stopped reason on cards, live running-count badge, distinct status colours.
- **Inspect tab**: capture key is now `(channel, user_id, chat_id, run_id)` — every subagent's last-sent payload is inspectable per run id, merged into the master list.
- **Logs tab**: unique per-run stream labels (`pricing#a1b2`), stored as a structured field with a new filter.
- Telegram `/subagents` and the turn preamble show run labels.

## Chat feedback

A fan-out posts one progress note when it starts — *🧩 Delegating N subtasks in parallel: … I'll read any new messages here once they're done* — so a long parallel run doesn't look hung and the steering semantics are explicit (👀 still means "the model has seen it").

## Skill

New bundled `subagent-orchestration` (166 lines, passes the bundled-skill validator): when not to fan out, independent-vs-dependent, brief writing, labels, sizing table, the five patterns (verification pass emphasized), Files: handoff, partial failure, pooled budgets, anti-patterns.

## Behaviour changes

- Spawns draw from a shared per-turn budget; a runaway turn now gets a readable budget refusal.
- `/stop` cancels in-flight subagents (cascading) instead of letting them finish.
- `max_concurrent` applies to sync spawns too and queues; a singular background spawn still refuses at the cap (best-effort under same-tick races — excess queues, the cap is never exceeded).

## Tests

1110 passed (20+ new): real-concurrency overlap, per-chat cap queueing and isolation, ordered results, partial failure, budget pooling/refund/shared-tree, abort mid-fan-out, cascade cancel, width cap, nested-fan-out refusal, legacy `spawn_subagent` allowlists getting the plural, telemetry fields, 4-tuple Inspect capture. `ruff check` clean.

## Update 2: delegation trust lists + subagent imagegen

**`Agent.spawnable_agents`** — a per-agent delegation trust list, resolving the "intersection narrowing makes specialists useless" problem:
- **Empty (default)**: exactly the previous behavior — any agent may be named, child narrowed to the intersection (inherit-never-widen).
- **Non-empty**: a curated **team**. Only listed agents may be named (off-list refused with the team listed so the model self-corrects), and a listed specialist runs with its **own** tools, skills, secrets, and accounts — the list is the owner's trust grant, making delegation a capability handoff instead of a leak.
- Anonymous/self spawns unchanged. The `<agents>` roster is filtered to the team and its guidance flips to "pick the best-equipped teammate". Editable in the Agents editor (new Delegation card) and frontmatter; persisted with migration.
- Security posture: subagents run with system semantics (no per-action prompts), so the spawn approval is the one human gate — it now names the target agent and task. Docs advise keeping lists short on agents exposed to untrusted input (group chats, webhooks).

**Bugs found by the test pass and fixed:**
- `_narrow_agent` dropped `spawnable_agents`, letting an anonymous child of a team-scoped agent escape its containment. The list now travels with the identity.
- `narrow_scope` collapsed disjoint non-empty scopes to `[]`, which means *all* for tools/skills — a narrowing that **widened**. Now returns a match-nothing sentinel.

**Subagents can `generate_image` again** — the blanket strip predated the `Files:` handoff; the tool result's note now branches on depth so a subagent reports the saved path for the parent to deliver.

Suite: 1122 tests passing, ruff clean.

## Update 3: charge-as-you-go budgets + subagent media delivery (field-test round 2)

Live testing (delegating image generation to a teammate agent) exposed that a sync subagent's generated image never reached the chat — its attachment queue died with the run, and the `Files:` fallback reported a cwd-relative path the parent couldn't find, so the parent paid to regenerate.

**Media delivery fixed:** a sync child now shares the spawning turn's attachment queue (propagated down sync chains), so `generate_image` inside a subagent is delivered natively with the turn's reply. Background runs keep the `Files:` handoff, and the saved path is now absolute.

**Budgets simplified** (removing the incidental complexity the reservation model dragged in): `FanoutBudget` is now charge-as-you-go — spend is charged per LLM round as it happens. Spawns are **never refused for tokens up front** (only when the spawn count is used up or the pool is already dry); runs stop gracefully between rounds when the shared pool drains, with a distinct `stopped_reason: "turn_budget"` that tells the model retrying won't help. Deleted along with reservations: refunds, the pool `max()` normalization, and fan-out fair-share splitting. Overshoot is bounded at ≤1 round per concurrent child — the documented price of the simplicity.

Also: `tools/skills.py` now accepts underscores in skill names (the bundled `image_generation` skill was un-showable, costing children a recovery round).

Suite: 1129 tests passing, ruff clean.

## Update 4: per-run completion notes

When a subagent run finishes, the originating chat gets a one-line status note — `✅ Subagent pricing — done (42s, 23k tokens)` / `⚠️ … failed`. Notification-only by construction (same `channel.send` path as the 🧩 start note): never recorded in history, never model input, can never trigger a turn.

Noise rules, no config: fan-out children always note; singular sync spawns only when ≥10s (their result lands in the next reply); background runs only mid-batch (the last finisher stays silent — the batch digest lands right after it); no notes on cancellation (/stop is the user's own action, and per-run cancels already show a notice); scheduler runs send nothing.

## Update 5: full run-tree visibility

Every spawn now announces itself in the chat the moment it starts — `🧬 Spawned subagent pricing (as qa)`, and for nested spawns `🧬 pricing spawned subagent deep-dive` — so the run tree is visible as it grows and any run can be cancelled while still working. One choke point covers all paths; fan-out children are excluded (the group 🧩 note already names them). Turn-safe like all notes (channel-send only; never history or model input).

`/subagents` (which already listed runs at every depth) now renders the tree: oldest-first so parents sit above their children, with a `└ spawned by <parent>` line on nested runs; cancelling a parent cascades to its subtree.

## Update 6: subagent runs live in Inspect

The live runs panel moved from the Jobs tab to Inspect — runs are context-bound executions (Inspect's subject; their payloads were already listed there), while Jobs stays about scheduling (`subagent`-type jobs untouched). Each chat row in the Inspect master list gets a **runs** button filtering the panel to that conversation (channel+chat_id params on the partial, show-all reset); the panel self-polls carrying its filter, with the running count in its header. Also fixed en passant: the cancel route rendered the panel with the wrong context (blank until next poll) and dropped the active filter.