### PR TITLE
feat: live read-only web transcript (/weburl)

### DIFF
--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -188,7 +188,11 @@ https://your-agent.example/t/<token>
   tree — arguments and results render as an indented, colour-coded structure you can
   fold open a level at a time (nested objects start collapsed, showing `{…} 4 keys`),
   with long strings clipped behind a "more" toggle; non-JSON results stay as wrapped
-  monospace text. The primary reading flow stays clean. These only exist in `session`
+  monospace text. The primary reading flow stays clean. A **💭 thinking** toggle in
+  the top bar switches to always-expanded reasoning — every chip on the page opens,
+  and new ones arrive open — for when you are following the agent's work rather than
+  reading the conversation. It is a per-browser preference, remembered across visits
+  and private to whoever is looking. These only exist in `session`
   history mode, which is what records the tool round-trips — in `injection` mode the
   page shows the text turns and no chips.
 

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -156,6 +156,42 @@ The filter bar narrows the view:
 **Auto-refresh** re-polls every few seconds keeping the active filters; model
 chain-of-thought lines render in a distinct style.
 
+## Live transcript (`/weburl`)
+
+Send **`/weburl`** in any Telegram chat with the agent and it replies with a link
+to a read-only web page showing that conversation, updating as it happens:
+
+```
+https://your-agent.example/t/<token>
+```
+
+- **One link per conversation** — the token maps to exactly one
+  (channel, user, chat) triple, so a group, a DM, and a forum topic each get their
+  own page and none of them can see the others' messages. Asking again returns the
+  **same** link rather than invalidating the old one.
+- **The token is the credential** — 32 unguessable url-safe bytes, no login, no
+  admin API key. The page is served with `no-store` and `X-Robots-Tag: noindex`,
+  but anyone holding the URL can read that conversation, so share it deliberately.
+  `/weburl` itself is gated by the same per-chat permissions as any other action,
+  so only people who may talk to the bot there can mint the link.
+- **Read-only** — there is no way to send a message, change settings, or reach any
+  other part of the admin app from it. The system prompt is never included.
+- **Reading view** — user turns as tinted bubbles, agent turns as plain prose with
+  light markdown (code blocks, bold/italic, links), automatic light/dark, and a live
+  dot that greys out and says "reconnecting…" while polling fails.
+- **Progressive disclosure** — the agent's chain-of-thought and tool activity sit
+  between messages as muted one-line chips ("💭 thinking", "🔧 web_search (+2 more)").
+  Click one to expand reasoning as quiet prose and tool calls as monospace blocks
+  with pretty-printed arguments and truncated results; the primary reading flow stays
+  clean. These only exist in `session` history mode, which is what records the tool
+  round-trips — in `injection` mode the page shows the text turns and no chips.
+
+Set `HUMUX_BASE_URL` to the agent's public URL so the link is reachable from your
+phone; without it the reply points at `localhost` and says so.
+
+The page polls `/t/<token>/messages?after=<cursor>` every 2 seconds and backs off to
+10 seconds after repeated failures, resuming as soon as a request succeeds.
+
 ## Setup wizard
 
 On first boot, the admin UI presents a step-by-step setup wizard:

--- a/docs/content/docs/admin-ui.mdx
+++ b/docs/content/docs/admin-ui.mdx
@@ -177,14 +177,20 @@ https://your-agent.example/t/<token>
 - **Read-only** — there is no way to send a message, change settings, or reach any
   other part of the admin app from it. The system prompt is never included.
 - **Reading view** — user turns as tinted bubbles, agent turns as plain prose with
-  light markdown (code blocks, bold/italic, links), automatic light/dark, and a live
-  dot that greys out and says "reconnecting…" while polling fails.
+  light markdown (code blocks, bold/italic, links), automatic light/dark, and a small
+  floating pill at the bottom of the screen that says "updating live" — it greys out
+  and says "reconnecting…" while polling fails, and steps aside when the
+  "↓ new messages" pill appears. A share button in the top right copies the page link
+  to the clipboard.
 - **Progressive disclosure** — the agent's chain-of-thought and tool activity sit
   between messages as muted one-line chips ("💭 thinking", "🔧 web_search (+2 more)").
-  Click one to expand reasoning as quiet prose and tool calls as monospace blocks
-  with pretty-printed arguments and truncated results; the primary reading flow stays
-  clean. These only exist in `session` history mode, which is what records the tool
-  round-trips — in `injection` mode the page shows the text turns and no chips.
+  Click one to expand reasoning as quiet prose and tool calls as a collapsible JSON
+  tree — arguments and results render as an indented, colour-coded structure you can
+  fold open a level at a time (nested objects start collapsed, showing `{…} 4 keys`),
+  with long strings clipped behind a "more" toggle; non-JSON results stay as wrapped
+  monospace text. The primary reading flow stays clean. These only exist in `session`
+  history mode, which is what records the tool round-trips — in `injection` mode the
+  page shows the text turns and no chips.
 
 Set `HUMUX_BASE_URL` to the agent's public URL so the link is reachable from your
 phone; without it the reply points at `localhost` and says so.

--- a/docs/content/docs/channels.mdx
+++ b/docs/content/docs/channels.mdx
@@ -41,6 +41,7 @@ agent's row, after which every bot is configured per-agent. See
 - **User ID whitelist** — only allowed users can interact with the bot
 - **Bot-per-agent** — every agent has its own bot token, so it's a separate Telegram contact, all running in one process; see below
 - **Group rooms** — several agent-bots share one group sanely: each replies only when addressed, ignores other bots, and tags who said what; see below
+- **Live web transcript** — `/weburl` replies with a read-only link that shows this chat as a web page, updating live, with the agent's reasoning and tool calls behind click-to-expand chips; see [Live transcript](/docs/admin-ui#live-transcript-weburl)
 
 ### Bot-per-agent
 

--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -30,7 +30,13 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import httpx
 import requests as http_requests
 from fastapi import Depends, FastAPI, HTTPException, Request
-from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse, Response
+from fastapi.responses import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    RedirectResponse,
+    Response,
+)
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
@@ -48,6 +54,7 @@ from core.prompt_builder import (
 )
 from core.tools import gh_token_secret_name, tool_env
 from core.tools import registry as tool_registry
+from core.transcript import to_entries
 from core.wacli import WacliManager
 
 if TYPE_CHECKING:
@@ -1280,6 +1287,44 @@ def create_admin_app(
                 "X-Content-Type-Options": "nosniff",
             },
         )
+
+    # ── Read-only live web transcript (share token from /weburl) ──────────────
+    # No auth dependency: the 32-byte urlsafe token in the path IS the credential,
+    # the same trade the public artifacts route makes. A token maps to exactly one
+    # (channel, user_id, chat_id), so one link never exposes another conversation.
+
+    async def _transcript_context(token: str):
+        history = await _history_from_config(config_store)
+        ctx = await history.resolve_web_token(token)
+        return history, ctx
+
+    @app.get("/t/{token}", response_model=None)
+    async def transcript_page(token: str) -> Response:
+        history, ctx = await _transcript_context(token)
+        if ctx is None:
+            return Response("Not found", status_code=404, media_type="text/plain")
+        channel, user_id, chat_id = ctx
+        name = await history.get_chat_agent(channel, user_id, chat_id)
+        name = name or await config_store.get("agent.name") or "Assistant"
+        page = _render("transcript.html", agent_name=name, token=token)
+        # Not indexable and never cached: the URL is a secret, and a stale copy
+        # would show a frozen transcript.
+        page.headers["X-Robots-Tag"] = "noindex, nofollow"
+        page.headers["Cache-Control"] = "no-store"
+        return page
+
+    @app.get("/t/{token}/messages", response_model=None)
+    async def transcript_messages(token: str, after: int = 0) -> Response:
+        """Typed entries recorded after cursor ``after``, plus the new cursor."""
+        history, ctx = await _transcript_context(token)
+        if ctx is None:
+            return Response("Not found", status_code=404, media_type="text/plain")
+        rows = await history.transcript_rows(*ctx, after=after)
+        payload = {
+            "entries": to_entries(rows),
+            "cursor": rows[-1]["id"] if rows else max(0, after),
+        }
+        return JSONResponse(payload, headers={"Cache-Control": "no-store"})
 
     auth = _make_auth_dependency(config_store, secret_store)
 

--- a/humux/api/templates/transcript.html
+++ b/humux/api/templates/transcript.html
@@ -1,0 +1,416 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>{{ agent_name }}</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --page: #faf9f7;
+    --ink: #1b1a18;
+    --muted: #7d7a74;
+    --faint: #e6e3dd;
+    --bubble: #eeebe4;
+    --code: #f0ede6;
+    --accent: #3f7d58;
+    --shadow: 0 1px 2px rgba(0, 0, 0, .05);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --page: #1a1a1c;
+      --ink: #ecebe7;
+      --muted: #93908a;
+      --faint: #2e2e31;
+      --bubble: #2a2a2e;
+      --code: #232326;
+      --accent: #7fc79b;
+      --shadow: none;
+    }
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--page);
+    color: var(--ink);
+    font: 16px/1.6 system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-synthesis-weight: none;
+  }
+  a { color: var(--accent); }
+
+  header {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: color-mix(in srgb, var(--page) 88%, transparent);
+    backdrop-filter: saturate(1.6) blur(10px);
+    border-bottom: 1px solid var(--faint);
+  }
+  .bar {
+    max-width: 46rem;
+    margin: 0 auto;
+    padding: .85rem 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+  }
+  .name { font-weight: 600; letter-spacing: -.01em; }
+  .live {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: .45rem;
+    font-size: .75rem;
+    color: var(--muted);
+  }
+  .dot {
+    width: .5rem;
+    height: .5rem;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: pulse 2s ease-in-out infinite;
+  }
+  .live.down .dot { background: var(--muted); animation: none; }
+  @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .25; } }
+  @media (prefers-reduced-motion: reduce) { .dot { animation: none; } }
+
+  main {
+    max-width: 46rem;
+    margin: 0 auto;
+    padding: 2rem 1.25rem 6rem;
+  }
+  .empty {
+    color: var(--muted);
+    text-align: center;
+    padding: 6rem 1rem;
+    font-size: .95rem;
+  }
+
+  .turn { margin: 1.75rem 0; }
+  .turn.enter { animation: rise .28s ease-out both; }
+  @keyframes rise { from { opacity: 0; transform: translateY(.5rem); } to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) { .turn.enter { animation: none; } }
+
+  .turn.user { display: flex; flex-direction: column; align-items: flex-end; }
+  .turn.user .body {
+    background: var(--bubble);
+    border-radius: 1.15rem;
+    padding: .7rem 1.05rem;
+    max-width: 85%;
+    box-shadow: var(--shadow);
+  }
+  .turn.assistant .body { max-width: 100%; }
+  .body > :first-child { margin-top: 0; }
+  .body > :last-child { margin-bottom: 0; }
+  .body p { margin: .75em 0; overflow-wrap: anywhere; }
+  .time {
+    font-size: .7rem;
+    color: var(--muted);
+    margin: .35rem .3rem 0;
+    font-variant-numeric: tabular-nums;
+  }
+
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: .875em;
+    background: var(--code);
+    padding: .12em .35em;
+    border-radius: .3rem;
+  }
+  pre {
+    background: var(--code);
+    border: 1px solid var(--faint);
+    border-radius: .6rem;
+    padding: .85rem 1rem;
+    overflow-x: auto;
+    margin: 1em 0;
+  }
+  pre code { background: none; padding: 0; font-size: .8125rem; line-height: 1.5; }
+
+  /* Progressive disclosure — reasoning + tool activity */
+  .aside { margin: 1.1rem 0; }
+  .chips { display: flex; flex-wrap: wrap; gap: .4rem; }
+  .chip {
+    font: inherit;
+    font-size: .75rem;
+    line-height: 1.4;
+    color: var(--muted);
+    background: none;
+    border: 1px solid var(--faint);
+    border-radius: 999px;
+    padding: .2rem .65rem;
+    cursor: pointer;
+    transition: border-color .15s, color .15s;
+  }
+  .chip:hover { color: var(--ink); border-color: var(--muted); }
+  .chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .chip[aria-expanded="true"] { color: var(--ink); border-color: var(--muted); }
+  .panel {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows .22s ease;
+  }
+  .panel.open { grid-template-rows: 1fr; }
+  .panel > .inner { overflow: hidden; }
+  .panel.open > .inner { overflow: visible; }
+  @media (prefers-reduced-motion: reduce) { .panel { transition: none; } }
+  .disclosure {
+    border-left: 2px solid var(--faint);
+    padding: .1rem 0 .1rem 1rem;
+    margin: .6rem 0 .2rem;
+  }
+  .think { font-style: italic; color: var(--muted); font-size: .9rem; }
+  .call { margin: .75rem 0; }
+  .call:first-child { margin-top: .35rem; }
+  .call-name {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: .8125rem;
+    color: var(--ink);
+  }
+  .call pre { margin: .35rem 0 0; font-size: .78rem; }
+  .call .label { font-size: .7rem; color: var(--muted); text-transform: uppercase; letter-spacing: .06em; }
+  .more {
+    font: inherit;
+    font-size: .72rem;
+    color: var(--accent);
+    background: none;
+    border: 0;
+    padding: .25rem 0 0;
+    cursor: pointer;
+  }
+  pre.clip { max-height: 11rem; overflow: hidden; }
+
+  #pill {
+    position: fixed;
+    left: 50%;
+    bottom: 1.5rem;
+    transform: translate(-50%, 1rem);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .2s, transform .2s;
+    background: var(--ink);
+    color: var(--page);
+    border: 0;
+    border-radius: 999px;
+    padding: .5rem 1rem;
+    font: inherit;
+    font-size: .8rem;
+    cursor: pointer;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, .18);
+  }
+  #pill.show { opacity: 1; transform: translate(-50%, 0); pointer-events: auto; }
+
+  @media (max-width: 32rem) {
+    main { padding: 1.25rem .9rem 5rem; }
+    .bar { padding: .75rem .9rem; }
+    .turn.user .body { max-width: 92%; }
+  }
+</style>
+</head>
+<body>
+<header>
+  <div class="bar">
+    <span class="name">{{ agent_name }}</span>
+    <span class="live" id="live"><span class="dot"></span><span id="live-label">live</span></span>
+  </div>
+</header>
+
+<main id="feed" aria-live="polite">
+  <div class="empty" id="empty">Nothing here yet — messages appear as the conversation happens.</div>
+</main>
+
+<button id="pill" type="button">↓ new messages</button>
+
+<script>
+(function () {
+  "use strict";
+  var TOKEN = {{ token | tojson }};
+  var feed = document.getElementById("feed");
+  var empty = document.getElementById("empty");
+  var pill = document.getElementById("pill");
+  var live = document.getElementById("live");
+  var liveLabel = document.getElementById("live-label");
+  var cursor = 0, first = true, fails = 0, group = null;
+
+  // -- markdown-lite ---------------------------------------------------------
+  function esc(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+  function inline(s) {
+    return s
+      .replace(/`([^`\n]+)`/g, "<code>$1</code>")
+      .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
+      .replace(/(^|[^*\w])\*([^*\n]+)\*/g, "$1<em>$2</em>")
+      .replace(/\[([^\]\n]+)\]\((https?:\/\/[^)\s]+)\)/g,
+        '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+      .replace(/(^|[\s(])(https?:\/\/[^\s<)]+)/g,
+        '$1<a href="$2" target="_blank" rel="noopener noreferrer">$2</a>');
+  }
+  function md(src) {
+    // Split on fences: odd chunks are code, even chunks are prose.
+    var out = "", chunks = esc(src).split(/```/);
+    chunks.forEach(function (chunk, i) {
+      if (i % 2) {
+        var code = chunk.replace(/^[^\n]*\n?/, "").replace(/\n+$/, "");
+        out += "<pre><code>" + code + "</code></pre>";
+        return;
+      }
+      chunk.split(/\n{2,}/).forEach(function (para) {
+        if (para.trim()) out += "<p>" + inline(para.trim()).replace(/\n/g, "<br>") + "</p>";
+      });
+    });
+    return out;
+  }
+
+  // -- rendering -------------------------------------------------------------
+  function stamp(at) {
+    if (!at) return "";
+    var d = new Date(at.replace(" ", "T") + "Z");
+    if (isNaN(d)) return "";
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  function el(tag, cls, html) {
+    var node = document.createElement(tag);
+    if (cls) node.className = cls;
+    if (html !== undefined) node.innerHTML = html;
+    return node;
+  }
+  function pretty(args) {
+    try { return JSON.stringify(args, null, 2); } catch (e) { return String(args); }
+  }
+
+  function renderText(entry) {
+    group = null;
+    var turn = el("div", "turn " + (entry.role === "user" ? "user" : "assistant"));
+    turn.appendChild(el("div", "body", md(entry.text)));
+    var t = stamp(entry.at);
+    if (t) turn.appendChild(el("div", "time", esc(t)));
+    if (!first) turn.classList.add("enter");
+    feed.appendChild(turn);
+  }
+
+  function newGroup() {
+    var wrap = el("div", "aside");
+    var chips = el("div", "chips");
+    wrap.appendChild(chips);
+    var g = { node: wrap, chips: chips, think: null, tools: null };
+    feed.appendChild(wrap);
+    return g;
+  }
+
+  /* One collapsible section per group: a chip that toggles a panel below it. */
+  function section(g, icon) {
+    var chip = el("button", "chip");
+    chip.type = "button";
+    chip.setAttribute("aria-expanded", "false");
+    var panel = el("div", "panel");
+    var inner = el("div", "inner");
+    var box = el("div", "disclosure");
+    inner.appendChild(box);
+    panel.appendChild(inner);
+    g.chips.appendChild(chip);
+    g.node.appendChild(panel);
+    chip.addEventListener("click", function () {
+      var open = panel.classList.toggle("open");
+      chip.setAttribute("aria-expanded", open ? "true" : "false");
+    });
+    return { chip: chip, box: box, icon: icon, count: 0, names: [] };
+  }
+
+  function renderThinking(g, entry) {
+    if (!g.think) g.think = section(g, "💭");
+    g.think.count++;
+    g.think.box.appendChild(el("div", "think", md(entry.text)));
+    g.think.chip.textContent = "💭 thinking";
+  }
+
+  function renderTool(g, entry) {
+    if (!g.tools) g.tools = section(g, "🔧");
+    var t = g.tools;
+    var call = el("div", "call");
+    if (entry.kind === "tool_call") {
+      t.count++;
+      if (t.names.length < 1) t.names.push(entry.name || "tool");
+      call.appendChild(el("div", "call-name", esc(entry.name || "tool")));
+      call.appendChild(el("pre", null, "<code>" + esc(pretty(entry.args)) + "</code>"));
+    } else {
+      call.appendChild(el("div", "label", esc(entry.name ? entry.name + " result" : "result")));
+      var pre = el("pre", null, "<code>" + esc(entry.text) + "</code>");
+      call.appendChild(pre);
+      if (entry.text.length > 400) {
+        pre.classList.add("clip");
+        var more = el("button", "more", "show more");
+        more.type = "button";
+        more.addEventListener("click", function () {
+          var clipped = pre.classList.toggle("clip");
+          more.textContent = clipped ? "show more" : "show less";
+        });
+        call.appendChild(more);
+      }
+    }
+    t.box.appendChild(call);
+    var extra = t.count - 1;
+    t.chip.textContent = "🔧 " + (t.names[0] || "tool") + (extra > 0 ? " (+" + extra + " more)" : "");
+  }
+
+  function render(entries) {
+    entries.forEach(function (entry) {
+      if (entry.kind === "text") { renderText(entry); return; }
+      if (!group) group = newGroup();
+      if (entry.kind === "reasoning") renderThinking(group, entry);
+      else renderTool(group, entry);
+    });
+  }
+
+  // -- scrolling -------------------------------------------------------------
+  function nearBottom() {
+    return window.innerHeight + window.scrollY >= document.body.scrollHeight - 160;
+  }
+  function toBottom(smooth) {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: smooth ? "smooth" : "auto" });
+  }
+  pill.addEventListener("click", function () { pill.classList.remove("show"); toBottom(true); });
+  window.addEventListener("scroll", function () {
+    if (nearBottom()) pill.classList.remove("show");
+  }, { passive: true });
+
+  // -- polling ---------------------------------------------------------------
+  function setLive(ok) {
+    live.classList.toggle("down", !ok);
+    liveLabel.textContent = ok ? "live" : "reconnecting…";
+  }
+
+  async function poll() {
+    try {
+      var resp = await fetch("/t/" + encodeURIComponent(TOKEN) + "/messages?after=" + cursor, {
+        headers: { "Accept": "application/json" }
+      });
+      if (!resp.ok) throw new Error(resp.status);
+      var data = await resp.json();
+      fails = 0;
+      setLive(true);
+      cursor = data.cursor;
+      if (data.entries.length) {
+        var stick = first || nearBottom();
+        empty.remove();
+        render(data.entries);
+        if (stick) toBottom(!first);
+        else pill.classList.add("show");
+      }
+      first = false;
+    } catch (e) {
+      fails++;
+      if (fails >= 3) setLive(false);
+    }
+    setTimeout(poll, fails >= 3 ? 10000 : 2000);
+  }
+
+  poll();
+})();
+</script>
+</body>
+</html>

--- a/humux/api/templates/transcript.html
+++ b/humux/api/templates/transcript.html
@@ -64,9 +64,8 @@
     align-items: center;
     gap: .6rem;
   }
-  .name { font-weight: 600; letter-spacing: -.01em; }
+  .name { font-weight: 600; letter-spacing: -.01em; margin-right: auto; }
   .share {
-    margin-left: auto;
     display: inline-flex;
     align-items: center;
     gap: .3rem;
@@ -87,6 +86,7 @@
   .share.copied { color: var(--accent); border-color: var(--accent); }
   .share.copied .link { display: none; }
   .share.copied .check, .share.copied .copied-label { display: block; }
+  .share[aria-pressed="true"] { color: var(--accent); border-color: var(--accent); }
 
   /* Live state — a quiet floating pill, out of the reading column. */
   .live {
@@ -287,6 +287,8 @@
 <header>
   <div class="bar">
     <span class="name">{{ agent_name }}</span>
+    <button class="share" id="think-toggle" type="button" aria-pressed="false"
+            title="Always expand thinking">💭 thinking</button>
     <button class="share" id="share" type="button" aria-label="Copy link to this page">
       <svg class="link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -511,11 +513,11 @@
   }
 
   /* One collapsible section per group: a chip that toggles a panel below it. */
-  function section(g, icon) {
-    var chip = el("button", "chip");
+  function section(g, icon, cls) {
+    var chip = el("button", "chip " + cls);
     chip.type = "button";
     chip.setAttribute("aria-expanded", "false");
-    var panel = el("div", "panel");
+    var panel = el("div", "panel " + cls);
     var inner = el("div", "inner");
     var box = el("div", "disclosure");
     inner.appendChild(box);
@@ -526,18 +528,21 @@
       var open = panel.classList.toggle("open");
       chip.setAttribute("aria-expanded", open ? "true" : "false");
     });
-    return { chip: chip, box: box, icon: icon, count: 0, names: [] };
+    return { chip: chip, panel: panel, box: box, icon: icon, count: 0, names: [] };
   }
 
   function renderThinking(g, entry) {
-    if (!g.think) g.think = section(g, "💭");
+    if (!g.think) {
+      g.think = section(g, "💭", "think-sec");
+      if (expandThinking) openSection(g.think.chip, g.think.panel, true);
+    }
     g.think.count++;
     g.think.box.appendChild(el("div", "think", md(entry.text)));
     g.think.chip.textContent = "💭 thinking";
   }
 
   function renderTool(g, entry) {
-    if (!g.tools) g.tools = section(g, "🔧");
+    if (!g.tools) g.tools = section(g, "🔧", "tool-sec");
     var t = g.tools;
     var call = el("div", "call");
     if (entry.kind === "tool_call") {
@@ -564,6 +569,33 @@
     var extra = t.count - 1;
     t.chip.textContent = "🔧 " + (t.names[0] || "tool") + (extra > 0 ? " (+" + extra + " more)" : "");
   }
+
+  /* Always-expand thinking: a viewer preference, remembered per browser. New
+     sections open as they stream in; flipping it applies to what is already on
+     screen. localStorage can throw (private mode, blocked site data), so every
+     access is guarded and the feature simply doesn't persist when it does. */
+  var expandThinking = false;
+  try { expandThinking = localStorage.getItem("expand-thinking") === "1"; } catch (e) { /* ok */ }
+  var thinkToggle = document.getElementById("think-toggle");
+
+  function openSection(chip, panel, open) {
+    panel.classList.toggle("open", open);
+    chip.setAttribute("aria-expanded", open ? "true" : "false");
+  }
+
+  function applyThinking() {
+    thinkToggle.setAttribute("aria-pressed", expandThinking ? "true" : "false");
+    var chips = feed.querySelectorAll(".chip.think-sec");
+    var panels = feed.querySelectorAll(".panel.think-sec");
+    for (var i = 0; i < chips.length; i++) openSection(chips[i], panels[i], expandThinking);
+  }
+
+  thinkToggle.addEventListener("click", function () {
+    expandThinking = !expandThinking;
+    try { localStorage.setItem("expand-thinking", expandThinking ? "1" : "0"); } catch (e) { /* ok */ }
+    applyThinking();
+  });
+  applyThinking();
 
   function render(entries) {
     entries.forEach(function (entry) {

--- a/humux/api/templates/transcript.html
+++ b/humux/api/templates/transcript.html
@@ -16,6 +16,10 @@
     --code: #f0ede6;
     --accent: #3f7d58;
     --shadow: 0 1px 2px rgba(0, 0, 0, .05);
+    --j-key: #5c6f8c;
+    --j-str: #3f7d58;
+    --j-num: #8a5c2e;
+    --j-bool: #7a5288;
   }
   @media (prefers-color-scheme: dark) {
     :root {
@@ -27,6 +31,10 @@
       --code: #232326;
       --accent: #7fc79b;
       --shadow: none;
+      --j-key: #93aac6;
+      --j-str: #7fc79b;
+      --j-num: #d3a877;
+      --j-bool: #bd9dd2;
     }
   }
   * { box-sizing: border-box; }
@@ -57,14 +65,51 @@
     gap: .6rem;
   }
   .name { font-weight: 600; letter-spacing: -.01em; }
-  .live {
+  .share {
     margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: .3rem;
+    font: inherit;
+    font-size: .72rem;
+    color: var(--muted);
+    background: none;
+    border: 1px solid var(--faint);
+    border-radius: 999px;
+    padding: .3rem .55rem;
+    cursor: pointer;
+    transition: color .15s, border-color .15s;
+  }
+  .share:hover { color: var(--ink); border-color: var(--muted); }
+  .share:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .share svg { width: 1rem; height: 1rem; display: block; }
+  .share .check, .share .copied-label { display: none; }
+  .share.copied { color: var(--accent); border-color: var(--accent); }
+  .share.copied .link { display: none; }
+  .share.copied .check, .share.copied .copied-label { display: block; }
+
+  /* Live state — a quiet floating pill, out of the reading column. */
+  .live {
+    position: fixed;
+    left: 50%;
+    bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+    z-index: 4;
+    transform: translateX(-50%);
     display: flex;
     align-items: center;
-    gap: .45rem;
-    font-size: .75rem;
+    gap: .4rem;
+    font-size: .7rem;
     color: var(--muted);
+    background: color-mix(in srgb, var(--page) 78%, transparent);
+    backdrop-filter: saturate(1.4) blur(8px);
+    border: 1px solid var(--faint);
+    border-radius: 999px;
+    padding: .25rem .7rem;
+    pointer-events: none;
+    opacity: .9;
+    transition: opacity .2s;
   }
+  #pill.show ~ .live { opacity: 0; }  /* new-messages pill wins the spot */
   .dot {
     width: .5rem;
     height: .5rem;
@@ -181,11 +226,40 @@
     cursor: pointer;
   }
   pre.clip { max-height: 11rem; overflow: hidden; }
+  pre.raw { white-space: pre-wrap; overflow-wrap: anywhere; }
+
+  /* JSON viewer — collapsible tree for tool arguments and results */
+  .json {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: .78rem;
+    line-height: 1.55;
+    background: var(--code);
+    border: 1px solid var(--faint);
+    border-radius: .6rem;
+    padding: .6rem .8rem;
+    margin: .35rem 0 0;
+  }
+  .jrow { white-space: pre-wrap; overflow-wrap: anywhere; }
+  .jkids { padding-left: 2ch; }
+  .jhead { cursor: pointer; }
+  .jhead:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: .25rem; }
+  .jtog { display: inline-block; width: 1.4ch; color: var(--muted); }
+  .jtog::before { content: "▾"; }
+  .jnode.collapsed > .jhead .jtog::before { content: "▸"; }
+  .jnode.collapsed > .jkids, .jnode.collapsed > .jclose { display: none; }
+  .jnode:not(.collapsed) > .jhead .jhint { display: none; }
+  .jhint, .jpunct { color: var(--muted); }
+  .jkey { color: var(--j-key); }
+  .jstr { color: var(--j-str); }
+  .jnum { color: var(--j-num); }
+  .jbool { color: var(--j-bool); }
+  .jnull { color: var(--muted); font-style: italic; }
+  .json .more { padding: 0 0 0 .4rem; vertical-align: baseline; }
 
   #pill {
     position: fixed;
     left: 50%;
-    bottom: 1.5rem;
+    bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
     transform: translate(-50%, 1rem);
     opacity: 0;
     pointer-events: none;
@@ -213,7 +287,18 @@
 <header>
   <div class="bar">
     <span class="name">{{ agent_name }}</span>
-    <span class="live" id="live"><span class="dot"></span><span id="live-label">live</span></span>
+    <button class="share" id="share" type="button" aria-label="Copy link to this page">
+      <svg class="link" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
+           stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M10 13.5a4 4 0 0 0 5.7.3l3-3a4 4 0 0 0-5.7-5.7L11.6 6.5"/>
+        <path d="M14 10.5a4 4 0 0 0-5.7-.3l-3 3a4 4 0 0 0 5.7 5.7l1.4-1.4"/>
+      </svg>
+      <svg class="check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+           stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M5 12.5 10 17.5 19 7"/>
+      </svg>
+      <span class="copied-label">Copied</span>
+    </button>
   </div>
 </header>
 
@@ -222,6 +307,7 @@
 </main>
 
 <button id="pill" type="button">↓ new messages</button>
+<div class="live" id="live"><span class="dot"></span><span id="live-label">updating live</span></div>
 
 <script>
 (function () {
@@ -279,8 +365,130 @@
     if (html !== undefined) node.innerHTML = html;
     return node;
   }
-  function pretty(args) {
-    try { return JSON.stringify(args, null, 2); } catch (e) { return String(args); }
+  // -- json viewer -----------------------------------------------------------
+  var STR_CLIP = 200;
+
+  function punct(text) {
+    var node = el("span", "jpunct");
+    node.textContent = text;
+    return node;
+  }
+
+  /* A string value, quoted and escaped, clipped with an inline "more" toggle. */
+  function jsonString(value) {
+    var full = JSON.stringify(value);
+    var span = el("span", "jstr");
+    if (full.length <= STR_CLIP) {
+      span.textContent = full;
+      return span;
+    }
+    var short = full.slice(0, STR_CLIP) + '…"';
+    span.textContent = short;
+    var wrap = el("span");
+    var more = el("button", "more", "more");
+    more.type = "button";
+    more.addEventListener("click", function () {
+      var open = span.textContent === short;
+      span.textContent = open ? full : short;
+      more.textContent = open ? "less" : "more";
+    });
+    wrap.appendChild(span);
+    wrap.appendChild(more);
+    return wrap;
+  }
+
+  function jsonLeaf(value) {
+    if (typeof value === "string") return jsonString(value);
+    var span = el("span", value === null ? "jnull" : typeof value === "number" ? "jnum" : "jbool");
+    span.textContent = String(value);
+    return span;
+  }
+
+  function jsonKey(row, key) {
+    if (key === null) return;
+    var node = el("span", "jkey");
+    node.textContent = key;
+    row.appendChild(node);
+    row.appendChild(punct(": "));
+  }
+
+  /* One value → one row (leaf) or a collapsible node. Nesting from depth 2 down
+     starts collapsed so a big payload still reads as a shape, not a wall. */
+  function jsonValue(value, key, depth, comma) {
+    var row;
+    if (!value || typeof value !== "object") {
+      row = el("div", "jrow");
+      jsonKey(row, key);
+      row.appendChild(jsonLeaf(value));
+      if (comma) row.appendChild(punct(","));
+      return row;
+    }
+    var arr = Array.isArray(value);
+    var keys = arr ? null : Object.keys(value);
+    var count = arr ? value.length : keys.length;
+    var open = arr ? "[" : "{";
+    var close = arr ? "]" : "}";
+    if (!count) {
+      row = el("div", "jrow");
+      jsonKey(row, key);
+      row.appendChild(punct(open + close + (comma ? "," : "")));
+      return row;
+    }
+    var node = el("div", "jnode" + (depth >= 2 ? " collapsed" : ""));
+    var head = el("div", "jrow jhead");
+    head.tabIndex = 0;
+    head.setAttribute("role", "button");
+    head.setAttribute("aria-expanded", depth >= 2 ? "false" : "true");
+    head.appendChild(el("span", "jtog"));
+    jsonKey(head, key);
+    head.appendChild(punct(open));
+    var hint = el("span", "jhint");
+    var unit = arr ? "item" : "key";
+    hint.textContent = "…" + close + " " + count + " " + unit + (count === 1 ? "" : "s");
+    head.appendChild(hint);
+    var kids = el("div", "jkids");
+    (keys || value).forEach(function (item, i) {
+      var last = i === count - 1;
+      kids.appendChild(arr
+        ? jsonValue(item, null, depth + 1, !last)
+        : jsonValue(value[item], item, depth + 1, !last));
+    });
+    var tail = el("div", "jrow jclose");
+    tail.appendChild(punct(close + (comma ? "," : "")));
+    node.appendChild(head);
+    node.appendChild(kids);
+    node.appendChild(tail);
+    function toggle() {
+      var collapsed = node.classList.toggle("collapsed");
+      head.setAttribute("aria-expanded", collapsed ? "false" : "true");
+    }
+    head.addEventListener("click", toggle);
+    head.addEventListener("keydown", function (e) {
+      if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggle(); }
+    });
+    return node;
+  }
+
+  /* Tool args arrive already decoded; results arrive as text that is often JSON.
+     Either way: a tree when it is JSON, wrapped monospace text when it is not. */
+  function payloadView(value) {
+    var data = value;
+    if (typeof data === "string") {
+      var head = data.trim().charAt(0);
+      if (head === "{" || head === "[") {
+        try { data = JSON.parse(data); } catch (e) { data = value; }
+      }
+    }
+    if (data && typeof data === "object") {
+      var box = el("div", "json");
+      box.appendChild(jsonValue(data, null, 0, false));
+      return box;
+    }
+    var pre = el("pre", "raw");
+    var code = el("code");
+    code.textContent = typeof value === "string" ? value : String(value);
+    pre.appendChild(code);
+    return pre;
   }
 
   function renderText(entry) {
@@ -336,12 +544,12 @@
       t.count++;
       if (t.names.length < 1) t.names.push(entry.name || "tool");
       call.appendChild(el("div", "call-name", esc(entry.name || "tool")));
-      call.appendChild(el("pre", null, "<code>" + esc(pretty(entry.args)) + "</code>"));
+      call.appendChild(payloadView(entry.args));
     } else {
       call.appendChild(el("div", "label", esc(entry.name ? entry.name + " result" : "result")));
-      var pre = el("pre", null, "<code>" + esc(entry.text) + "</code>");
+      var pre = payloadView(entry.text);
       call.appendChild(pre);
-      if (entry.text.length > 400) {
+      if (pre.tagName === "PRE" && entry.text.length > 400) {
         pre.classList.add("clip");
         var more = el("button", "more", "show more");
         more.type = "button";
@@ -378,10 +586,38 @@
     if (nearBottom()) pill.classList.remove("show");
   }, { passive: true });
 
+  // -- share -----------------------------------------------------------------
+  var share = document.getElementById("share");
+  var shareTimer = null;
+
+  share.addEventListener("click", function () {
+    var url = location.href;
+    function copied() {
+      share.classList.add("copied");
+      clearTimeout(shareTimer);
+      shareTimer = setTimeout(function () { share.classList.remove("copied"); }, 1500);
+    }
+    function legacy() {
+      var box = el("textarea");
+      box.value = url;
+      box.setAttribute("readonly", "");
+      box.style.cssText = "position:fixed;top:0;opacity:0";
+      document.body.appendChild(box);
+      box.select();
+      try { if (document.execCommand("copy")) copied(); } catch (e) { /* no clipboard */ }
+      box.remove();
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(copied, legacy);
+    } else {
+      legacy();
+    }
+  });
+
   // -- polling ---------------------------------------------------------------
   function setLive(ok) {
     live.classList.toggle("down", !ok);
-    liveLabel.textContent = ok ? "live" : "reconnecting…";
+    liveLabel.textContent = ok ? "updating live" : "reconnecting…";
   }
 
   async function poll() {

--- a/humux/channels/telegram.py
+++ b/humux/channels/telegram.py
@@ -54,6 +54,7 @@ _AGENT_COMMANDS = frozenset(
 _MENU_COMMANDS = [
     BotCommand("new", "Clear the conversation"),
     BotCommand("subagents", "List active subagent runs"),
+    BotCommand("weburl", "Open this chat as a live web page"),
     BotCommand("yolo_on", "Run actions without asking for approval"),
     BotCommand("yolo_off", "Restore approval prompts"),
     BotCommand("stop", "Stop the current turn"),
@@ -184,6 +185,7 @@ class TelegramChannel:
         # falls through to _on_text, which handles those.)
         self.app.add_handler(CommandHandler("subagents", self._on_subagents_command))
         self.app.add_handler(CommandHandler("jobs", self._on_subagents_command))  # compat alias
+        self.app.add_handler(CommandHandler("weburl", self._on_weburl_command))
         self.app.add_handler(MessageHandler(filters.TEXT, self._on_text))
         self.app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, self._on_voice))
         self.app.add_handler(MessageHandler(filters.PHOTO | filters.Document.IMAGE, self._on_photo))
@@ -674,6 +676,34 @@ class TelegramChannel:
                 [[InlineKeyboardButton("Cancel", callback_data=f"{_SUB_CANCEL_PREFIX}{r.run_id}")]]
             )
             await message.reply_text(text, parse_mode="HTML", reply_markup=keyboard)
+
+    async def _on_weburl_command(self, update: Update, context) -> None:
+        """/weburl — reply with this chat's read-only live web transcript link.
+
+        The link carries an unguessable token minted once per conversation, so
+        calling it again returns the same URL rather than invalidating the old one.
+        """
+        user = update.effective_user
+        message = update.message
+        chat = update.effective_chat
+        if not user or not message:
+            return
+        # Same keys the turn itself is stored under, so the page shows this exact
+        # conversation (a forum topic gets its own link, like its own history).
+        folded = self._fold(chat, message)
+        chat_id = str(folded if folded is not None else user.id)
+        convo_user = self._convo_user_id(chat, user.id)
+        if not await self._may_act(user.id, convo_user, chat_id):
+            return
+        token = await self.agent.history.web_token(self.channel_name, convo_user, chat_id)
+        base = self.agent._base_url()
+        text = f"🔗 Live transcript of this chat:\n{base}/t/{token}"
+        if "localhost" in base or "127.0.0.1" in base:
+            text += (
+                "\n\n<i>Set HUMUX_BASE_URL to the agent's public URL — this link "
+                "only opens on the machine running the agent.</i>"
+            )
+        await message.reply_text(text, parse_mode="HTML", disable_web_page_preview=True)
 
     async def _on_approval_callback(self, update: Update, context) -> None:
         """Handle inline keyboard button presses for permission approvals."""

--- a/humux/core/history.py
+++ b/humux/core/history.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import secrets
 from pathlib import Path
 from typing import Any
 
@@ -59,6 +60,14 @@ CREATE TABLE IF NOT EXISTS chat_agent (
     updated_at DATETIME DEFAULT (datetime('now')),
     PRIMARY KEY (channel, user_id, chat_id)
 );
+CREATE TABLE IF NOT EXISTS web_tokens (
+    token TEXT PRIMARY KEY,
+    channel TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    chat_id TEXT NOT NULL DEFAULT '',
+    created_at DATETIME DEFAULT (datetime('now')),
+    UNIQUE (channel, user_id, chat_id)
+);
 """
 
 # Migrations applied after initial schema creation.
@@ -83,6 +92,14 @@ _MIGRATIONS = [
         "ON session_messages(channel, user_id, chat_id, id)",
     ),
 ]
+
+
+def _loads(raw: str) -> Any:
+    """Parse a stored JSON payload, falling back to the raw string if it isn't JSON."""
+    try:
+        return json.loads(raw)
+    except TypeError, ValueError:
+        return raw
 
 
 class ConversationHistory:
@@ -542,6 +559,104 @@ class ConversationHistory:
             await db.commit()
         # The per-agent bot channel only carries traffic after a restart, so the
         # in-memory _session_system cache (keyed by the old channel) is moot here.
+
+    # -------------------------------------------------------------------
+    # Read-only web transcript — share tokens + raw rows (/weburl)
+    # -------------------------------------------------------------------
+
+    async def web_token(self, channel: str, user_id: str, chat_id: str = "") -> str:
+        """Return this context's web-transcript token, minting one on first call.
+
+        The token *is* the authentication for ``/t/<token>`` — 32 urlsafe bytes,
+        unguessable — so it is minted once and reused, keeping the link stable
+        across repeated ``/weburl`` calls. Kept here rather than in its own store
+        because it is keyed by exactly the (channel, user_id, chat_id) triple this
+        table set is already keyed by.
+        """
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT token FROM web_tokens WHERE channel = ? AND user_id = ? AND chat_id = ?",
+                (channel, user_id, chat_id),
+            )
+            row = await cursor.fetchone()
+            if row:
+                return str(row[0])
+            token = secrets.token_urlsafe(32)
+            await db.execute(
+                "INSERT INTO web_tokens (token, channel, user_id, chat_id) VALUES (?, ?, ?, ?)",
+                (token, channel, user_id, chat_id),
+            )
+            await db.commit()
+        return token
+
+    async def resolve_web_token(self, token: str) -> tuple[str, str, str] | None:
+        """The (channel, user_id, chat_id) a web token opens, or None if unknown."""
+        if not token:
+            return None
+        await self._ensure_schema()
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT channel, user_id, chat_id FROM web_tokens WHERE token = ?",
+                (token,),
+            )
+            row = await cursor.fetchone()
+        return (row[0], row[1], row[2]) if row else None
+
+    async def transcript_rows(
+        self, channel: str, user_id: str, chat_id: str = "", after: int = 0, limit: int = 500
+    ) -> list[dict[str, Any]]:
+        """Stored messages for one context with an id past ``after``, oldest first.
+
+        Reads whichever mode this context actually recorded in — the sticky
+        session when it has rows, else the windowed turns — so one integer cursor
+        works for both. The system prompt lives in its own table and is never
+        returned here. ponytail: a context that switches history mode mid-life
+        restarts its cursor space; the page just re-renders from 0 on the next
+        load, which is not worth a compound cursor.
+        """
+        await self._ensure_schema()
+        after = max(0, after)
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "SELECT 1 FROM session_messages "
+                "WHERE channel = ? AND user_id = ? AND chat_id = ? LIMIT 1",
+                (channel, user_id, chat_id),
+            )
+            session_mode = await cursor.fetchone() is not None
+            if session_mode:
+                cursor = await db.execute(
+                    "SELECT id, message, created_at FROM session_messages "
+                    "WHERE channel = ? AND user_id = ? AND chat_id = ? AND id > ? "
+                    "ORDER BY id ASC LIMIT ?",
+                    (channel, user_id, chat_id, after, limit),
+                )
+                return [
+                    {
+                        "id": rid,
+                        "source": "session",
+                        "role": "",
+                        "payload": _loads(payload),
+                        "created_at": created_at,
+                    }
+                    for rid, payload, created_at in await cursor.fetchall()
+                ]
+            cursor = await db.execute(
+                "SELECT id, role, content, created_at FROM conversation_turns "
+                "WHERE channel = ? AND user_id = ? AND chat_id = ? AND id > ? "
+                "ORDER BY id ASC LIMIT ?",
+                (channel, user_id, chat_id, after, limit),
+            )
+            return [
+                {
+                    "id": rid,
+                    "source": "turn",
+                    "role": role,
+                    "payload": _loads(payload),
+                    "created_at": created_at,
+                }
+                for rid, role, payload, created_at in await cursor.fetchall()
+            ]
 
     async def list_chats(self) -> list[dict[str, str]]:
         """List every known (channel, user_id, chat_id), most-recently-active first.

--- a/humux/core/transcript.py
+++ b/humux/core/transcript.py
@@ -1,0 +1,178 @@
+"""Typed transcript entries for the read-only web view (``/weburl``).
+
+Flattens raw stored history into entries a dumb frontend can render without
+knowing anything about providers or history modes:
+
+    {"kind": "text",        "role": "user"|"assistant", "text": ...}
+    {"kind": "reasoning",   "text": ...}
+    {"kind": "tool_call",   "name": ..., "args": {...}}
+    {"kind": "tool_result", "name": ..., "text": ...}
+
+Injection mode stores plain text turns, so it only ever yields ``text``.
+Session mode stores the provider-shaped message array, so Anthropic content
+blocks (``thinking`` / ``tool_use`` / ``tool_result``) and OpenAI-family raw
+dicts (``reasoning_content``, ``tool_calls``, ``role: tool``) also yield the
+disclosure kinds. Anything unrecognised is dropped rather than guessed at.
+
+The system prompt is stored in its own table and never reaches this module.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+# The per-turn preamble the agent prepends to the user's text (live date/time,
+# skills index, memories, accounts, execution plan). It is context for the model,
+# not something the user typed, so it is stripped from the displayed message.
+# Every block is either a bracketed line or a <tag>…</tag> wrapper, and the whole
+# preamble always opens with the date stamp — which is what gates the strip.
+_PREAMBLE_MARKER = "[Current date & time:"
+_PREAMBLE_BLOCK = re.compile(r"\A(?:\[[^\]]*\]|<([a-z_]+)>.*?</\1>)\s*", re.S)
+
+# Tool results can be megabytes (a file read, a search dump). Cap what we ship;
+# the page shows the head behind a "show more" anyway.
+_MAX_RESULT_CHARS = 8000
+
+
+def strip_preamble(text: str) -> str:
+    """Drop the injected per-turn preamble from a stored user message.
+
+    ponytail: heuristic — a user message that itself opens with a bracketed line
+    right after a real preamble would lose that line. Cheaper than threading the
+    raw message through the whole persistence path just for this view.
+    """
+    if not text.startswith(_PREAMBLE_MARKER):
+        return text
+    while match := _PREAMBLE_BLOCK.match(text):
+        text = text[match.end() :]
+    return text.strip()
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= _MAX_RESULT_CHARS:
+        return text
+    return text[:_MAX_RESULT_CHARS] + "\n… (truncated)"
+
+
+def _block_text(content: Any) -> str:
+    """Flatten a tool_result ``content`` (str, or a list of text blocks) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return "\n".join(parts)
+    if content is None:
+        return ""
+    return json.dumps(content, ensure_ascii=False, default=str)
+
+
+def _parse_args(raw: Any) -> Any:
+    """Tool arguments as a JSON-able value (OpenAI ships them as a JSON string)."""
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw or "{}")
+        except ValueError:
+            return raw
+    return raw if raw is not None else {}
+
+
+def _session_entries(msg: dict, names: dict[str, str]) -> list[dict]:
+    """Entries for one stored session message. ``names`` maps tool-use id → name,
+    accumulated across the batch so a result can be labelled with its call."""
+    role = str(msg.get("role") or "")
+    if role == "system":
+        return []  # never surfaced, defence in depth
+    if role == "tool":  # OpenAI-family tool result
+        call_id = str(msg.get("tool_call_id") or "")
+        return [
+            {
+                "kind": "tool_result",
+                "name": names.get(call_id, ""),
+                "text": _truncate(_block_text(msg.get("content"))),
+            }
+        ]
+
+    out: list[dict] = []
+    reasoning = msg.get("reasoning_content") or msg.get("reasoning") or ""
+    if isinstance(reasoning, str) and reasoning.strip():
+        out.append({"kind": "reasoning", "text": reasoning.strip()})
+
+    content = msg.get("content")
+    text_parts: list[str] = []
+    if isinstance(content, str):
+        text_parts.append(content)
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text":
+                text_parts.append(str(block.get("text") or ""))
+            elif btype == "thinking":
+                thought = str(block.get("thinking") or "").strip()
+                if thought:
+                    out.append({"kind": "reasoning", "text": thought})
+            elif btype == "redacted_thinking":
+                out.append({"kind": "reasoning", "text": "[redacted reasoning]"})
+            elif btype == "tool_use":
+                name = str(block.get("name") or "")
+                names[str(block.get("id") or "")] = name
+                out.append({"kind": "tool_call", "name": name, "args": block.get("input") or {}})
+            elif btype == "tool_result":
+                call_id = str(block.get("tool_use_id") or "")
+                out.append(
+                    {
+                        "kind": "tool_result",
+                        "name": names.get(call_id, ""),
+                        "text": _truncate(_block_text(block.get("content"))),
+                    }
+                )
+            elif btype in ("image", "input_image", "image_url"):
+                text_parts.append("[image]")
+
+    for call in msg.get("tool_calls") or []:  # OpenAI-family assistant tool calls
+        if not isinstance(call, dict):
+            continue
+        fn = call.get("function") or {}
+        name = str(fn.get("name") or "")
+        names[str(call.get("id") or "")] = name
+        out.append({"kind": "tool_call", "name": name, "args": _parse_args(fn.get("arguments"))})
+
+    text = "\n\n".join(p for p in text_parts if p).strip()
+    if role == "user":
+        text = strip_preamble(text)
+    if text:
+        out.append({"kind": "text", "role": role or "assistant", "text": text})
+    return out
+
+
+def to_entries(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten :meth:`ConversationHistory.transcript_rows` output into entries.
+
+    Each entry carries the row id it came from plus its index within that row, so
+    the frontend has a stable key, and the row's ``created_at`` as ``at``.
+    """
+    names: dict[str, str] = {}
+    entries: list[dict[str, Any]] = []
+    for row in rows:
+        payload = row.get("payload")
+        if row.get("source") == "session":
+            row_entries = _session_entries(payload, names) if isinstance(payload, dict) else []
+        elif isinstance(payload, str):
+            role = str(row.get("role") or "assistant")
+            text = strip_preamble(payload) if role == "user" else payload
+            row_entries = [{"kind": "text", "role": role, "text": text}] if text.strip() else []
+        else:
+            row_entries = []
+        for index, entry in enumerate(row_entries):
+            entry["id"] = f"{row['id']}.{index}"
+            entry["at"] = row.get("created_at") or ""
+            entries.append(entry)
+    return entries

--- a/humux/tests/test_transcript_web.py
+++ b/humux/tests/test_transcript_web.py
@@ -94,6 +94,20 @@ def test_page_renders_with_agent_name(tmp_path) -> None:
     assert "noindex" in resp.headers["x-robots-tag"]
 
 
+def test_page_offers_the_always_expand_thinking_toggle(tmp_path) -> None:
+    """Thinking is collapsed behind a chip per turn; the toggle is what lets a
+    reader who wants all of it stop clicking every one."""
+
+    async def seed():
+        return await _history(tmp_path).web_token("telegram", "u1", "c1")
+
+    token = asyncio.run(seed())
+    body = _client(tmp_path).get(f"/t/{token}").text
+    assert 'id="think-toggle"' in body
+    assert "expand-thinking" in body  # remembered per browser
+    assert "think-sec" in body  # the class the toggle opens in bulk
+
+
 def test_messages_are_scoped_to_the_context_and_respect_after(tmp_path) -> None:
     async def seed():
         h = _history(tmp_path)

--- a/humux/tests/test_transcript_web.py
+++ b/humux/tests/test_transcript_web.py
@@ -1,0 +1,294 @@
+"""Read-only live web transcript: share tokens, the public routes, and the
+entry classification behind the page's progressive disclosures (/weburl)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+
+from api.admin import AgentState, create_admin_app
+from channels.telegram import _MENU_COMMANDS, TelegramChannel
+from core.config_store import ConfigStore
+from core.history import ConversationHistory
+from core.transcript import strip_preamble, to_entries
+
+
+class _Store:
+    """Config-store stub; history lives under tmp_path."""
+
+    def __init__(self, tmp_path):
+        self._data = {
+            "history.db_path": str(tmp_path / "history.db"),
+            "agent.name": "Ada",
+        }
+
+    async def is_setup_complete(self) -> bool:
+        return True
+
+    async def get(self, key: str):
+        if key == "admin.password_hash":
+            return "hash"
+        if key == "admin.password_salt":
+            return "salt"
+        return self._data.get(key)
+
+    async def set_many(self, values: dict) -> None:
+        self._data.update(values)
+
+    async def verify_admin_password(self, password: str) -> bool:
+        return password == "secret"
+
+    async def get_all_redacted(self) -> dict:
+        return {}
+
+
+def _history(tmp_path) -> ConversationHistory:
+    return ConversationHistory(db_path=str(tmp_path / "history.db"))
+
+
+def _client(tmp_path) -> TestClient:
+    app, _ = create_admin_app(AgentState(agent=None), cast(ConfigStore, _Store(tmp_path)))
+    return TestClient(app)
+
+
+# ── Token store ─────────────────────────────────────────────────────────────
+
+
+def test_token_is_stable_per_context_and_unique_across_contexts(tmp_path) -> None:
+    async def go():
+        h = _history(tmp_path)
+        first = await h.web_token("telegram", "u1", "c1")
+        second = await h.web_token("telegram", "u1", "c1")  # a second /weburl
+        other = await h.web_token("telegram", "u2", "c2")
+        assert first == second  # the link stays shareable
+        assert len(first) > 32 and other != first
+        assert await h.resolve_web_token(first) == ("telegram", "u1", "c1")
+        assert await h.resolve_web_token("nope") is None
+
+    asyncio.run(go())
+
+
+# ── Routes ──────────────────────────────────────────────────────────────────
+
+
+def test_bad_token_is_404_on_both_routes(tmp_path) -> None:
+    client = _client(tmp_path)
+    assert client.get("/t/whatever").status_code == 404
+    assert client.get("/t/whatever/messages").status_code == 404
+
+
+def test_page_renders_with_agent_name(tmp_path) -> None:
+    async def seed():
+        return await _history(tmp_path).web_token("telegram", "u1", "c1")
+
+    token = asyncio.run(seed())
+    resp = _client(tmp_path).get(f"/t/{token}")
+    assert resp.status_code == 200
+    assert "Ada" in resp.text
+    assert "Nothing here yet" in resp.text
+    assert resp.headers["cache-control"] == "no-store"
+    assert "noindex" in resp.headers["x-robots-tag"]
+
+
+def test_messages_are_scoped_to_the_context_and_respect_after(tmp_path) -> None:
+    async def seed():
+        h = _history(tmp_path)
+        await h.add_turn("telegram", "u1", "user", "mine", "c1")
+        await h.add_turn("telegram", "u1", "assistant", "yours", "c1")
+        await h.add_turn("telegram", "u2", "user", "SECRET", "c2")  # another chat
+        return await h.web_token("telegram", "u1", "c1")
+
+    token = asyncio.run(seed())
+    client = _client(tmp_path)
+    resp = client.get(f"/t/{token}/messages")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [e["text"] for e in data["entries"]] == ["mine", "yours"]
+    assert [e["role"] for e in data["entries"]] == ["user", "assistant"]
+    assert "SECRET" not in resp.text
+    assert data["cursor"] > 0
+
+    # The cursor pages forward: nothing new yet, then only the new turn.
+    again = client.get(f"/t/{token}/messages", params={"after": data["cursor"]}).json()
+    assert again["entries"] == [] and again["cursor"] == data["cursor"]
+
+    async def more():
+        await _history(tmp_path).add_turn("telegram", "u1", "user", "later", "c1")
+
+    asyncio.run(more())
+    tail = client.get(f"/t/{token}/messages", params={"after": data["cursor"]}).json()
+    assert [e["text"] for e in tail["entries"]] == ["later"]
+
+
+def test_session_mode_yields_typed_disclosure_entries(tmp_path) -> None:
+    """A session-mode tool round classifies into reasoning / tool_call /
+    tool_result / text; injection mode has none of them (plain text only)."""
+
+    async def seed():
+        h = _history(tmp_path)
+        await h.append_session_message("telegram", "u1", {"role": "user", "content": "hi"}, "c1")
+        await h.append_session_message(
+            "telegram",
+            "u1",
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "let me look"},
+                    {"type": "text", "text": "one sec"},
+                    {"type": "tool_use", "id": "t1", "name": "web_search", "input": {"q": "cats"}},
+                ],
+            },
+            "c1",
+        )
+        await h.append_session_message(
+            "telegram",
+            "u1",
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "found"}],
+            },
+            "c1",
+        )
+        await h.append_session_message(
+            "telegram", "u1", {"role": "assistant", "content": "done"}, "c1"
+        )
+        return await h.web_token("telegram", "u1", "c1")
+
+    token = asyncio.run(seed())
+    entries = _client(tmp_path).get(f"/t/{token}/messages").json()["entries"]
+    kinds = [e["kind"] for e in entries]
+    assert kinds == ["text", "reasoning", "tool_call", "text", "tool_result", "text"]
+    call = entries[2]
+    assert call["name"] == "web_search" and call["args"] == {"q": "cats"}
+    assert entries[4]["name"] == "web_search" and entries[4]["text"] == "found"
+    assert all(e["id"] and "at" in e for e in entries)
+
+
+def test_injection_mode_has_text_entries_only(tmp_path) -> None:
+    async def seed():
+        h = _history(tmp_path)
+        await h.add_turn("telegram", "u1", "user", "hello", "c1")
+        await h.add_turn("telegram", "u1", "assistant", "hi there", "c1")
+        return await h.web_token("telegram", "u1", "c1")
+
+    token = asyncio.run(seed())
+    entries = _client(tmp_path).get(f"/t/{token}/messages").json()["entries"]
+    assert {e["kind"] for e in entries} == {"text"}
+
+
+# ── Classification details ──────────────────────────────────────────────────
+
+
+def test_openai_shapes_and_preamble_stripping() -> None:
+    rows = [
+        {
+            "id": 1,
+            "source": "session",
+            "role": "",
+            "created_at": "2026-08-20 10:00:00",
+            "payload": {
+                "role": "user",
+                "content": (
+                    "[Current date & time: Thursday, August 20, 2026 10:00 UTC]\n\n"
+                    "<memories>\nlikes tea\n\nand cats\n</memories>\n\nwhat's up?"
+                ),
+            },
+        },
+        {
+            "id": 2,
+            "source": "session",
+            "role": "",
+            "created_at": "2026-08-20 10:00:01",
+            "payload": {
+                "role": "assistant",
+                "content": None,
+                "reasoning_content": "thinking hard",
+                "tool_calls": [
+                    {"id": "c1", "function": {"name": "bash", "arguments": '{"cmd": "ls"}'}}
+                ],
+            },
+        },
+        {
+            "id": 3,
+            "source": "session",
+            "role": "",
+            "created_at": "2026-08-20 10:00:02",
+            "payload": {"role": "tool", "tool_call_id": "c1", "content": "file.txt"},
+        },
+        {
+            "id": 4,
+            "source": "session",
+            "role": "",
+            "created_at": "2026-08-20 10:00:03",
+            "payload": {"role": "system", "content": "NEVER SHOW THIS"},
+        },
+    ]
+    entries = to_entries(rows)
+    assert [e["kind"] for e in entries] == ["text", "reasoning", "tool_call", "tool_result"]
+    assert entries[0]["text"] == "what's up?"  # preamble + memories dropped
+    assert entries[2]["args"] == {"cmd": "ls"}
+    assert entries[3]["name"] == "bash"  # result labelled from its call
+    assert not any("NEVER SHOW THIS" in str(e) for e in entries)
+
+
+def test_strip_preamble_leaves_ordinary_messages_alone() -> None:
+    assert strip_preamble("[note] to self") == "[note] to self"
+    assert strip_preamble("plain text") == "plain text"
+
+
+# ── Telegram command ────────────────────────────────────────────────────────
+
+
+def test_weburl_command_replies_with_the_stable_link(tmp_path) -> None:
+    async def go():
+        history = _history(tmp_path)
+        ch = object.__new__(TelegramChannel)
+        ch.channel_name = "telegram"
+        ch._fold = lambda chat, message=None: chat.id
+        ch._convo_user_id = lambda chat, sender_id: str(sender_id)
+        ch._may_act = AsyncMock(return_value=True)
+        ch.agent = SimpleNamespace(history=history, _base_url=lambda: "https://agent.example")
+
+        msg = SimpleNamespace(reply_text=AsyncMock(), message_id=1)
+        update = SimpleNamespace(
+            effective_user=SimpleNamespace(id=7),
+            message=msg,
+            effective_chat=SimpleNamespace(id=100, type="private"),
+        )
+        await ch._on_weburl_command(update, None)
+        await ch._on_weburl_command(update, None)
+
+        urls = [call.args[0] for call in msg.reply_text.await_args_list]
+        assert urls[0] == urls[1]  # same token on a second call
+        token = urls[0].rsplit("/t/", 1)[1]
+        assert await history.resolve_web_token(token) == ("telegram", "7", "100")
+        assert "localhost" not in urls[0]
+
+    asyncio.run(go())
+
+
+def test_weburl_command_respects_the_permission_gate(tmp_path) -> None:
+    async def go():
+        ch = object.__new__(TelegramChannel)
+        ch.channel_name = "telegram"
+        ch._fold = lambda chat, message=None: chat.id
+        ch._convo_user_id = lambda chat, sender_id: str(sender_id)
+        ch._may_act = AsyncMock(return_value=False)
+        msg = SimpleNamespace(reply_text=AsyncMock(), message_id=1)
+        update = SimpleNamespace(
+            effective_user=SimpleNamespace(id=7),
+            message=msg,
+            effective_chat=SimpleNamespace(id=100, type="private"),
+        )
+        await ch._on_weburl_command(update, None)
+        msg.reply_text.assert_not_awaited()
+
+    asyncio.run(go())
+
+
+def test_weburl_is_in_the_telegram_menu() -> None:
+    assert any(cmd.command == "weburl" for cmd in _MENU_COMMANDS)


### PR DESCRIPTION
Stacked on #312 (`feat/subagents-fanout`) — review that one first.

`/weburl` in any Telegram chat replies with a link to a read-only web page showing that conversation, updating live.

### Security model

The token in the path is the only credential — `secrets.token_urlsafe(32)`, no login, the same trade the public `/artifacts/` route already makes. It is minted **once** per `(channel, user_id, chat_id)` and reused, so the link stays shareable across repeated `/weburl` calls, and it resolves to exactly one context: a group, a DM and a forum topic each get their own page and none can read the others'. `/weburl` itself sits behind the usual `_may_act` per-chat gate, so only people who may talk to the bot there can mint a link. The system prompt lives in its own table and is never returned; responses are `no-store` + `noindex`.

Tokens live in a small table in the history DB — it is already keyed by the same triple, so no new store, db path or wiring.

### Polling

The page fetches `/t/{token}/messages?after=<cursor>` every 2s, backing off to 10s after 3 consecutive failures and resuming on the next success (the live dot greys and reads "reconnecting…" meanwhile). The cursor is the row id, so each poll ships only what is new. Entries are typed (`{kind: "text" | "reasoning" | "tool_call" | "tool_result"}`), which keeps the frontend dumb and makes an SSE swap a backend-only change later.

### Classification

`core/transcript.py` flattens whatever the context actually recorded into those entries: injection mode stores plain text turns, so it yields text only; session mode stores the provider-shaped array, so Anthropic content blocks (`thinking` / `tool_use` / `tool_result`) and OpenAI-family raw dicts (`reasoning_content`, `tool_calls`, `role: tool`) also yield the disclosure kinds. Tool results are labelled with their call's name and capped. The injected per-turn preamble (date stamp, memories, skills index, accounts) is stripped from user text so the page shows what was typed.

### The page

One self-contained Jinja template — inline CSS + vanilla JS, no CDNs, no build step. Reading column, user turns as tinted bubbles, agent turns as plain prose with a hand-rolled markdown-lite renderer (escape first, then fences / inline code / bold / italic / links). Reasoning and tool activity sit between messages as muted chips ("💭 thinking", "🔧 web_search (+2 more)") that expand inline; long results clip behind "show more". Tuned light and dark palettes via `prefers-color-scheme`, accent used only for the live dot and links. Auto-scrolls only when the reader is already near the bottom, otherwise offers a "↓ new messages" pill.

### Tests

`tests/test_transcript_web.py` — token stability and scoping, 404 on a bad token, page render, `after` paging, cross-context isolation, session-mode classification (Anthropic blocks and OpenAI shapes), injection-mode text-only, preamble stripping, and the Telegram command (stable link + permission gate + menu entry).

`1031 passed` on the main run, `117 passed` on the two isolated files, `ruff check` clean.
