### PR TITLE
the agent itself answers when delegated work lands

### DIFF
--- a/humux/api/admin.py
+++ b/humux/api/admin.py
@@ -2206,14 +2206,6 @@ def create_admin_app(
             )
         except json.JSONDecodeError, TypeError:
             sub_allowed = ""
-        # Result-summary inference (notification + context digest) for finished
-        # background batches — fast/cheap model by default.
-        ss_enabled = await config_store.get("subagent_summary.enabled")
-        ss_enabled = ss_enabled if ss_enabled is not None else "true"
-        ss_provider = await config_store.get("subagent_summary.provider") or "deepseek"
-        ss_model = await config_store.get("subagent_summary.model") or "deepseek-v4-flash"
-        ss_thinking = await config_store.get("subagent_summary.thinking_level") or ""
-
         # Image generation (issue #55).
         ig_enabled = await config_store.get("tools.imagegen.enabled")
         ig_enabled = ig_enabled if ig_enabled is not None else "false"
@@ -2275,10 +2267,6 @@ def create_admin_app(
             subagents_max_spawns_per_turn=sub_spawns_turn,
             subagents_turn_token_budget=sub_turn_tokens,
             subagents_allowed_models=sub_allowed,
-            summary_enabled=ss_enabled,
-            summary_provider=ss_provider,
-            summary_model=ss_model,
-            summary_thinking_level=ss_thinking,
             imagegen_enabled=ig_enabled,
             imagegen_provider=ig_provider,
             imagegen_model=ig_model,

--- a/humux/api/templates/partials/tools.html
+++ b/humux/api/templates/partials/tools.html
@@ -72,10 +72,6 @@
     spawnsPerTurn: {{ subagents_max_spawns_per_turn|default('12', true)|tojson|forceescape }},
     turnTokens: {{ subagents_turn_token_budget|default('400000', true)|tojson|forceescape }},
     allowedModels: {{ subagents_allowed_models|default('', true)|tojson|forceescape }},
-    summaryEnabled: {{ summary_enabled|default('true', true)|tojson|forceescape }},
-    summaryProvider: {{ summary_provider|default('deepseek', true)|tojson|forceescape }},
-    summaryModel: {{ summary_model|default('deepseek-v4-flash', true)|tojson|forceescape }},
-    summaryThinking: {{ summary_thinking_level|default('', true)|tojson|forceescape }},
     result: '', resultOk: false,
     save() {
       const vals = {
@@ -87,11 +83,7 @@
         'subagents.max_fanout': String(parseInt(this.fanout) || 1),
         'subagents.max_spawns_per_turn': String(parseInt(this.spawnsPerTurn) || 1),
         'subagents.turn_token_budget': String(parseInt(this.turnTokens) || 1),
-        'subagents.allowed_models': JSON.stringify(String(this.allowedModels || '').split('\n').map(s => s.trim()).filter(Boolean)),
-        'subagent_summary.enabled': String(this.summaryEnabled === true || this.summaryEnabled === 'true'),
-        'subagent_summary.provider': String(this.summaryProvider || 'deepseek').trim(),
-        'subagent_summary.model': String(this.summaryModel || 'deepseek-v4-flash').trim(),
-        'subagent_summary.thinking_level': String(this.summaryThinking || '').trim()
+        'subagents.allowed_models': JSON.stringify(String(this.allowedModels || '').split('\n').map(s => s.trim()).filter(Boolean))
       };
       return fetch('/config', {
         method: 'PATCH',
@@ -170,37 +162,6 @@
         spawn asking for anything else is refused. Blank = subagents always inherit the
         caller's model. Each provider uses its API key from the <strong>Assistant</strong> tab.
       </p>
-    </div>
-    <div class="border-t border-border mt-4 pt-4" x-show="enabled === 'true' || enabled === true">
-      <div class="flex items-center justify-between gap-3 mb-1">
-        <h4 class="text-xs text-accent">Result summary</h4>
-        <div class="flex items-center gap-2">
-          <label class="label mb-0" for="tools-sub-summary-enabled">Enabled</label>
-          <input type="checkbox" x-model="summaryEnabled"
-                 :checked="summaryEnabled === 'true' || summaryEnabled === true" id="tools-sub-summary-enabled">
-        </div>
-      </div>
-      <p class="text-muted text-xs mb-3">
-        When a batch of background runs finishes, a small inference distils it into a
-        one-line chat notification plus a concise context digest (instead of dumping
-        raw output). Off falls back to a crude first-line truncation.
-      </p>
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-3"
-           x-show="summaryEnabled === 'true' || summaryEnabled === true">
-        <div>
-          <label class="label" for="tools-sub-summary-provider">Provider</label>
-          <input type="text" class="input-sm" x-model="summaryProvider" placeholder="deepseek" id="tools-sub-summary-provider">
-        </div>
-        <div>
-          <label class="label" for="tools-sub-summary-model">Model</label>
-          <input type="text" class="input-sm" x-model="summaryModel" placeholder="deepseek-v4-flash" id="tools-sub-summary-model">
-        </div>
-        <div>
-          <label class="label" for="tools-sub-summary-thinking">Thinking level</label>
-          <input type="text" class="input-sm" x-model="summaryThinking" placeholder="off" id="tools-sub-summary-thinking">
-          <p class="text-muted text-xs mt-1">Blank = off. low / medium / high for reasoning models.</p>
-        </div>
-      </div>
     </div>
     <div class="flex items-center gap-2 mt-4">
       <button class="btn-primary btn-sm" @click="withLoading($el, () => save())">Save</button>

--- a/humux/config.yml.example
+++ b/humux/config.yml.example
@@ -227,15 +227,6 @@ subagents:
   # (e.g. a cheap worker under an expensive coordinator). Empty = inherit only.
   allowed_models: []   # e.g. ["deepseek:deepseek-v4-flash"]
 
-# When a background subagent batch finishes, distil it into a one-line chat
-# notification + a concise context digest (instead of dumping the raw output).
-# Off → a crude first-line truncation with no LLM call.
-subagent_summary:
-  enabled: true
-  provider: "deepseek"
-  model: "deepseek-v4-flash"   # fast + cheap is ideal for this distillation
-  thinking_level: ""           # "" (off) | "low" | "medium" | "high"
-
 # Reply decision — in shared/group chats with several bots and people, decide
 # per message whether to reply at all. Stays quiet for messages aimed at another
 # bot, caught in a bot-to-bot reaction loop, or that the agent can't usefully add

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -175,13 +175,15 @@ _SUBAGENT_NOTE_MIN_SECONDS = 10.0
 # Defensive ceiling on how much of ONE background run's result is folded back
 # into the conversation when its batch lands (#315). Nothing else caps a
 # subagent's output, and the batch is appended to the agent's context whole.
-# ~4000 chars ≈ 1k tokens: room for the dense fact dump the child is told to
-# return (RESULT_FOR_AGENT_INSTRUCTION), small enough that a runaway helper
-# can't weigh down every later turn. The full text stays in the registry, so
-# /subagents and the admin Jobs page still show it.
+# Size is NOT the primary control — the child is told to return a dense fact
+# dump (RESULT_FOR_AGENT_INSTRUCTION) and to hand bulk back as a file path, so
+# a result near this line means the brief was wrong, not that the cap is tight.
+# ~80k chars ≈ 20k tokens: deliberately generous, so this only ever catches a
+# genuine runaway and never silently clips a legitimate answer. The full text
+# stays in the registry, so /subagents and the admin Jobs page still show it.
 # ponytail: a flat character cap, not a token count — only worth refining if a
 # real run ever lands close to the line and loses something that mattered.
-_SUBAGENT_RESULT_MAX_CHARS = 4000
+_SUBAGENT_RESULT_MAX_CHARS = 80_000
 
 # A turn started BY a landing batch may not start more background work: its own
 # results would wake another turn, and so on (#315). Synchronous spawns stay

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -56,14 +56,12 @@ from core.subagents import (
     SubagentRun,
     allowed_models_hint,
     derive_label,
-    fallback_summary,
     narrow_accounts,
     narrow_scope,
     normalize_effort,
     resolve_cap,
     resolve_model_override,
     short_summary,
-    summarize_batch,
 )
 from core.tools import _gh_app_configured, effective_tool_env, github_repo_violation
 from voice.pipeline import VoicePipeline
@@ -173,6 +171,27 @@ _LOOP_ABORT_MESSAGE = (
 # A sync spawn's result lands in the very next reply, so a completion note only
 # earns its noise when the run kept the user waiting this long.
 _SUBAGENT_NOTE_MIN_SECONDS = 10.0
+
+# Defensive ceiling on how much of ONE background run's result is folded back
+# into the conversation when its batch lands (#315). Nothing else caps a
+# subagent's output, and the batch is appended to the agent's context whole.
+# ~4000 chars ≈ 1k tokens: room for the dense fact dump the child is told to
+# return (RESULT_FOR_AGENT_INSTRUCTION), small enough that a runaway helper
+# can't weigh down every later turn. The full text stays in the registry, so
+# /subagents and the admin Jobs page still show it.
+# ponytail: a flat character cap, not a token count — only worth refining if a
+# real run ever lands close to the line and loses something that mattered.
+_SUBAGENT_RESULT_MAX_CHARS = 4000
+
+# A turn started BY a landing batch may not start more background work: its own
+# results would wake another turn, and so on (#315). Synchronous spawns stay
+# allowed — they return inside the turn, already bounded by FanoutBudget and
+# max_tool_rounds, so they cannot chain into another wake-up.
+_NO_BACKGROUND_IN_WOKEN_TURN = (
+    "Background spawns are not allowed in this turn — it started because "
+    "delegated work landed. Run the subtask now with background=false, or leave "
+    "it until the owner asks again."
+)
 
 # Returned for ANY web-search backend failure. The raw exception was an httpx
 # message carrying the internal endpoint URL and a link to the HTTP status docs,
@@ -785,6 +804,10 @@ TOOLS = [
             "that is never wider than yours, and returns a structured result. It "
             "has NO memory of this conversation — put everything it needs in "
             "'task'.\n"
+            "Say exactly what shape you want back, and keep it small: the result "
+            "lands in your context whole, so bulk output (a long report, extracted "
+            "data) should be written to a file and returned as the path plus a "
+            "short summary.\n"
             "Agent: omit 'agent' to run the subagent as YOU (your identity, "
             "tools, scope). Name an agent from your roster when the subtask "
             "belongs to that specialist — follow the roster's guidance on when. "
@@ -797,9 +820,11 @@ TOOLS = [
             "absolute paths of any files it creates in its result — you can then "
             "read or send them.\n"
             "Use background=true for long-running work: you get a run id "
-            "immediately and the result is posted to this chat when done (monitor "
-            "or cancel it via /subagents or the admin Jobs page). Use background=false "
-            "(default) to block and get the result back in this turn.\n"
+            "immediately, and when the run finishes its result comes back to YOU "
+            "(in a <subagent_results> block) so you decide what to tell the owner "
+            "— monitor or cancel it via /subagents or the admin Jobs page. Use "
+            "background=false (default) to block and get the result back in this "
+            "turn.\n"
             "Subagents are depth-limited, so prefer one focused delegation over "
             "deep nesting.\n"
             "ONE subtask → this tool. TWO OR MORE independent subtasks → "
@@ -899,8 +924,9 @@ TOOLS = [
             "Partial failure is normal: read each result's status and decide "
             "what to do about the ones that failed — never silently synthesize "
             "as though you got everything.\n"
-            "Use background=true only for long-running work: you get run ids "
-            "now and one combined result is posted to this chat when all finish."
+            "Use background=true only for long-running work: you get run ids now, "
+            "and when the last one finishes the whole batch comes back to YOU in a "
+            "<subagent_results> block to answer from."
         ),
         "input_schema": {
             "type": "object",
@@ -1259,8 +1285,17 @@ class AgentCore:
         addressed: bool = True,
         message_id: int | None = None,
         steerable: bool = False,
+        steer_kind: str = "user",
     ) -> AgentResponse:
         """Serialize concurrent turns of one chat, then run the turn.
+
+        ``steer_kind`` says WHOSE message this is: ``"user"`` (the default, and
+        every inbound message) or ``"subagent"`` for a finished background batch
+        coming back to the agent that delegated it (#315). It picks the framing in
+        ``_steer_message`` — the agent's own delegation returning must never read
+        as an instruction from the owner — and, on the idle path, bars the woken
+        turn from spawning further background subagents (see
+        ``_NO_BACKGROUND_IN_WOKEN_TURN``).
 
         ``steerable=True`` opts a system-channel caller into mid-turn steering
         (#266): the GitHub webhook passes it so an event landing on a thread
@@ -1306,7 +1341,12 @@ class AgentCore:
             and not _control_command(message)
             and self._active_turns_map().get(key) is not None
         ):
-            steer_entry = {"text": message, "message_id": message_id, "consumed": False}
+            steer_entry = {
+                "text": message,
+                "message_id": message_id,
+                "kind": steer_kind,
+                "consumed": False,
+            }
             self._steer_map().setdefault(key, []).append(steer_entry)
 
         async with self._chat_lock(channel, user_id, chat_id):
@@ -1324,6 +1364,7 @@ class AgentCore:
                 respond=respond,
                 addressed=addressed,
                 message_id=message_id,
+                woken_by_subagent=steer_kind == "subagent",
             )
 
     def _active_turns_map(self) -> dict:
@@ -1378,16 +1419,25 @@ class AgentCore:
         """Build one labelled user message from drained steer entries (#145). ponytail:
         text only — a steer's attachments are dropped; if it wasn't consumed its own
         turn still carries them, and mid-turn image steers are rare enough to defer."""
-        joined = "\n\n".join(e["text"] for e in entries)
-        # Neutral label (#266): a steer may be a user's follow-up OR an inbound
-        # event (a GitHub comment on the thread being worked) — "the user said"
-        # would misattribute the latter.
-        text = (
-            "[A follow-up arrived while you were working:]\n"
-            f"<steering_message>\n{joined}\n</steering_message>\n"
-            "Continue your current task taking this into account."
-        )
-        return {"role": "user", "content": text}
+        # Grouped by kind (#315): a finished background batch is the agent's own
+        # delegation returning, and framing it as a follow-up would present it as
+        # an instruction from the owner. It arrives pre-framed
+        # (_subagent_batch_message), so it passes through verbatim — identical
+        # text whether it lands here or as its own turn.
+        parts = []
+        followups = [e["text"] for e in entries if e.get("kind", "user") != "subagent"]
+        if followups:
+            # Neutral label (#266): a steer may be a user's follow-up OR an inbound
+            # event (a GitHub comment on the thread being worked) — "the user said"
+            # would misattribute the latter.
+            joined = "\n\n".join(followups)
+            parts.append(
+                "[A follow-up arrived while you were working:]\n"
+                f"<steering_message>\n{joined}\n</steering_message>\n"
+                "Continue your current task taking this into account."
+            )
+        parts.extend(e["text"] for e in entries if e.get("kind") == "subagent")
+        return {"role": "user", "content": "\n\n".join(parts)}
 
     async def _commit_steer(self, channel: str, chat_id: str, entries: list[dict]) -> None:
         """Confirm steers the model has now received: mark each consumed (so its
@@ -1452,6 +1502,7 @@ class AgentCore:
         respond: bool = True,
         addressed: bool = True,
         message_id: int | None = None,
+        woken_by_subagent: bool = False,
     ) -> AgentResponse:
         """Process an incoming message through the LLM with tool-use loop.
 
@@ -1481,6 +1532,10 @@ class AgentCore:
         ``message_id`` is the inbound message's id, carried into request_state so
         the ``set_reaction`` tool can react to the triggering message without the
         model having to know its id (#70). Channel-specific; None off Telegram.
+
+        ``woken_by_subagent`` marks a turn that only exists because a background
+        batch landed (#315); it bars further background spawns so wake-ups can't
+        chain. See ``_NO_BACKGROUND_IN_WOKEN_TURN``.
         """
 
         # Respond-gate (#30): record the turn for context, but do not reply. Runs
@@ -1682,6 +1737,7 @@ class AgentCore:
                     tools,
                     agent,
                     message_id,
+                    woken_by_subagent,
                 )
             return await self._process_injection(
                 system,
@@ -1694,6 +1750,7 @@ class AgentCore:
                 tools,
                 agent,
                 message_id,
+                woken_by_subagent,
             )
         finally:
             reset_capture_context(cap_token)
@@ -2227,6 +2284,7 @@ class AgentCore:
         tools: list[dict] | None = None,
         agent: Agent | None = None,
         message_id: int | None = None,
+        woken_by_subagent: bool = False,
     ) -> AgentResponse:
         """Injection mode: replay windowed history as native alternating messages."""
         tools = tools if tools is not None else TOOLS
@@ -2268,6 +2326,7 @@ class AgentCore:
                 "chat_id": chat_id,
                 "message_id": message_id,
             },
+            woken_by_subagent=woken_by_subagent,
         )
         # Resolve the YOLO grant once per turn (channel+chat_id are in scope here
         # but not in _execute_tool); every tool call this turn reads the cached flag.
@@ -2381,6 +2440,7 @@ class AgentCore:
         tools: list[dict] | None = None,
         agent: Agent | None = None,
         message_id: int | None = None,
+        woken_by_subagent: bool = False,
     ) -> AgentResponse:
         """Session mode: sticky session per (channel, user_id, chat_id).
 
@@ -2425,6 +2485,7 @@ class AgentCore:
                 "chat_id": chat_id,
                 "message_id": message_id,
             },
+            woken_by_subagent=woken_by_subagent,
         )
         # Resolve the YOLO grant once per turn (channel+chat_id are in scope here
         # but not in _execute_tool); every tool call this turn reads the cached flag.
@@ -2992,6 +3053,7 @@ class AgentCore:
         depth: int = 0,
         origin: dict | None = None,
         run_id: str | None = None,
+        woken_by_subagent: bool = False,
     ) -> dict:
         """Fresh per-turn state tracking write actions and approval decisions.
 
@@ -3013,6 +3075,9 @@ class AgentCore:
             "depth": depth,
             "origin": origin or {},
             "run_id": run_id,
+            # This turn exists because a background batch landed (#315) — no
+            # further background spawns, or wake-ups would chain.
+            "woken_by_subagent": woken_by_subagent,
         }
 
     @staticmethod
@@ -3826,6 +3891,9 @@ class AgentCore:
         task = str(params.get("task", "")).strip()
         if not task:
             return {"error": "Missing 'task' for spawn_subagent."}
+        background = bool(params.get("background", False))
+        if background and request_state.get("woken_by_subagent"):
+            return {"error": _NO_BACKGROUND_IN_WOKEN_TURN}
         origin = request_state.get("origin") or {}
         return await self.run_subagent(
             task=task,
@@ -3834,7 +3902,7 @@ class AgentCore:
             origin_user_id=str(origin.get("user_id", user_id)),
             origin_chat_id=str(origin.get("chat_id", "")),
             parent_state=request_state,
-            background=bool(params.get("background", False)),
+            background=background,
             max_steps=params.get("max_steps"),
             token_budget=params.get("token_budget"),
             thinking_effort=params.get("thinking_effort"),
@@ -3876,6 +3944,8 @@ class AgentCore:
                 )
             }
         background = bool(params.get("background", False))
+        if background and request_state.get("woken_by_subagent"):
+            return {"error": _NO_BACKGROUND_IN_WOKEN_TURN}
         if len(tasks) == 1:
             one = tasks[0] if isinstance(tasks[0], dict) else {}
             return await self._tool_spawn_subagent(
@@ -4106,10 +4176,10 @@ class AgentCore:
 
     async def _notify_background_progress(self, run: SubagentRun) -> None:
         """Completion note for a background run, but only mid-batch: the last
-        finisher's note would land right next to the batch digest — one event,
-        two bubbles — so it is skipped and the digest speaks for it. The check
-        mirrors _maybe_deliver_subagent_batch's barrier (background runs only),
-        so note-or-digest is exhaustive and exclusive."""
+        finisher's note would land right next to the agent's own reply about the
+        batch — one event, two bubbles — so it is skipped and the reply speaks for
+        it. The check mirrors _maybe_deliver_subagent_batch's barrier (background
+        runs only), so note-or-reply is exhaustive and exclusive."""
         still_running = any(
             r.background
             and r.status == "running"
@@ -4697,8 +4767,8 @@ class AgentCore:
         self, run: SubagentRun, child_agent: Agent | None, child_state: dict
     ) -> None:
         """Run a subagent off-turn. When the chat's whole batch of background runs
-        has finished, the spawning agent ingests their results and writes one reply
-        — the user never sees raw subagent output; it works for the agent (#15)."""
+        has finished, the results are routed back to the spawning agent, which reads
+        them and decides what to tell the owner (#15/#315)."""
         try:
             text = await self._run_subagent_loop(run.task, child_agent, child_state, run)
         except asyncio.CancelledError:
@@ -4729,9 +4799,9 @@ class AgentCore:
             await self._maybe_deliver_subagent_batch(run)
 
     async def _maybe_deliver_subagent_batch(self, run: SubagentRun) -> None:
-        """Once every background run for this chat is done, distil the batch into a
-        chat notification + a context digest and deliver them. The barrier collapses
-        a fan-out of parallel spawns into a single delivery (#15)."""
+        """Once every background run for this chat is done, hand the whole batch
+        back to the agent so it answers for them itself. The barrier collapses a
+        fan-out of parallel spawns into a single wake-up (#15/#315)."""
         channel, user_id, chat_id = run.origin_channel, run.origin_user_id, run.origin_chat_id
         if not chat_id or channel == "system":
             return  # scheduler / system-origin runs have no user chat to answer
@@ -4761,82 +4831,84 @@ class AgentCore:
             return
         for r in batch:
             r.synthesized = True
-        await self._summarize_and_deliver(channel, user_id, chat_id, batch)
+        await self._wake_on_subagent_batch(channel, user_id, chat_id, batch)
 
-    async def _summarize_and_deliver(
+    async def _wake_on_subagent_batch(
         self, channel: str, user_id: str, chat_id: str, batch: list[SubagentRun]
     ) -> None:
-        """Distil a finished batch into a one-line chat notification + a concise
-        context digest, then deliver: notification → the user, digest → the agent's
-        context. The raw subagent output reaches neither the user nor the context.
+        """Hand a finished background batch back to the agent that delegated it (#315).
+
+        Routed through ``process(steerable=True, steer_kind="subagent")``, so it
+        takes whichever branch fits: a turn already running for this conversation
+        gets the batch injected between tool rounds, an idle one runs it as its own
+        turn. Either way the AGENT decides what the owner is told — its reply is the
+        assistant turn, written to history by the normal turn path — instead of a
+        cheap summariser speaking in its voice into a chat the agent never saw.
+
+        Nothing to send when the batch was consumed as a steer: the running turn
+        answers for it, and ``process`` returns an empty response.
         """
-        notification, digest = await self._summarize_subagent_batch(batch)
-        # The user only ever saw the notification; the agent's context keeps the
-        # concise digest (so it can answer follow-ups) — never the raw output.
-        framed = notification
-        if digest and digest.strip() and digest.strip() != notification.strip():
-            framed = f"{notification}\n\n<subagent_digest>\n{digest}\n</subagent_digest>"
-        await self._record_subagent_context(channel, user_id, chat_id, framed)
-        ch = self.channels.get(channel)
-        if ch and chat_id and notification:
-            try:
-                await ch.send(chat_id, notification)
-            except Exception:
-                log.exception("Failed to deliver subagent notification (chat=%s)", chat_id)
-
-    async def _summarize_subagent_batch(self, batch: list[SubagentRun]) -> tuple[str, str]:
-        """(notification, digest) for a finished batch via the summary inference,
-        falling back to truncation when it is disabled or the inference fails."""
-        items = [
-            (
-                r.task,
-                r.result if r.status == "done" else f"[failed: {r.error or 'unknown error'}]",
-                r.agent or "",
-                r.status,
-            )
-            for r in batch
-        ]
-        cfg = self.config.subagent_summary
-        if cfg.enabled:
-            try:
-                llm = self._background_llm(cfg.provider, cfg.thinking_level)
-                return await summarize_batch(llm, cfg.model, items)
-            except Exception:
-                log.exception("Subagent summary inference failed; using truncation fallback")
-        return fallback_summary(items)
-
-    async def _record_subagent_context(
-        self, channel: str, user_id: str, chat_id: str, framed: str
-    ) -> None:
-        """Record a background batch's notification + digest as an assistant turn —
-        merged into the trailing assistant turn so replayed history stays strictly
-        alternating for providers that require it (#15).
-
-        Runs in the background subagent task, so it holds the same per-chat lock as
-        ``process()``: this fold is another read-modify-write on the chat's history,
-        and a concurrent foreground turn on the same chat would otherwise interleave
-        with it. Background delivery never runs under a held lock for this key (the
-        spawning turn returned long ago), so acquiring it here can't deadlock."""
-        if not chat_id or channel == "system":
-            return
         try:
-            async with self._chat_lock(channel, user_id, chat_id):
-                if self.history_mode == "session":
-                    merged = await self.history.append_to_last_session_message(
-                        channel, user_id, f"\n\n{framed}", chat_id
-                    )
-                    if not merged:
-                        await self.history.append_session_message(
-                            channel, user_id, {"role": "assistant", "content": framed}, chat_id
-                        )
-                else:
-                    merged = await self.history.append_to_last_turn(
-                        channel, user_id, "assistant", f"\n\n{framed}", chat_id
-                    )
-                    if not merged:
-                        await self.history.add_turn(channel, user_id, "assistant", framed, chat_id)
+            response = await self.process(
+                self._subagent_batch_message(batch),
+                channel,
+                user_id,
+                chat_id=chat_id,
+                steerable=True,
+                steer_kind="subagent",
+            )
         except Exception:
-            log.exception("Failed to record subagent context (chat=%s)", chat_id)
+            log.exception("Subagent batch wake-up failed (chat=%s)", chat_id)
+            return
+        ch = self.channels.get(channel)
+        if not ch:
+            return
+        # Each [[split]] bubble in order (#202) — response.text alone would collapse
+        # them into one. ponytail: text only; voice on an unprompted background
+        # landing would be a worse answer than text, and images from a woken turn
+        # (rare) would need channel-specific sends this helper deliberately avoids.
+        for msg in response.delivery_messages:
+            if not msg.text:
+                continue
+            try:
+                await ch.send(chat_id, msg.text)
+            except Exception:
+                log.exception("Failed to deliver a subagent batch reply (chat=%s)", chat_id)
+
+    def _subagent_batch_message(self, batch: list[SubagentRun]) -> str:
+        """Frame a finished background batch as one message for the agent (#315).
+
+        A bare tag plus per-run status lines and results: the standing rules for
+        reading this live once in the cached <delegation> block, and repeating a
+        paragraph of guidance in every landing batch would be paid for on every
+        later turn (the whole thing is persisted verbatim).
+        """
+        lines = ["<subagent_results>", "Delegated work you started earlier has finished."]
+        for run in batch:
+            name = " | ".join(p for p in (run.label, run.agent) if p) or run.run_id
+            if run.status == "error":
+                lines.append(f"- [{name}] status=error: {run.error or 'unknown error'}")
+                continue
+            head = f"- [{name}] status={run.status}"
+            # stopped_reason only when it says the result may be thin — "complete"
+            # is the norm and carries nothing the agent can act on.
+            if run.stopped_reason and run.stopped_reason != "complete":
+                head += f", stopped: {run.stopped_reason}"
+            lines.append(head)
+            lines.append(self._clip_subagent_result(run))
+        lines.append("</subagent_results>")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _clip_subagent_result(run: SubagentRun) -> str:
+        """One run's result, capped — see ``_SUBAGENT_RESULT_MAX_CHARS``."""
+        text = (run.result or "").strip() or "(no output)"
+        if len(text) > _SUBAGENT_RESULT_MAX_CHARS:
+            text = (
+                text[:_SUBAGENT_RESULT_MAX_CHARS]
+                + f"\n[truncated — full result of run {run.run_id} is on /subagents]"
+            )
+        return text
 
     async def _record_inbound(
         self,
@@ -4849,8 +4921,8 @@ class AgentCore:
         """Record an inbound message as a user turn without generating a reply —
         the respond-gate's silent path for group rooms (#30).
 
-        Folds into the trailing user turn (mirroring ``_record_subagent_context``)
-        so a run of un-answered group messages stays a single turn and the
+        Folds into the trailing user turn so a run of un-answered group messages
+        stays a single turn and the
         replayed history keeps strict user/assistant alternation. ``message``
         already carries its ``[from <author>]`` speaker tag, so the bot sees who
         said what when it is later addressed. A refused fold (trailing turn is an

--- a/humux/core/agent.py
+++ b/humux/core/agent.py
@@ -4973,10 +4973,21 @@ class AgentCore:
 
     @staticmethod
     def _usage_total(usage: dict | None) -> int:
-        """Best-effort token count for budgeting (0 when the provider omits usage)."""
+        """Genuinely-new tokens for budgeting (0 when the provider omits usage).
+
+        Charging the whole prompt made a budget deplete quadratically in rounds:
+        cache reads are the re-sent conversation earlier rounds already paid for,
+        and the provider bills them at a fraction. ``context_tokens`` is already
+        normalised per provider shape (Anthropic: uncached input + cache
+        read/creation; OpenAI: the whole prompt), so subtracting the cache read
+        leaves the new input on both. Falls back to ``input_tokens`` when the
+        provider reports no context size.
+        """
         if not usage:
             return 0
-        return int(usage.get("input_tokens", 0) or 0) + int(usage.get("output_tokens", 0) or 0)
+        context = int(usage.get("context_tokens") or usage.get("input_tokens") or 0)
+        cache_read = int(usage.get("cache_read_input_tokens") or 0)
+        return int(usage.get("output_tokens") or 0) + max(0, context - cache_read)
 
     async def _tool_web_search(self, params: dict) -> dict:
         """Search the web via the configured provider (Tavily or SearXNG)."""
@@ -5121,8 +5132,7 @@ class AgentCore:
                     tools=[],
                     max_tokens=max_tokens,
                 )
-                u = r.usage or {}
-                return r.text, u.get("input_tokens", 0) + u.get("output_tokens", 0)
+                return r.text, self._usage_total(r.usage)
 
             return gen
 

--- a/humux/core/config.py
+++ b/humux/core/config.py
@@ -534,21 +534,6 @@ class SubagentsConfig(BaseModel):
     allowed_models: list[str] = []
 
 
-class SubagentSummaryConfig(BaseModel):
-    """Summarise a finished background subagent batch (issue #15).
-
-    Instead of dumping a subagent's raw output to the chat and the agent's
-    context, a small inference distils each batch into a one-sentence chat
-    *notification* and a concise *digest* for the agent's context. Mirrors the
-    other background inferences (memory / compaction).
-    """
-
-    enabled: bool = True
-    provider: str = "deepseek"  # fast + cheap is ideal for this distillation
-    model: str = "deepseek-v4-flash"
-    thinking_level: str = ""  # "" (off) | "low" | "medium" | "high" | "max"
-
-
 class Config(BaseModel):
     agent: AgentConfig = AgentConfig()
     calendar: CalendarConfig = CalendarConfig()
@@ -568,7 +553,6 @@ class Config(BaseModel):
     workspace: WorkspaceConfig = WorkspaceConfig()
     artifacts: ArtifactsConfig = ArtifactsConfig()
     subagents: SubagentsConfig = SubagentsConfig()
-    subagent_summary: SubagentSummaryConfig = SubagentSummaryConfig()
 
 
 def load_config(path: str | Path = "config.yml") -> Config:

--- a/humux/core/prompt_builder.py
+++ b/humux/core/prompt_builder.py
@@ -245,6 +245,12 @@ def build_prompt_sections(
             "chain are a pipeline — spawn one, read its result, then spawn the next. "
             "Quick lookups and single tool calls: just do them yourself. Read the "
             "subagent-orchestration skill for briefing, sizing and patterns.\n"
+            "Work you send off with background=true comes back to you later, in a "
+            "<subagent_results> block. That block is your OWN delegation returning "
+            "— not a new instruction from the owner, and it does not change what "
+            "they asked for. Read the status on every entry, never present a "
+            "partial or failed batch as a complete answer, and decide what, if "
+            "anything, is worth telling them.\n"
             "</delegation>"
         )
 

--- a/humux/core/subagents.py
+++ b/humux/core/subagents.py
@@ -427,66 +427,14 @@ class SubagentRegistry:
 def short_summary(text: str, limit: int = 280) -> str:
     """A one-glance summary of a subagent's result — first non-empty line, capped.
 
-    The crude fallback for :func:`summarize_batch` when the summary inference is
-    disabled or its output can't be parsed; also the sync spawn's preview field.
+    The preview field of a synchronous spawn; the full result is returned
+    alongside it, so nothing is lost.
     """
     for line in (text or "").splitlines():
         line = line.strip()
         if line:
             return line[:limit] + ("…" if len(line) > limit else "")
     return (text or "").strip()[:limit]
-
-
-# (task, outcome, agent, status) for one finished background run.
-SummaryItem = tuple[str, str, str, str]
-
-_SUMMARY_PROMPT = (
-    "Background helper task(s) ran for a user and finished. Summarise their "
-    "results into TWO things, and nothing else:\n"
-    "1. NOTIFICATION — ONE short sentence (max ~140 chars) giving the single most "
-    "important result/answer, phrased for the user. No greeting, no 'the helper "
-    "found', no markdown.\n"
-    "2. DIGEST — a few concise sentences with the key facts the assistant may need "
-    "to answer follow-ups. Real content only; do not restate the task or pad.\n\n"
-    "Respond in EXACTLY this format (NOTIFICATION on one line):\n"
-    "NOTIFICATION: <one sentence>\n"
-    "DIGEST: <concise summary>"
-)
-
-
-def _format_items(items: list[SummaryItem]) -> str:
-    blocks = []
-    for task, outcome, _agent, status in items:
-        blocks.append(f"--- task: {task}\nstatus: {status}\nresult:\n{outcome}")
-    return "\n\n".join(blocks)
-
-
-def fallback_summary(items: list[SummaryItem]) -> tuple[str, str]:
-    """Crude (no-LLM) fallback for :func:`summarize_batch`: first-line previews
-    for both the notification and the digest, used when the summary inference is
-    disabled or its output is unusable."""
-    notif = "; ".join(s for s in (short_summary(o, 120) for _, o, _, _ in items) if s)[:200]
-    digest = "\n".join(f"- {t[:80]}: {short_summary(o, 280)}" for t, o, _, _ in items)
-    return notif, digest
-
-
-def _parse_summary(raw: str) -> tuple[str, str]:
-    """Pull (notification, digest) out of the model's reply; ('', '') if unusable."""
-    if not raw or not raw.strip():
-        return "", ""
-    low = raw.lower()
-    n_idx, d_idx = low.find("notification:"), low.find("digest:")
-    if n_idx == -1 and d_idx == -1:
-        # No markers — take the first non-empty line as the notification.
-        lines = [ln.strip() for ln in raw.strip().splitlines() if ln.strip()]
-        return (lines[0], "\n".join(lines[1:]) or lines[0]) if lines else ("", "")
-    notif = ""
-    if n_idx != -1:
-        end = d_idx if (d_idx > n_idx) else len(raw)
-        body = raw[n_idx + len("notification:") : end].strip()
-        notif = body.splitlines()[0].strip() if body else ""
-    digest = raw[d_idx + len("digest:") :].strip() if d_idx != -1 else ""
-    return notif, digest
 
 
 def _selfcheck() -> None:
@@ -539,21 +487,6 @@ def _selfcheck() -> None:
     assert derive_label("", "", 3) == "task3"
     assert len(derive_label("x" * 99, "")) == 32
     print("subagents.py self-check OK")
-
-
-async def summarize_batch(llm, model: str, items: list[SummaryItem]) -> tuple[str, str]:
-    """LLM-distil a finished background batch into (notification, digest).
-
-    ``notification`` is one sentence for the chat; ``digest`` is concise context
-    for the spawning agent. Falls back to truncation if the model's output can't
-    be parsed (the caller falls back too if the inference itself raises).
-    """
-    prompt = f"{_SUMMARY_PROMPT}\n\n{_format_items(items)}"
-    raw = await llm.generate_text(model=model, prompt=prompt, max_tokens=600)
-    notif, digest = _parse_summary(raw)
-    if not notif:
-        return fallback_summary(items)
-    return notif, digest or notif
 
 
 if __name__ == "__main__":

--- a/humux/skills/subagent-orchestration.md
+++ b/humux/skills/subagent-orchestration.md
@@ -34,8 +34,9 @@ message. Everything it needs goes in `task`. Include:
 - **goal** — one sentence, what "done" means;
 - **inputs** — absolute paths, URLs, ids, versions. Never "the file we discussed";
 - **constraints** — what not to touch, time/source limits, tone;
-- **answer shape** — the exact structure you want back, since you will paste it
-  into a synthesis.
+- **answer shape** — the exact structure you want back, and how long it may be.
+  You will paste it into a synthesis, or read it back later when a background
+  run lands; either way it goes into your context whole.
 
 > **Bad:** Look into the pricing thing and report back.
 
@@ -141,6 +142,11 @@ absolute path plus a summary. Put that in the brief:
 
 Then read the file only if you need the detail. Returning 20k tokens of body
 text through the result field burns your turn budget for no gain.
+
+This applies just as much to `background=true`. A finished background batch is
+handed back to you in a `<subagent_results>` block, so its bulk lands in your
+context too — later, and clipped if a run ran long. Same discipline: file on
+disk, path and summary in the result.
 
 ## Partial failure
 

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -236,21 +236,83 @@ async def test_budget_stop_returns_the_work_done_so_far(agent) -> None:
     assert agent.subagents.get(result["run_id"]).stopped_reason == "max_steps"
 
 
+# ---------------------------------------------------------------------------
+# A finished background batch wakes the AGENT (#315) — no summariser, no
+# fabricated assistant turn. It is routed back into the originating
+# conversation: a steer if a turn is running there, its own turn if not.
+# ---------------------------------------------------------------------------
+
+
+class _LoopingLLM:
+    """Tool-calls ``rounds`` times, then answers. Records every ``messages`` array
+    it was asked to generate on, so a test can assert what the model saw."""
+
+    provider = "deepseek"
+
+    def __init__(self, rounds: int = 3, final: str = "done") -> None:
+        self.rounds = rounds
+        self.final = final
+        self.calls = 0
+        self.seen: list[list[dict]] = []
+
+    async def generate(self, *, messages, **_kw) -> LLMResponse:
+        self.seen.append(list(messages))
+        self.calls += 1
+        if self.calls <= self.rounds:
+            return LLMResponse(
+                text="",
+                tool_calls=[
+                    LLMToolCall(id=f"c{self.calls}", name="web_search", arguments={"q": "x"})
+                ],
+            )
+        return LLMResponse(text=self.final, tool_calls=[])
+
+    def assistant_message(self, response: LLMResponse) -> dict:
+        return {"role": "assistant", "content": response.text}
+
+    def tool_result_messages(self, results: list[dict]) -> list[dict]:
+        return [{"role": "user", "content": results}]
+
+
+async def _wait_active(agent, key, task) -> None:
+    for _ in range(400):
+        await asyncio.sleep(0.001)
+        if key in agent._active_turns_map():
+            return
+    task.cancel()
+    pytest.fail("turn never registered an abort Event")
+
+
+def _finished_run(**kw) -> SubagentRun:
+    base = dict(
+        run_id="s1",
+        agent="",
+        task="price check",
+        label="pricing",
+        background=True,
+        origin_channel="telegram",
+        origin_user_id="u1",
+        origin_chat_id="555",
+        status="done",
+        stopped_reason="complete",
+        result="iPhone 17e 256GB at CHF 599",
+    )
+    return SubagentRun(**{**base, **kw})
+
+
 @pytest.mark.asyncio
-async def test_background_subagent_notifies_user_digests_context(agent, monkeypatch) -> None:
+async def test_landing_batch_runs_its_own_turn_when_idle(agent) -> None:
+    """Nothing running for the chat → a fresh turn under the ORIGIN triple. The
+    agent sees the raw result, and its own reply is what the user gets — split
+    into bubbles like any other turn (#202)."""
     channel = AsyncMock()
     agent.channels["telegram"] = channel
-    agent.llm = _ScriptedLLM([LLMResponse(text="raw verbose findings: CHF 599 ...", tool_calls=[])])
-
-    # Stub the summary inference: (chat notification, context digest).
-    async def fake_summary(batch):
-        return "Cheapest is CHF 599.", "iPhone 17e 256GB at CHF 599; entry model."
-
-    monkeypatch.setattr(agent, "_summarize_subagent_batch", fake_summary)
-
-    # A trailing assistant turn for the digest to merge into (keeps alternation).
-    await agent.history.add_turn("telegram", "u1", "user", "price?", "555")
-    await agent.history.add_turn("telegram", "u1", "assistant", "On it.", "555")
+    agent.llm = _ScriptedLLM(
+        [
+            LLMResponse(text="raw verbose findings: CHF 599 ...", tool_calls=[]),  # the subagent
+            LLMResponse(text="Found it.[[split]]Cheapest is CHF 599.", tool_calls=[]),  # the wake
+        ]
+    )
 
     result = await agent.run_subagent(
         task="price check",
@@ -263,29 +325,97 @@ async def test_background_subagent_notifies_user_digests_context(agent, monkeypa
     await run._task
 
     assert run.status == "done"
-    # Chat: the spawn note, then ONLY the one-line NOTIFICATION — no per-run
-    # completion note (the last/only finisher's note is suppressed; the digest
-    # speaks for it), and never the raw output.
-    assert _sent(channel) == ["🧬 Spawned subagent price check", "Cheapest is CHF 599."]
-    # Context: the concise digest is kept (merged), the raw output never is.
+    # Chat: the spawn note, then the agent's own reply as two bubbles — never the
+    # raw subagent output, and no per-run completion note (only finisher).
+    assert _sent(channel) == [
+        "🧬 Spawned subagent price check",
+        "Found it.",
+        "Cheapest is CHF 599.",
+    ]
+    # History: the batch is a user-role message and the agent's reply is the
+    # assistant turn — written by the normal turn path, not fabricated.
     turns = await agent.history.get_messages("telegram", "u1", "555")
-    blob = str(turns[-1]["content"])
-    assert [t["role"] for t in turns] == ["user", "assistant"]  # still alternating
-    assert "iPhone 17e 256GB at CHF 599" in blob
-    assert "raw verbose findings" not in blob
+    roles = [t["role"] for t in turns]
+    assert roles[0] == "user" and set(roles[1:]) == {"assistant"}
+    assert "<subagent_results>" in str(turns[0]["content"])
+    assert "raw verbose findings" in str(turns[0]["content"])
+    assert "Cheapest is CHF 599." in str(turns[-1]["content"])
+
+
+@pytest.mark.asyncio
+async def test_landing_batch_steers_a_running_turn(agent) -> None:
+    """A turn is already running for the chat → the batch is injected into THAT
+    turn, framed as returning delegation and never as a user follow-up."""
+    channel = AsyncMock()
+    agent.channels["telegram"] = channel
+    agent.llm = _LoopingLLM(rounds=3)
+
+    async def fake_tool(call, channel_, user_id, request_state):
+        await asyncio.sleep(0.002)  # pace the rounds so the batch lands mid-loop
+        return {"ok": True}
+
+    agent._execute_tool = fake_tool
+    key = ("telegram", "u1", "555")
+    turn = asyncio.create_task(agent.process("look into pricing", "telegram", "u1", chat_id="555"))
+    await _wait_active(agent, key, turn)
+
+    # Runs as a task: process() deposits the steer, then queues on the chat lock
+    # the running turn holds — exactly like a user's mid-turn follow-up.
+    wake = asyncio.create_task(
+        agent._wake_on_subagent_batch("telegram", "u1", "555", [_finished_run()])
+    )
+    assert (await asyncio.wait_for(turn, timeout=2)).text == "done"
+    await asyncio.wait_for(wake, timeout=2)
+
+    flat = "".join(str(m.get("content")) for seen in agent.llm.seen for m in seen)
+    assert "<subagent_results>" in flat
+    assert "iPhone 17e 256GB at CHF 599" in flat
+    # The agent's own delegation returning is NOT an instruction from the owner.
+    assert "<steering_message>" not in flat
+    assert "A follow-up arrived" not in flat
+    # Consumed by the running turn → the wake sends nothing of its own.
+    assert _sent(channel) == []
+
+
+@pytest.mark.asyncio
+async def test_fanout_produces_exactly_one_wake(agent, monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_wake(channel, user_id, chat_id, batch):
+        calls.append([r.run_id for r in batch])
+
+    monkeypatch.setattr(agent, "_wake_on_subagent_batch", fake_wake)
+
+    common = dict(background=True, origin_channel="telegram", origin_chat_id="c")
+    r1 = SubagentRun(run_id="s1", agent="", task="a", origin_user_id="u", **common)
+    r2 = SubagentRun(run_id="s2", agent="", task="b", origin_user_id="u", **common)
+    agent.subagents.register(r1)
+    agent.subagents.register(r2)
+
+    # First finishes → the other is still running → barrier holds, no wake-up.
+    agent.subagents.finish("s1", "done", result="x")
+    await agent._maybe_deliver_subagent_batch(r1)
+    assert calls == []
+
+    # Last finishes → barrier releases → ONE wake-up over the whole batch.
+    agent.subagents.finish("s2", "done", result="y")
+    await agent._maybe_deliver_subagent_batch(r2)
+    assert len(calls) == 1
+    assert sorted(calls[0]) == ["s1", "s2"]
+    assert r1.synthesized and r2.synthesized
 
 
 @pytest.mark.asyncio
 async def test_midbatch_background_finisher_posts_a_note(agent, monkeypatch) -> None:
     """While siblings are still running, a background finisher notes its
-    completion; the LAST finisher stays silent — the batch digest follows."""
+    completion; the LAST finisher stays silent — the agent's reply follows."""
     channel = AsyncMock()
     agent.channels["telegram"] = channel
 
-    async def fake_summary(batch):
-        return "All done.", "digest"
+    async def fake_wake(channel_, user_id, chat_id, batch):
+        raise AssertionError("the barrier must hold while a sibling is running")
 
-    monkeypatch.setattr(agent, "_summarize_subagent_batch", fake_summary)
+    monkeypatch.setattr(agent, "_wake_on_subagent_batch", fake_wake)
     # A second background run for the same chat is still "running", so the
     # first finisher is mid-batch.
     agent.subagents.register(
@@ -311,36 +441,6 @@ async def test_midbatch_background_finisher_posts_a_note(agent, monkeypatch) -> 
 
     notes = [t for t in _sent(channel) if t.startswith("✅ Subagent")]
     assert len(notes) == 1 and run.label in notes[0]
-    # And no batch digest yet — the sibling is still running.
-    assert "All done." not in _sent(channel)
-
-
-@pytest.mark.asyncio
-async def test_background_batch_delivers_once_when_all_done(agent, monkeypatch) -> None:
-    calls: list[list[str]] = []
-
-    async def fake_deliver(channel, user_id, chat_id, batch):
-        calls.append([r.run_id for r in batch])
-
-    monkeypatch.setattr(agent, "_summarize_and_deliver", fake_deliver)
-
-    common = dict(background=True, origin_channel="telegram", origin_chat_id="c")
-    r1 = SubagentRun(run_id="s1", agent="", task="a", origin_user_id="u", **common)
-    r2 = SubagentRun(run_id="s2", agent="", task="b", origin_user_id="u", **common)
-    agent.subagents.register(r1)
-    agent.subagents.register(r2)
-
-    # First finishes → the other is still running → barrier holds, no delivery.
-    agent.subagents.finish("s1", "done", result="x")
-    await agent._maybe_deliver_subagent_batch(r1)
-    assert calls == []
-
-    # Last finishes → barrier releases → ONE delivery over the whole batch.
-    agent.subagents.finish("s2", "done", result="y")
-    await agent._maybe_deliver_subagent_batch(r2)
-    assert len(calls) == 1
-    assert sorted(calls[0]) == ["s1", "s2"]
-    assert r1.synthesized and r2.synthesized
 
 
 @pytest.mark.asyncio
@@ -351,10 +451,10 @@ async def test_cancelling_a_sibling_releases_a_deferred_reply(agent, monkeypatch
 
     calls: list[list[str]] = []
 
-    async def fake_deliver(channel, user_id, chat_id, batch):
+    async def fake_wake(channel, user_id, chat_id, batch):
         calls.append(sorted(r.run_id for r in batch))
 
-    monkeypatch.setattr(agent, "_summarize_and_deliver", fake_deliver)
+    monkeypatch.setattr(agent, "_wake_on_subagent_batch", fake_wake)
 
     gate = asyncio.Event()
 
@@ -385,33 +485,82 @@ async def test_cancelling_a_sibling_releases_a_deferred_reply(agent, monkeypatch
     assert agent.subagents.get(a_res["run_id"]).synthesized is True
 
 
-def test_summary_parsing_and_fallback() -> None:
-    from core.subagents import _parse_summary, fallback_summary
+def test_batch_message_states_failures_and_thin_results(agent) -> None:
+    text = agent._subagent_batch_message(
+        [
+            _finished_run(),
+            _finished_run(run_id="s2", label="deep-dive", stopped_reason="max_steps"),
+            _finished_run(
+                run_id="s3",
+                label="legal-check",
+                status="error",
+                result="",
+                error="max_steps exhausted",
+            ),
+        ]
+    )
+    assert text.startswith("<subagent_results>") and text.endswith("</subagent_results>")
+    assert "- [pricing] status=done" in text
+    # A complete run says nothing about why it stopped; a thin one does.
+    assert "stopped: complete" not in text
+    assert "- [deep-dive] status=done, stopped: max_steps" in text
+    assert "- [legal-check] status=error: max_steps exhausted" in text
 
-    n, d = _parse_summary("NOTIFICATION: Cheapest is CHF 599.\nDIGEST: iPhone 17e 256GB CHF 599.")
-    assert n == "Cheapest is CHF 599."
-    assert "iPhone 17e" in d
-    # No markers → first non-empty line becomes the notification.
-    assert _parse_summary("Just one line")[0] == "Just one line"
-    assert _parse_summary("") == ("", "")
-    # Truncation fallback from raw items (no LLM).
-    items = [("task a", "line1\nline2", "", "done"), ("task b", "r b", "", "done")]
-    notif, digest = fallback_summary(items)
-    assert "line1" in notif and "r b" in notif
-    assert "- task a:" in digest
+
+def test_oversized_result_is_clipped_with_the_run_id(agent) -> None:
+    from core.agent import _SUBAGENT_RESULT_MAX_CHARS
+
+    text = agent._subagent_batch_message([_finished_run(result="x" * 50_000)])
+    assert len(text) < _SUBAGENT_RESULT_MAX_CHARS + 500
+    assert "full result of run s1 is on /subagents" in text
+
+
+def test_mixed_drain_frames_each_kind_under_its_own_wrapper(agent) -> None:
+    msg = agent._steer_message(
+        [
+            {"text": "actually use the calendar API", "kind": "user"},
+            {"text": "<subagent_results>\nCHF 599\n</subagent_results>", "kind": "subagent"},
+        ]
+    )
+    body = msg["content"]
+    assert "<steering_message>\nactually use the calendar API\n</steering_message>" in body
+    assert "<subagent_results>\nCHF 599\n</subagent_results>" in body
+    # The batch sits outside the follow-up wrapper — it is not what the owner said.
+    assert body.index("</steering_message>") < body.index("<subagent_results>")
 
 
 @pytest.mark.asyncio
-async def test_summarize_batch_calls_llm_and_parses() -> None:
-    from core.subagents import summarize_batch
+async def test_woken_turn_may_not_spawn_more_background_work(agent) -> None:
+    """The wake-loop guard: a turn that exists because a batch landed cannot start
+    another batch. Structural, not a threshold — synchronous spawns still run."""
+    woken = agent._new_request_state(None, woken_by_subagent=True)
+    for params in ({"task": "t", "background": True},):
+        out = await agent._tool_spawn_subagent(params, "telegram", "u1", woken)
+        assert "background=false" in out["error"]
+    out = await agent._tool_spawn_subagents(
+        {"tasks": [{"task": "a"}, {"task": "b"}], "background": True}, "telegram", "u1", woken
+    )
+    assert "background=false" in out["error"]
 
-    class FakeLLM:
-        async def generate_text(self, *, model, prompt, max_tokens=600):
-            return "NOTIFICATION: Done — 3 results.\nDIGEST: A, B and C found."
+    # Synchronous delegation is untouched — it returns inside the turn and cannot
+    # chain into another wake-up.
+    agent.llm = _ScriptedLLM([LLMResponse(text="sync answer", tool_calls=[])])
+    ok = await agent._tool_spawn_subagent({"task": "t"}, "telegram", "u1", woken)
+    assert ok["ok"] is True and ok["result"] == "sync answer"
 
-    notif, digest = await summarize_batch(FakeLLM(), "m", [("t", "r", "", "done")])
-    assert notif == "Done — 3 results."
-    assert digest == "A, B and C found."
+    # And an ordinary turn may still spawn background work.
+    normal = agent._new_request_state(None)
+    assert normal["woken_by_subagent"] is False
+
+
+def test_summariser_is_gone() -> None:
+    """#315 deleted the cheap-model batch summariser and its config knob."""
+    import core.subagents as sub
+    from core.config import Config
+
+    assert not hasattr(Config(), "subagent_summary")
+    for name in ("summarize_batch", "fallback_summary", "_parse_summary", "_SUMMARY_PROMPT"):
+        assert not hasattr(sub, name), name
 
 
 @pytest.mark.asyncio

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -510,7 +510,10 @@ def test_batch_message_states_failures_and_thin_results(agent) -> None:
 def test_oversized_result_is_clipped_with_the_run_id(agent) -> None:
     from core.agent import _SUBAGENT_RESULT_MAX_CHARS
 
-    text = agent._subagent_batch_message([_finished_run(result="x" * 50_000)])
+    # Sized off the constant, so raising the ceiling can't quietly stop this
+    # from testing the clip at all.
+    oversized = "x" * (_SUBAGENT_RESULT_MAX_CHARS * 2)
+    text = agent._subagent_batch_message([_finished_run(result=oversized)])
     assert len(text) < _SUBAGENT_RESULT_MAX_CHARS + 500
     assert "full result of run s1 is on /subagents" in text
 

--- a/humux/tests/test_subagents.py
+++ b/humux/tests/test_subagents.py
@@ -1430,6 +1430,41 @@ async def test_run_reports_steps_tokens_and_stopped_reason(agent) -> None:
     assert res["tokens_used"] == run.tokens_used == 200  # 4 rounds × 50
 
 
+def test_usage_total_charges_only_new_tokens(agent) -> None:
+    # DeepSeek/OpenAI shape: input_tokens is the whole re-sent prompt, so only
+    # the cache miss is new (#199).
+    assert (
+        agent._usage_total(
+            {
+                "input_tokens": 10_000,
+                "output_tokens": 200,
+                "cache_read_input_tokens": 9_600,
+                "cache_creation_input_tokens": 400,
+                "context_tokens": 10_000,
+            }
+        )
+        == 600
+    )
+    # Anthropic shape: input_tokens is ALREADY the uncached input, cache reads
+    # sit beside it — charging input + creation, never collapsing to output.
+    assert (
+        agent._usage_total(
+            {
+                "input_tokens": 300,
+                "output_tokens": 200,
+                "cache_read_input_tokens": 9_600,
+                "cache_creation_input_tokens": 100,
+                "context_tokens": 10_000,
+            }
+        )
+        == 600
+    )
+    # No cache info at all: unchanged, input + output.
+    assert agent._usage_total({"input_tokens": 50, "output_tokens": 0}) == 50
+    assert agent._usage_total(None) == 0
+    assert agent._usage_total({}) == 0
+
+
 @pytest.mark.asyncio
 async def test_sync_result_carries_telemetry_on_a_clean_run(agent) -> None:
     agent.llm = _ScriptedLLM(


### PR DESCRIPTION
Stacked on #314 (`feat/prompt-diet`) — review that one first; this PR's base is that branch.

## What changed

When a background subagent batch finished, `deepseek-v4-flash` summarised it, sent a one-liner **straight to the user's chat bypassing the agent**, and filed a digest in history **as an assistant turn the agent never wrote**. The agent was never re-invoked and never saw its own helpers' output.

Now the batch is routed back into the originating conversation, so the **agent** handles it:

- a turn is already running for that chat → the batch is injected as a steer between tool rounds;
- the chat is idle → it runs as its own turn under the origin `(channel, user_id, chat_id)`.

Either way the agent reads the raw results and decides what — if anything — to tell the owner. Its reply is the assistant turn, delivered and recorded by the normal turn path (all `[[split]]` bubbles, in order).

This is routing into `process(..., steerable=True)`, the same mechanism #266 put in production for the GitHub webhook. No new concurrency machinery.

## Notes

**Subagent results are not framed as user follow-ups.** Steer entries gained a `kind`; `_steer_message` frames each group separately. A returning delegation arrives pre-framed as `<subagent_results>` — identical text whether it lands mid-turn or starts one — and never under `[A follow-up arrived while you were working:]`, which would present the agent's own dispatch as an instruction from the owner.

**Everything is an append.** No persisted message is rewritten, reordered or re-framed, so the cached prompt prefix stays byte-identical on replay. The standing interpretation rules live once in `<delegation>` (inside the cached prefix); the per-batch wrapper is a bare tag plus status lines, because it is persisted verbatim on every landing.

**The wake-loop guard is structural, not numeric.** A turn started by a landing batch may not spawn `background=true` subagents (`_NO_BACKGROUND_IN_WOKEN_TURN`); synchronous spawns stay allowed, already bounded by `FanoutBudget` and `max_tool_rounds`. A wake can only follow a background spawn, and a woken turn cannot make one, so every chain is at most one wake deep. No config field, no threshold.

**Result size.** Nothing caps a subagent's result anywhere in the codebase, and the summariser was the only thing absorbing that on the background path. Each run is clipped at 4000 chars (~1k tokens) with a marker naming the run id; the full text stays in the registry and on `/subagents`. Plus the two prompt fixes that address the cause rather than the symptom: `spawn_subagent` (singular) now asks for an answer shape like the plural does, and the `subagent-orchestration` skill no longer frames the "write bulk to a file" discipline as sync-only.

**Untouched on purpose:** the batch barrier and `synthesized` marking in `_maybe_deliver_subagent_batch` — the absence of an `await` between the check and the marking loop is what makes a fan-out produce exactly one wake-up. Mid-batch completion notes stay too.

**Deleted:** `subagent_summary` config + admin card, `summarize_batch` / `fallback_summary` / `_parse_summary` / `_SUMMARY_PROMPT` / `_format_items`, `_summarize_and_deliver`, `_summarize_subagent_batch`, `_record_subagent_context`. That last one is load-bearing: it took the per-chat lock that `process()` also takes. Leftover `subagent_summary.*` rows in `config.db` are inert (`Config` has no `extra="forbid"` — verified), so no migration.

## Tests

1139 pass. New coverage: steer vs fresh turn, one wake per fan-out, subagent framing ≠ user framing, mixed drain, failure/`stopped_reason` framing, oversized-result clipping, the woken-turn background guard, multi-part delivery.